### PR TITLE
docs(cli): hide broken "Additional resources" cards on CLI overview u…

### DIFF
--- a/docs/factory-cli/getting-started/overview.mdx
+++ b/docs/factory-cli/getting-started/overview.mdx
@@ -103,25 +103,29 @@ You're now connected to Factory's development agent from your terminal. [Try the
   >
     Configure project-specific guidance and conventions
   </Card>
-  <Card
-    title="CLI Reference"
-    icon="terminal"
-    href="/factory-cli/configuration/cli-reference"
-  >
-    Complete reference for droid commands
-  </Card>
-  <Card
-    title="CI/CD Integration"
-    icon="workflow"
-    href="/factory-cli/configuration/ci-cd"
-  >
-    Use droid in your continuous integration pipelines
-  </Card>
-  <Card
-    title="Pricing & Usage"
-    icon="credit-card"
-    href="/factory-cli/account/tokens-and-pricing"
-  >
-    Understand usage tracking and billing
-  </Card>
+  {false && (
+    <>
+      <Card
+        title="CLI Reference"
+        icon="terminal"
+        href="/factory-cli/configuration/cli-reference"
+      >
+        Complete reference for droid commands
+      </Card>
+      <Card
+        title="CI/CD Integration"
+        icon="workflow"
+        href="/factory-cli/configuration/ci-cd"
+      >
+        Use droid in your continuous integration pipelines
+      </Card>
+      <Card
+        title="Pricing & Usage"
+        icon="credit-card"
+        href="/factory-cli/account/tokens-and-pricing"
+      >
+        Understand usage tracking and billing
+      </Card>
+    </>
+  )}
 </CardGroup>


### PR DESCRIPTION
…ntil pages exist\n\nPrevents dead links for CLI Reference, CI/CD Integration, and Pricing & Usage while keeping content in place for future publish.\n\nCo-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>