### PR TITLE
docs(cli): surface new CLI guides

### DIFF
--- a/docs/cli/configuration/custom-commands.mdx
+++ b/docs/cli/configuration/custom-commands.mdx
@@ -1,0 +1,165 @@
+---
+title: Custom Slash Commands
+description: Extend the CLI with reusable Markdown prompts or executable scripts that run from the chat input.
+---
+
+Custom slash commands turn repeatable prompts or setup steps into `/shortcuts`. Droid scans a pair of `.factory/commands` folders, turns each file into a command, and pipes the result straight into the conversation or your terminal session.
+
+---
+
+## 1 · Discovery & naming
+
+| Scope | Location | Purpose |
+| --- | --- | --- |
+| **Workspace** | `<repo>/.factory/commands` | Project-specific commands shared with teammates. Overrides any personal command with the same slug. |
+| **Personal** | `~/.factory/commands` | Always scanned. Stores private or cross-project shortcuts. |
+
+- Only Markdown (`*.md`) files and files with a leading shebang (`#!`) are registered.
+- Filenames are slugged (lowercase, spaces → `-`, non URL-safe characters dropped). `Code Review.mdx` becomes `/code-review`.
+- Invoke commands from chat with `/command-name optional arguments`. Slash suggestions use the description pulled from the file.
+- Run `/commands` to open the **Custom Commands** manager UI for browsing, reloading (`R`), or importing commands.
+- Commands must live at the top level of the `commands` directory. Nested folders are ignored today.
+
+---
+
+## 2 · Markdown commands
+
+Markdown files render into a system notification that seeds droid’s next turn. Optional YAML frontmatter controls autocomplete metadata.
+
+```md
+---
+description: Send a code review checklist
+argument-hint: <branch-name>
+---
+
+Please review `$ARGUMENTS` and summarize any merge blockers, test gaps, and risky areas.
+
+- Highlight security or performance concerns
+- Suggest follow-up tasks with owners
+- List files that need attention
+```
+
+| Frontmatter key | Purpose |
+| --- | --- |
+| `description` | Overrides the generated summary shown in slash suggestions. |
+| `argument-hint` | Appends inline usage hints (e.g., `/code-review <branch-name>`). |
+| `allowed-tools` | Reserved for future use. Safe to omit. |
+
+`$ARGUMENTS` expands to everything typed after the command name. If you do not reference `$ARGUMENTS`, the body is sent unchanged.
+
+<Tip>
+  Markdown output is wrapped in a system notification so the next agent turn immediately sees the prompt.
+</Tip>
+
+<Note>
+  Positional placeholders like `$1` or `$2` are not supported yet—use `$ARGUMENTS` and parse inside the prompt if you need structured input.
+</Note>
+
+---
+
+## 3 · Executable commands
+
+Executable files must start with a valid shebang so the CLI can call the interpreter.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Preparing $1"
+npm install
+npm run lint
+echo "Ready to deploy $1"
+```
+
+- The executable receives the command arguments (`/deploy feature/login` → `$1=feature/login`).
+- Scripts run from the current working directory and inherit your environment, so they have the same permissions you do.
+- Stdout and stderr (up to 64 KB) plus the script contents are posted back to the chat transcript for transparency. Failures still surface their logs.
+
+<Note>
+  Auto-Run respects your autonomy level. High-risk commands inside a script can still trigger confirmation if the CLI flags dangerous patterns (e.g., `rm -rf /`).
+</Note>
+
+---
+
+## 4 · Managing commands
+
+- **Edit or add** files directly in `.factory/commands`. The CLI rescans on launch; press `R` inside `/commands` to reload without restarting.
+- **Import** existing `.agents` or `.claude` commands: open `/commands`, press `I`, select entries, and they copy into your Factory directory.
+- **Remove** a command by deleting its file. Since workspace commands win precedence, deleting the repo version reveals the personal fallback if one exists.
+
+---
+
+## 5 · Usage patterns
+
+- Keep project workflows under version control inside the repo’s `.factory/commands` so teammates share the same shortcuts.
+- Build idempotent scripts that are safe to rerun; document any cleanup steps in the file itself.
+- Use Markdown templates for checklists, code review rubrics, onboarding instructions, or context packets you frequently provide to droid.
+- Review executable commands like any other source code—treat secrets carefully and prefer referencing environment variables already loaded in your shell.
+
+---
+
+## 6 · Examples
+
+### Code review rubric (Markdown)
+
+```md
+---
+description: Ask droid for a structured code review
+argument-hint: <branch-or-PR>
+---
+
+Review `$ARGUMENTS` and respond with:
+
+1. **Summary** – What changed and why it matters.
+2. **Correctness** – Tests, edge cases, and regressions to check.
+3. **Risks** – Security, performance, or migration concerns.
+4. **Follow-up** – Concrete TODOs for the author.
+
+Include file paths alongside any specific feedback.
+```
+
+Invoke with `/review feature/login-flow` to seed droid with a consistent checklist before it inspects the diff.
+
+### Daily standup helper (Markdown)
+
+```md
+---
+description: Summarize progress for standup
+---
+
+Draft a standup update using:
+
+- **Yesterday:** Key wins, merged PRs, or blockers cleared.
+- **Today:** Planned work items and their goals.
+- **Risks:** Anything at risk of slipping, support needed, or cross-team dependencies.
+
+Keep it to three short bullet sections.
+```
+
+Use `/standup` after droid reviews your git history or TODO list to generate a polished update.
+
+### Regression smoke test (Executable)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+target=${1:-"src"}
+
+echo "Running lint + unit tests for $target"
+npm run lint -- "$target"
+npm test -- --runTestsByPath "$target"
+
+echo "Collecting git status"
+git status --short
+
+echo "Done"
+```
+
+Saved as `smoke.sh`, this shows up as `/smoke`. Pass a path (`/smoke src/widgets/__tests__/widget.test.tsx`) to constrain the checks and share the aggregated output with everyone on the thread.
+
+<Tip>
+  Keep built-in slash commands (such as `/help` or `/settings`) separate. This page focuses on custom commands you control inside `.factory/commands`.
+</Tip>
+
+Once set up, custom slash commands compress multi-step prompts or environment setup into a single keystroke, keeping your focus on guiding droid instead of repeating boilerplate.

--- a/docs/cli/configuration/custom-commands.mdx
+++ b/docs/cli/configuration/custom-commands.mdx
@@ -9,10 +9,10 @@ Custom slash commands turn repeatable prompts or setup steps into `/shortcuts`. 
 
 ## 1 · Discovery & naming
 
-| Scope | Location | Purpose |
-| --- | --- | --- |
+| Scope         | Location                   | Purpose                                                                                             |
+| ------------- | -------------------------- | --------------------------------------------------------------------------------------------------- |
 | **Workspace** | `<repo>/.factory/commands` | Project-specific commands shared with teammates. Overrides any personal command with the same slug. |
-| **Personal** | `~/.factory/commands` | Always scanned. Stores private or cross-project shortcuts. |
+| **Personal**  | `~/.factory/commands`      | Always scanned. Stores private or cross-project shortcuts.                                          |
 
 - Only Markdown (`*.md`) files and files with a leading shebang (`#!`) are registered.
 - Filenames are slugged (lowercase, spaces → `-`, non URL-safe characters dropped). `Code Review.mdx` becomes `/code-review`.
@@ -39,20 +39,22 @@ Please review `$ARGUMENTS` and summarize any merge blockers, test gaps, and risk
 - List files that need attention
 ```
 
-| Frontmatter key | Purpose |
-| --- | --- |
-| `description` | Overrides the generated summary shown in slash suggestions. |
+| Frontmatter key | Purpose                                                          |
+| --------------- | ---------------------------------------------------------------- |
+| `description`   | Overrides the generated summary shown in slash suggestions.      |
 | `argument-hint` | Appends inline usage hints (e.g., `/code-review <branch-name>`). |
-| `allowed-tools` | Reserved for future use. Safe to omit. |
+| `allowed-tools` | Reserved for future use. Safe to omit.                           |
 
 `$ARGUMENTS` expands to everything typed after the command name. If you do not reference `$ARGUMENTS`, the body is sent unchanged.
 
 <Tip>
-  Markdown output is wrapped in a system notification so the next agent turn immediately sees the prompt.
+  Markdown output is wrapped in a system notification so the next agent turn
+  immediately sees the prompt.
 </Tip>
 
 <Note>
-  Positional placeholders like `$1` or `$2` are not supported yet—use `$ARGUMENTS` and parse inside the prompt if you need structured input.
+  Positional placeholders like `$1` or `$2` are not supported yet—use
+  `$ARGUMENTS` and parse inside the prompt if you need structured input.
 </Note>
 
 ---
@@ -74,10 +76,6 @@ echo "Ready to deploy $1"
 - The executable receives the command arguments (`/deploy feature/login` → `$1=feature/login`).
 - Scripts run from the current working directory and inherit your environment, so they have the same permissions you do.
 - Stdout and stderr (up to 64 KB) plus the script contents are posted back to the chat transcript for transparency. Failures still surface their logs.
-
-<Note>
-  Auto-Run respects your autonomy level. High-risk commands inside a script can still trigger confirmation if the CLI flags dangerous patterns (e.g., `rm -rf /`).
-</Note>
 
 ---
 
@@ -157,9 +155,5 @@ echo "Done"
 ```
 
 Saved as `smoke.sh`, this shows up as `/smoke`. Pass a path (`/smoke src/widgets/__tests__/widget.test.tsx`) to constrain the checks and share the aggregated output with everyone on the thread.
-
-<Tip>
-  Keep built-in slash commands (such as `/help` or `/settings`) separate. This page focuses on custom commands you control inside `.factory/commands`.
-</Tip>
 
 Once set up, custom slash commands compress multi-step prompts or environment setup into a single keystroke, keeping your focus on guiding droid instead of repeating boilerplate.

--- a/docs/cli/configuration/custom-droids.mdx
+++ b/docs/cli/configuration/custom-droids.mdx
@@ -5,11 +5,16 @@ description: Create specialized subagents with their own prompts, tool access, a
 
 Custom droids are reusable subagents defined in Markdown. Each droid carries its own system prompt, model preference, and tooling policy so you can hand off focused tasks—like code review, security checks, or research—without re-typing instructions.
 
+<Warning>
+  Custom Droids are experimental. You must enable them in settings before they
+  will be picked up.
+</Warning>
+
 ---
 
 ## 1 · What are custom droids?
 
-Custom droids live as text files under either your project’s `.factory/droids/` or your personal `~/.factory/droids/` directory. When enabled, the CLI scans these folders (top-level files only), validates each definition, and exposes them as `subagent_type` targets for the **Task** tool. This lets the primary assistant spin up purpose-built helpers mid-session.
+Custom droids live as `.md` files under either your project’s `.factory/droids/` or your personal `~/.factory/droids/` directory. When enabled, the CLI scans these folders (top-level files only), validates each definition, and exposes them as `subagent_type` targets for the **Task** tool. This lets the primary assistant spin up purpose-built helpers mid-session.
 
 - **Project droids** sit in `<repo>/.factory/droids/` and are shared with teammates.
 - **Personal droids** live in `~/.factory/droids/` and follow you across workspaces.
@@ -71,7 +76,7 @@ Key metadata fields:
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                  | Required. Lowercase letters, digits, `-`, `_`. Drives the `subagent_type` value and filename.                                                                                     |
 | `description`           | Optional. Shown in the UI list. Keep ≤500 chars.                                                                                                                                  |
-| `model`                 | `claude-opus-4-1-20250805`, `claude-sonnet-4-20250514`, `gpt-5-2025-08-07`, or `inherit` (use the parent session’s model). The validator rejects other strings.              |
+| `model`                 | `claude-opus-4-1-20250805`, `claude-sonnet-4-20250514`, `gpt-5-2025-08-07`, or `inherit` (use the parent session’s model). The validator rejects other strings.                   |
 | `tools`                 | `all`, a category (`read-only`, `edit`, `execution`, `web`, `mcp`), or an explicit list of tool IDs (e.g. `"Read"`, `"Execute"`). Default is `all`, which enables every CLI tool. |
 | `createdAt`/`updatedAt` | Auto-filled when using the wizard; optional otherwise.                                                                                                                            |
 | `version`               | Optional string to track revisions.                                                                                                                                               |
@@ -80,13 +85,13 @@ Prompts must start with YAML frontmatter containing at least `name` and include 
 
 ### Tool categories → concrete tools
 
-| Category     | Tools granted (LLM IDs)                     |
-| ------------ | ------------------------------------------- |
-| `read-only`  | `Read`, `Grep`, `Glob`, `LS`                |
-| `edit`       | `Edit`, `MultiEdit`, `Create`               |
-| `execution`  | `Execute`                                   |
-| `web`        | `WebSearch`, `FetchUrl`                     |
-| `mcp`        | Dynamically populated MCP tools (if any)    |
+| Category    | Tools granted (LLM IDs)                  |
+| ----------- | ---------------------------------------- |
+| `read-only` | `Read`, `Grep`, `Glob`, `LS`             |
+| `edit`      | `Edit`, `MultiEdit`, `Create`            |
+| `execution` | `Execute`                                |
+| `web`       | `WebSearch`, `FetchUrl`                  |
+| `mcp`       | Dynamically populated MCP tools (if any) |
 
 Explicit arrays must use the tool names above (case-sensitive). Unknown names cause validation errors.
 
@@ -94,13 +99,11 @@ Explicit arrays must use the tool names above (case-sensitive). Unknown names ca
 
 ## 5 · Managing droids in the UI
 
-`/droids` opens an Ink UI with:
+`/droids` opens a modal with:
 
 - **Create a new Droid** – launches the guided flow above.
 - **List of droids** – shows name, summary, and location badge (Project / Personal).
 - Selecting a droid lets you **View**, **Edit**, **Delete**, or go **Back**.
-
-Edits run through `DroidStorageService`, which keeps timestamps up to date and re-validates on save. Delete removes the underlying Markdown file. Import/export helpers exist (`DroidStorageService.importDroid` / `exportDroid`) and are wired into future UI work, but the current manager only targets local files.
 
 The “Generate from description” flow in the creator is stubbed today—it seeds placeholder content while the generation pipeline is under construction.
 
@@ -108,19 +111,12 @@ The “Generate from description” flow in the creator is stubbed today—it se
 
 ## 6 · Using custom droids effectively
 
-- **Invoke via the Task tool** – when custom droids are enabled, the registry exposes the **Task** tool. droid may call it autonomously, or you can request it directly (“Use the Task tool with subagent `security-auditor` on this change”).
+- **Invoke via the Task tool** – when custom droids are enabled, the droid may call it autonomously, or you can request it directly (“Use the subagent `security-auditor` on this change”).
 - **Switch models intentionally** – the subagent respects the `model` field. Use `inherit` when you want it to follow the parent session’s active provider and reasoning effort.
 - **Limit tool access** – prefer categories (e.g. `read-only`) or explicit lists so the subagent can’t execute unexpected shell commands.
 - **Version in git** – check `.factory/droids/*.md` into your repo to share prompts and review changes like code.
-- **Review logs** – the Task executor shells out to the Python `droid` binary as `droid task <name> <prompt> --output-format debug`, consuming JSONL debug output. Only assistant messages are surfaced, and the CLI appends stderr/exit-code details when something fails.
 
-Structuring the prompt to emit sections like `Summary:` and `Findings:` helps the Task tool UI summarize results—the renderer keys off those markers when available.
-
-<Note>
-  Make sure your local `droid` binary is on a build that ships the `task` command. Older versions will exit immediately with a Typer usage message when the Task tool runs.
-</Note>
-
-Recommendation: switch core models after milestones (post-commit, after a PR review, or when restarting a plan) so the lossy but low-impact provider translation only happens on clean state transitions.
+Structuring the prompt to emit sections like `Summary:` and `Findings:` helps the Task tool UI summarize results.
 
 ---
 
@@ -151,7 +147,7 @@ Findings:
 - <action or leave blank>
 ```
 
-Use: “Run the Task tool with subagent `code-reviewer` on the staged diff.”
+Use: “Run the subagent `code-reviewer` on the staged diff.”
 
 ### Security sweeper (personal scope)
 

--- a/docs/cli/configuration/custom-droids.mdx
+++ b/docs/cli/configuration/custom-droids.mdx
@@ -1,0 +1,186 @@
+---
+title: Custom Droids (Subagents)
+description: Create specialized subagents with their own prompts, tool access, and models that droid can delegate work to.
+---
+
+Custom droids are reusable subagents defined in Markdown. Each droid carries its own system prompt, model preference, and tooling policy so you can hand off focused tasks—like code review, security checks, or research—without re-typing instructions.
+
+---
+
+## 1 · What are custom droids?
+
+Custom droids live as text files under either your project’s `.factory/droids/` or your personal `~/.factory/droids/` directory. When enabled, the CLI scans these folders (top-level files only), validates each definition, and exposes them as `subagent_type` targets for the **Task** tool. This lets the primary assistant spin up purpose-built helpers mid-session.
+
+- **Project droids** sit in `<repo>/.factory/droids/` and are shared with teammates.
+- **Personal droids** live in `~/.factory/droids/` and follow you across workspaces.
+- Project definitions override personal ones when the names match.
+
+---
+
+## 2 · Why use them?
+
+- **Faster delegation** – encode complex checklists once and reuse them with a single tool call.
+- **Stricter safety** – limit an agent to read-only, edit-only, or curated tool sets.
+- **Context isolation** – each subagent runs with a fresh context window, avoiding prompt bloat.
+- **Repeatable reviews** – capture team-specific review, testing, or release gates as code you can version.
+
+---
+
+## 3 · Quick start
+
+1. Open **Settings** (`Shift+Tab` → **Settings**) and toggle **Custom Droids** under the _Experimental_ section. This persists `"enableCustomDroids"` in `~/.factory/settings.json` and registers the Task tool.
+2. Run `/droids` to launch the Droids menu.
+3. Choose **Create a new Droid**, pick a storage location (project or personal), then follow the wizard to set an identifier, system prompt, tools, and model.
+4. Save. The CLI writes `<name>.md` into the chosen `droids/` directory and normalizes the filename (lowercase, hyphenated).
+5. Ask droid to use it, e.g. “Run the Task tool with subagent `code-reviewer` to review this diff,” or trigger it from automation.
+
+The loader caches scans for ~5 seconds. The current UI instantiates a fresh loader on every open, so changes usually show up on the next visit; a long-running watch is not yet enabled by default.
+
+---
+
+## 4 · Configuration
+
+Each droid file is Markdown with YAML frontmatter.
+
+```md
+---
+name: code-reviewer
+description: Focused reviewer that checks diffs for correctness risks
+model: claude-opus-4-1-20250805 # or claude-sonnet-4-20250514, gpt-5-2025-08-07, inherit
+tools: read-only # all | read-only | edit | execution | web | mcp | ["Read", "Edit", ...]
+version: v1
+---
+
+You are the team’s senior reviewer. Examine the diff the parent agent shares and:
+
+- flag correctness, security, and migration risks
+- list targeted follow-up tasks if changes are required
+- confirm tests or manual validation needed before merge
+
+Respond with:
+Summary: <one-line finding>
+Findings:
+
+- <bullet>
+- <bullet>
+```
+
+Key metadata fields:
+
+| Field                   | Notes                                                                                                                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                  | Required. Lowercase letters, digits, `-`, `_`. Drives the `subagent_type` value and filename.                                                                                     |
+| `description`           | Optional. Shown in the UI list. Keep ≤500 chars.                                                                                                                                  |
+| `model`                 | `claude-opus-4-1-20250805`, `claude-sonnet-4-20250514`, `gpt-5-2025-08-07`, or `inherit` (use the parent session’s model). The validator rejects other strings.              |
+| `tools`                 | `all`, a category (`read-only`, `edit`, `execution`, `web`, `mcp`), or an explicit list of tool IDs (e.g. `"Read"`, `"Execute"`). Default is `all`, which enables every CLI tool. |
+| `createdAt`/`updatedAt` | Auto-filled when using the wizard; optional otherwise.                                                                                                                            |
+| `version`               | Optional string to track revisions.                                                                                                                                               |
+
+Prompts must start with YAML frontmatter containing at least `name` and include a non-empty body. `DroidValidator` surfaces errors (invalid names, unknown models, unknown tools) and warnings (missing description, duplicated tools, unrestricted `all`). Validation issues appear in the CLI logs when a file fails to load.
+
+### Tool categories → concrete tools
+
+| Category     | Tools granted (LLM IDs)                     |
+| ------------ | ------------------------------------------- |
+| `read-only`  | `Read`, `Grep`, `Glob`, `LS`                |
+| `edit`       | `Edit`, `MultiEdit`, `Create`               |
+| `execution`  | `Execute`                                   |
+| `web`        | `WebSearch`, `FetchUrl`                     |
+| `mcp`        | Dynamically populated MCP tools (if any)    |
+
+Explicit arrays must use the tool names above (case-sensitive). Unknown names cause validation errors.
+
+---
+
+## 5 · Managing droids in the UI
+
+`/droids` opens an Ink UI with:
+
+- **Create a new Droid** – launches the guided flow above.
+- **List of droids** – shows name, summary, and location badge (Project / Personal).
+- Selecting a droid lets you **View**, **Edit**, **Delete**, or go **Back**.
+
+Edits run through `DroidStorageService`, which keeps timestamps up to date and re-validates on save. Delete removes the underlying Markdown file. Import/export helpers exist (`DroidStorageService.importDroid` / `exportDroid`) and are wired into future UI work, but the current manager only targets local files.
+
+The “Generate from description” flow in the creator is stubbed today—it seeds placeholder content while the generation pipeline is under construction.
+
+---
+
+## 6 · Using custom droids effectively
+
+- **Invoke via the Task tool** – when custom droids are enabled, the registry exposes the **Task** tool. droid may call it autonomously, or you can request it directly (“Use the Task tool with subagent `security-auditor` on this change”).
+- **Switch models intentionally** – the subagent respects the `model` field. Use `inherit` when you want it to follow the parent session’s active provider and reasoning effort.
+- **Limit tool access** – prefer categories (e.g. `read-only`) or explicit lists so the subagent can’t execute unexpected shell commands.
+- **Version in git** – check `.factory/droids/*.md` into your repo to share prompts and review changes like code.
+- **Review logs** – the Task executor shells out to the Python `droid` binary as `droid task <name> <prompt> --output-format debug`, consuming JSONL debug output. Only assistant messages are surfaced, and the CLI appends stderr/exit-code details when something fails.
+
+Structuring the prompt to emit sections like `Summary:` and `Findings:` helps the Task tool UI summarize results—the renderer keys off those markers when available.
+
+<Note>
+  Make sure your local `droid` binary is on a build that ships the `task` command. Older versions will exit immediately with a Typer usage message when the Task tool runs.
+</Note>
+
+Recommendation: switch core models after milestones (post-commit, after a PR review, or when restarting a plan) so the lossy but low-impact provider translation only happens on clean state transitions.
+
+---
+
+## 7 · Examples
+
+### Code reviewer (project scope)
+
+```md
+---
+name: code-reviewer
+description: Reviews diffs for correctness, tests, and migration fallout
+model: claude-opus-4-1-20250805
+tools: read-only
+---
+
+You are the team’s principal reviewer. Given the diff and context:
+
+- Summarize the intent of the change.
+- Flag correctness risks, missing tests, or rollback hazards.
+- Call out any migrations or data changes that need coordination.
+
+Reply with:
+Summary: <one-line>
+Findings:
+
+- <issue or ✅ No blockers>
+  Follow-up:
+- <action or leave blank>
+```
+
+Use: “Run the Task tool with subagent `code-reviewer` on the staged diff.”
+
+### Security sweeper (personal scope)
+
+```md
+---
+name: security-sweeper
+description: Looks for insecure patterns in recently edited files
+model: gpt-5-2025-08-07
+tools:
+  - Read
+  - Grep
+  - WebSearch
+---
+
+Investigate the files referenced in the prompt for security issues:
+
+- Identify injection, insecure transport, privilege escalation, or secrets exposure.
+- Suggest concrete mitigations.
+- Link to relevant CWE or internal standards when helpful.
+
+Respond with:
+Summary: <headline>
+Findings:
+
+- <file>: <issue>
+  Mitigations:
+- <recommendation>
+```
+
+---
+
+With custom droids, you capture tribal knowledge as code. Compose specialized prompts once, assign the right tools, and let the primary assistant delegate heavy lifts to the subagents you design.

--- a/docs/cli/getting-started/overview.mdx
+++ b/docs/cli/getting-started/overview.mdx
@@ -13,15 +13,10 @@ description: Meet `droid` — the power of Factory in your terminal
 ## Get started in 30 seconds
 
 <CodeGroup>
+
 ```bash macOS/Linux
 # Install droid
 curl -fsSL https://app.factory.ai/cli | sh
-
-# Navigate to your project
-cd your-project
-
-# Start your development session
-droid
 ```
 
 ```powershell Windows
@@ -34,13 +29,22 @@ $env:PATH += ";$Env:USERPROFILE\bin"
 # Persist for your user:
 setx PATH "$Env:Path;$Env:USERPROFILE\bin"
 # Then restart your terminal or IDE to pick up the change
+```
 
+</CodeGroup>
+
+Then navigate to your project and start the droid CLI.
+
+<CodeGroup>
+```bash
 # Navigate to your project
-cd your-project
+cd /path/to/your/project
 
-# Start your development session
+# Start interactive session
+
 droid
-````
+
+```
 
 </CodeGroup>
 
@@ -129,3 +133,4 @@ You're now connected to Factory's development agent from your terminal. [Try the
     </>
   )}
 </CardGroup>
+```

--- a/docs/cli/getting-started/overview.mdx
+++ b/docs/cli/getting-started/overview.mdx
@@ -15,20 +15,13 @@ description: Meet `droid` — the power of Factory in your terminal
 <CodeGroup>
 
 ```bash macOS/Linux
-# Install droid
 curl -fsSL https://app.factory.ai/cli | sh
 ```
 
 ```powershell Windows
-# Install droid
 irm https://app.factory.ai/cli/windows | iex
-
-# Add to PATH (required)
-# Current session:
 $env:PATH += ";$Env:USERPROFILE\bin"
-# Persist for your user:
 setx PATH "$Env:Path;$Env:USERPROFILE\bin"
-# Then restart your terminal or IDE to pick up the change
 ```
 
 </CodeGroup>

--- a/docs/cli/getting-started/quickstart.mdx
+++ b/docs/cli/getting-started/quickstart.mdx
@@ -17,12 +17,10 @@ Make sure you have:
 <CodeGroup>
 
 ```bash macOS/Linux
-# Install droid
 curl -fsSL https://app.factory.ai/cli | sh
 ```
 
 ```powershell Windows
-# Install droid
 irm https://app.factory.ai/cli/windows | iex
 
 # Add to PATH (required)
@@ -43,7 +41,9 @@ Then navigate to your project and start the droid CLI.
 cd /path/to/your/project
 
 # Start interactive session
+
 droid
+
 ```
 
 </CodeGroup>

--- a/docs/cli/user-guides/auto-run.mdx
+++ b/docs/cli/user-guides/auto-run.mdx
@@ -1,165 +1,97 @@
 ---
 title: Auto-Run Mode
-description: Enable automatic execution of file edits and creation without manual approval for faster development workflows.
+description: Choose low, medium, or high autonomy so droid can execute work that matches your risk tolerance without repeated confirmations.
 ---
 
-Auto-Run Mode eliminates the need for manual confirmation when droid makes file changes. Instead of stopping to ask for approval before each edit or file creation, droid automatically executes these changes, creating a seamless and faster development experience.
+Auto-Run Mode lets you decide how much autonomy droid has after you approve a plan. Instead of confirming every tool call, pick the level of risk you are comfortable with and droid will keep moving while still surfacing everything it does.
 
 <CardGroup cols={2}>
-  <Card title="Automatic Execution" icon="bolt">
-    File edits and creation happen instantly without approval prompts
+  <Card title="Configurable Autonomy" icon="slider">
+    Switch between Low, Medium, and High depending on the type of work in front of you.
   </Card>
-  <Card title="Faster Workflows" icon="rocket">
-    Eliminate waiting time between file operations for rapid iteration
+  <Card title="Risk-Aware Execution" icon="shield-check">
+    Commands run automatically only when their risk rating is at or below your chosen level.
   </Card>
-  <Card title="Batch Operations" icon="layer-group">
-    Perfect for multi-file changes across your entire codebase
+  <Card title="No Surprises" icon="eye">
+    Dangerous commands and command substitutions always require an explicit approval.
   </Card>
-  <Card title="Streamlined Experience" icon="gauge-high">
-    Focus on results rather than approving individual operations
+  <Card title="Persistent Preference" icon="floppy">
+    Your autonomy level is saved in settings and restored for the next session.
   </Card>
 </CardGroup>
 
-## How it works
+## Autonomy levels at a glance
 
-<Steps>
-  <Step title="Enable Auto-Run">
-    Activate Auto-Run Mode in the CLI or through settings to bypass file operation confirmations.
-  </Step>
-  <Step title="Droid makes changes">
-    When droid needs to edit or create files, it executes these operations immediately without waiting for your approval.
-  </Step>
-  <Step title="View the results">
-    See all changes as they happen in real-time, with full visibility into what was modified or created.
-  </Step>
-  <Step title="Review when complete">
-    Once the task is finished, review all changes at once rather than approving each individual operation.
-  </Step>
-</Steps>
+| Level | What runs automatically | Typical examples |
+| --- | --- | --- |
+| **Auto (Low)** | File edits, file creation, and read-only commands from the built-in allowlist | `Edit`, `Create`, `ls`, `git status`, `rg` |
+| **Auto (Medium)** | Everything from Low plus reversible commands that change your workspace | `npm install`, `pip install`, `git commit`, `mv`, `cp`, build tooling |
+| **Auto (High)** | All commands that are not explicitly blocked for safety | `docker compose up`, `git push` (if allowed), migrations, custom scripts |
 
-## Example workflow
+Auto-Run always shows streamed output and highlights every file change, regardless of the autonomy level.
 
-**Normal mode:**
+## Risk classification
+
+Every command sent through the CLI includes a risk rating (`low`, `medium`, or `high`) along with a short justification. Auto-Run compares that rating to your selected autonomy level:
+
+- **Low risk** – read-only operations and changes that cannot create irreversible damage (listing files, showing logs, git diff).
+- **Medium risk** – actions that alter your workspace but are straightforward to undo (package installs, moving files, local git operations, builds).
+- **High risk** – commands that could be destructive, hard to roll back, or security sensitive (sudo, wiping directories, deploying, piping remote scripts).
+
+Commands run automatically only when their risk level is less than or equal to your current setting. If a tool labels a command above your threshold, the CLI pauses and asks for confirmation.
+
+## How Auto-Run decides what to execute
+
+- **File tools** (`Create`, `Edit`, `MultiEdit`, `ApplyPatch`) are treated as low risk and run instantly whenever Auto-Run is active.
+- **Execute commands** follow the risk threshold. Low autonomy auto-accepts only read-only allowlisted commands. Medium adds reversible commands. High accepts any command with a declared risk level, except for those blocked below.
+- **Safety interlocks** always trigger confirmation, even in Auto (High): dangerous patterns (`rm -rf /`, `dd of=/dev/*`, etc.), command substitution (`$(...)`, backticks), or anything explicitly flagged by the CLI security checks.
+- **Allowlist expansion** – when you approve a command, you can add it to the session allowlist so future occurrences run without another prompt.
+
+## Enabling and switching modes
+
+- **Cycle from the keyboard** – press **Shift+Tab** (or `Ctrl+T` on Windows) to move through Normal → Spec → Auto (Low) → Auto (Medium) → Auto (High) → back to Normal. The active mode is shown in the status banner and Help popup.
+- **Set a default in Settings** – open the CLI settings menu, choose your preferred autonomy level, and the CLI persists it for future sessions.
+- **Choose it after a spec** – when approving a Specification Mode plan, pick “Proceed” (manual), or enable Auto-Run at Low, Medium, or High for the implementation phase.
+- **Return to manual control** at any time by cycling back to Normal; droid will resume asking for each file change and command.
+
+## Workflow examples
+
+**Auto (Low)** – quick file updates and reconnaissance
 ```
-Droid: "I need to edit config.js to add the new API endpoint"
-You: [Approve] ✓
-Droid: "I need to create a new routes/api.js file"
-You: [Approve] ✓
-Droid: "I need to update package.json with the new dependency"
-You: [Approve] ✓
+- Update docs/README.md with new instructions
+- Run ls, git status, and rg searches as needed
 ```
+All edits and read-only checks happen without prompts, while anything that modifies dependencies still asks first.
 
-**Auto-Run mode:**
+**Auto (Medium)** – feature work that needs tooling
 ```
-Droid: "Adding new API endpoint..."
-✓ Edited config.js
-✓ Created routes/api.js  
-✓ Updated package.json
-Task complete!
+- Add a new React component (multiple file edits)
+- npm install @acme/widget
+- npm run lint
 ```
+File changes, dependency installs, and build scripts execute automatically so long as they are reversible.
 
-<Note>
-Auto-Run Mode can be toggled on/off at any time during your session. It only affects file editing and creation operations.
-</Note>
-
-## How to enable Auto-Run Mode
-
-**In the CLI:** Use the keyboard shortcut **Shift+Tab** to toggle Auto-Run Mode on or off during your session.
-
-**From Specification Mode:** When approving a specification, choose "Approve and continue with auto-run enabled" to automatically enable Auto-Run for the implementation.
-
-## What Auto-Run affects
-
-**Automatically executed:**
-- Creating new files
-- Editing existing files  
-- Saving file changes
-
-**Still requires approval:**
-- Running shell commands
-- Installing packages
-- Making git commits
-- Deleting files or directories
-
-Auto-Run Mode is designed specifically for the most common and safe file operations that developers typically want to happen quickly.
-
-## When to use Auto-Run Mode
-
-**Perfect for:**
-- Refactoring across multiple files
-- Adding features that span several components
-- Code cleanup and formatting tasks
-- Generating boilerplate code
-- Applying consistent changes across your codebase
-
-**Consider normal mode for:**
-- Working with unfamiliar codebases
-- Making changes to critical system files
-- When you want to review each change individually
-- Learning how droid approaches problems
-
-## Benefits
-
-<CardGroup cols={2}>
-  <Card title="Speed" icon="gauge-high">
-    Eliminate the back-and-forth of approving each file operation for faster development.
-  </Card>
-  <Card title="Flow State" icon="brain">
-    Stay focused on the problem rather than clicking through approval prompts.
-  </Card>
-  <Card title="Batch Operations" icon="layer-group">
-    Handle large refactoring tasks efficiently without constant interruption.
-  </Card>
-  <Card title="Trust Building" icon="handshake">
-    As you become comfortable with droid's capabilities, reduce friction in your workflow.
-  </Card>
-</CardGroup>
-
-## Safety features
-
-Auto-Run Mode includes built-in safety measures:
-
-**File operation limits:** Droid will pause and ask for confirmation if it needs to modify an unusually large number of files (typically 20+).
-
-**Critical file protection:** Changes to package.json, configuration files, and other critical files may still prompt for approval depending on the scope.
-
-**Easy toggle:** You can instantly disable Auto-Run Mode with Shift+Tab if you want to return to manual approval.
-
-**Full visibility:** Every change is logged and displayed as it happens, so you always know what's being modified.
-
-## Example use cases
-
-**Multi-file refactoring:**
+**Auto (High)** – migrations or integration tests
 ```
-"Rename the UserService class to AccountService throughout the codebase"
+- Run database migration script
+- docker compose up test-environment
+- git push origin feature/autonomy-docs
 ```
+Droid executes the entire sequence without pauses while still blocking obviously dangerous commands.
 
-With Auto-Run enabled, droid will automatically:
-- Update all import statements
-- Rename the class file
-- Modify all references in components
-- Update related tests
+## When you will still get prompted
 
-**Feature implementation:**
-```
-"Add user authentication to the existing API endpoints"
-```
+- A command is rated above your current autonomy level.
+- The CLI detects command substitution or a dangerous pattern.
+- A tool requests something outside the session allowlist and you are in Auto (Low).
+- Droid needs clarity (e.g., missing context, ambiguous edits) and asks for input.
+- You manually interrupt with **Esc**.
 
-Droid will automatically create and edit the necessary files for:
-- Middleware functions
-- Route protections  
-- Database schema updates
-- Test files
+## Best practices
 
-**Code organization:**
-```
-"Move all utility functions to a shared utils directory"
-```
+- Start new or high-stakes work in Normal or Auto (Low) until you trust the plan.
+- Use Auto (Medium) for day-to-day feature development and refactors that rely on package managers or build steps.
+- Reserve Auto (High) for well-understood pipelines where you expect droid to run end-to-end scripts.
+- If you spot a suspect command, interrupt, provide guidance, and resume at the autonomy level that fits the remaining risk.
 
-Auto-Run handles:
-- Creating the new directory structure
-- Moving files to appropriate locations
-- Updating all import paths
-- Maintaining code functionality
-
-Ready to try Auto-Run Mode? Enable it with **Shift+Tab** and experience faster, more fluid development with droid.
+Ready to try it? Cycle into the level you need with **Shift+Tab**, or pick the desired option when you approve your next spec.

--- a/docs/cli/user-guides/choosing-your-model.mdx
+++ b/docs/cli/user-guides/choosing-your-model.mdx
@@ -65,8 +65,5 @@ Factory ships with managed Anthropic and OpenAI access. If you prefer to run aga
 
 ## 6 · Keep notes on what works
 
-- Share lessons in your project’s `AGENTS.md` so teammates know when to upgrade or downgrade models.
 - Track high-impact workflows (e.g., spec generation vs. quick edits) and which combinations of model + reasoning effort feel best.
 - Ping the community or your Factory contact when you notice a model regression so we can benchmark and update this guidance quickly.
-
-Staying model-aware lets you preserve Opus for the tasks that truly demand it while leaning on Codex, GPT‑5, or Sonnet everywhere else.

--- a/docs/cli/user-guides/choosing-your-model.mdx
+++ b/docs/cli/user-guides/choosing-your-model.mdx
@@ -1,0 +1,72 @@
+---
+title: Choosing Your Model
+description: Balance accuracy, speed, and cost by picking the right model and reasoning level for each CLI task.
+---
+
+Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shifts. Use this guide as a snapshot of how the major options compare today, and expect to revisit it as we publish updates. This guide was last updated on Wednesday, September 24th 2025.
+
+---
+
+## 1 · Current stack rank (September 2025)
+
+| Rank | Model                               | Why we reach for it                                                                                                                                    |
+| ---- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1    | **Claude Opus 4.1**                 | Highest reliability on complex planning, architecture decisions, and long edits. Slight lead in reasoning and code quality, but also the highest cost. |
+| 2    | **GPT‑5 Codex**                     | Nearly Opus-level output with noticeably lower latency and ~5× lower cost. Great daily driver for implementation work.                                 |
+| 3    | **GPT‑5** <br/> **Claude Sonnet 4** | Solid generalists. We see similar behavior between them; pick based on preference, latency, or cost.                                                   |
+
+<Note>
+  We ship model updates regularly. When a new release overtakes the list above,
+  we update this page and the CLI defaults.
+</Note>
+
+---
+
+## 2 · Match the model to the job
+
+| Scenario                                                         | Recommended model                                                                                                                                    |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Deep planning, architecture reviews, ambiguous product specs** | Start with **Opus 4.1**. Switch down if you only need execution after the plan is locked.                                                            |
+| **Full-feature development, large refactors**                    | **GPT‑5 Codex** balances quality and speed; Opus is a good fallback if Codex struggles.                                                              |
+| **Repeatable edits, summarization, boilerplate generation**      | **GPT‑5** or **Sonnet 4** keep costs low while staying accurate.                                                                                     |
+| **CI/CD or automation loops**                                    | Favor **GPT‑5 Codex** or **Sonnet 4** for predictable throughput. Promote the critical planning steps to **Opus 4.1** when correctness matters most. |
+
+Tip: you can swap models mid-session with `/model` or by toggling in the settings panel (`Shift+Tab` → **Settings**).
+
+---
+
+## 3 · Switching models mid-session
+
+- Use `/model` (or **Shift+Tab → Settings → Model**) to swap without losing your chat history.
+- If you change providers (e.g. Anthropc to OpenAI), the CLI converts the session transcript between Anthropic and OpenAI formats. The translation is lossy—provider-specific metadata is dropped—but we have not seen accuracy regressions in practice.
+- For the best context continuity, switch models at natural milestones: after a commit, once a PR lands, or when you abandon a failed approach and reset the plan.
+- If you flip back and forth rapidly, expect the assistant to spend a turn re-grounding itself; consider summarizing recent progress when you switch.
+
+---
+
+## 4 · Reasoning effort settings
+
+- Anthropic models (Opus/Sonnet) show modest gains between Low and High.
+- GPT models respond much more to higher reasoning effort—bumping **GPT‑5** or **GPT‑5 Codex** to **High** can materially improve planning and debugging.
+- Reasoning effort increases latency and cost, so start Low for simple work and escalate when you need more depth.
+
+<Tip>
+  Change reasoning effort from `/model` → **Reasoning effort**, or via the
+  settings menu.
+</Tip>
+
+---
+
+## 5 · Bring Your Own Keys (BYOK)
+
+Factory ships with managed Anthropic and OpenAI access. If you prefer to run against your own accounts, BYOK is opt-in—see [Bring Your Own Keys](/cli/configuration/byok) for setup steps, supported providers, and billing notes.
+
+---
+
+## 6 · Keep notes on what works
+
+- Share lessons in your project’s `AGENTS.md` so teammates know when to upgrade or downgrade models.
+- Track high-impact workflows (e.g., spec generation vs. quick edits) and which combinations of model + reasoning effort feel best.
+- Ping the community or your Factory contact when you notice a model regression so we can benchmark and update this guidance quickly.
+
+Staying model-aware lets you preserve Opus for the tasks that truly demand it while leaning on Codex, GPT‑5, or Sonnet everywhere else.

--- a/docs/cli/user-guides/specification-mode.mdx
+++ b/docs/cli/user-guides/specification-mode.mdx
@@ -189,13 +189,24 @@ This approach allows you to validate each phase before proceeding to the next.
 
 ## Specification approval options
 
-After droid presents the specification, you have three options:
+After droid presents the specification, choose how to continue:
 
-1. **Approve and continue** - Proceed with the implementation using normal execution mode
-2. **Approve and continue with auto-run enabled** - Proceed with implementation and automatically enable [auto-run mode](/cli/user-guides/auto-run) for faster execution
-3. **Reject, continue editing** - Decline the specification and remain in Specification Mode to refine your request
+1. **Proceed with implementation** – Approve the plan and keep normal (manual) execution controls.
+2. **Proceed, and allow file edits and read-only commands (Low)** – Enable low autonomy auto-run so droid can edit files and run safe read-only commands automatically.
+3. **Proceed, and allow reversible commands (Medium)** – Enable medium autonomy auto-run so droid can also run reversible commands without additional prompts.
+4. **Proceed, and allow all commands (High)** – Enable high autonomy auto-run for fully automated execution, including commands that are not easily reversible.
+5. **No, keep iterating on spec** – Stay in Specification Mode to refine the plan before implementation.
 
-The third option keeps you in Specification Mode, allowing you to iterate on your request until the specification meets your requirements.
+Selecting any auto-run option sets the corresponding autonomy level for the rest of the session. Choosing to keep iterating leaves Specification Mode active so you can continue shaping the plan.
+
+## Saving your specifications as Markdown
+
+Specification Mode can automatically write the approved plan to disk. Open the CLI settings and enable **Save spec as Markdown** to turn this on.
+
+- By default, plans are saved to `.factory/docs` inside the nearest project-level `.factory` directory. If none exists, the CLI falls back to `~/.factory/docs` in your home directory.
+- Use the **Spec save directory** setting to pick between the project directory, your home directory, or a custom path. Custom values support absolute paths, `~` expansion, `.factory/...` shortcuts, and relative paths from the current workspace.
+- The CLI creates the target directory if it does not exist and writes the Markdown exactly as shown in the approval dialog.
+- Files are named `YYYY-MM-DD-slug.md`, where the slug comes from the spec title or first heading, and a counter is appended if a file with the same name already exists.
 
 ## What happens after approval
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -36,6 +36,7 @@
             "pages": [
               "cli/user-guides/specification-mode",
               "cli/user-guides/auto-run",
+              "cli/user-guides/choosing-your-model",
               "cli/user-guides/implementing-large-features"
             ]
           },
@@ -44,6 +45,8 @@
             "pages": [
               "cli/configuration/ide-integrations",
               "cli/configuration/agents-md",
+              "cli/configuration/custom-commands",
+              "cli/configuration/custom-droids",
               "cli/configuration/settings",
               "cli/configuration/byok",
               "cli/configuration/mcp"


### PR DESCRIPTION
## Summary
- add navigation entries for the new CLI guides covering custom commands, custom droids, and choosing a model

## Testing
- not run (docs-only change)
