### PR TITLE
docs: temporarily hide changelog navigation

### DIFF
--- a/docs/changelog/1-1.mdx
+++ b/docs/changelog/1-1.mdx
@@ -1,6 +1,7 @@
 ---
 title: Factory Release 1.1
 description: "Windows Support for Bridge, Token Efficiency Improvements, and GitLab Remote Workspaces"
+draft: true
 ---
 
 Windows developers can now execute code on their local machine with Factory Bridge. Run local CLI from chat and sync code between your desktop and Factory. Along with native Windows support, we're rolling out a 50% boost in token efficiency, support for creating remote workspaces hosted in GitLab, sharper UI flows, and more predictable billing.

--- a/docs/changelog/1-2.mdx
+++ b/docs/changelog/1-2.mdx
@@ -1,6 +1,7 @@
 ---
 title: Factory Release 1.2
 description: "Improved Long Running Agents and Workspace Customization"
+draft: true
 ---
 
 Factory 1.2 comes with major improvements to the Droids’ ability to work across long sessions, additional customization for remote workspaces, and tons of stability and bug fixes.

--- a/docs/changelog/1-3.mdx
+++ b/docs/changelog/1-3.mdx
@@ -1,6 +1,7 @@
 ---
 title: Factory Release 1.3
 description: "Better, Faster Droids"
+draft: true
 ---
 
 Factory 1.3 comes with improvements on the speed, quality, and reliability of Droids. Commands run faster, Droids pull in context in a more targeted and precise way, and prompt caching is significantly more effective.

--- a/docs/changelog/1-4.mdx
+++ b/docs/changelog/1-4.mdx
@@ -1,6 +1,7 @@
 ---
 title: Factory Release 1.4
 description: "Droids in Slack & UX Upgrades"
+draft: true
 ---
 
 Factory 1.4 introduces Droids into Slack and delivers key improvements to onboarding and overall user experience. 

--- a/docs/changelog/1-5.mdx
+++ b/docs/changelog/1-5.mdx
@@ -1,6 +1,7 @@
 ---
 title: Factory Release 1.5
 description: 'Session Revamp & Workflow Upgrades'
+draft: true
 ---
 
 Factory 1.5 introduces a fully redesigned Session interface, transforming how you manage your Droids.

--- a/docs/changelog/1-6.mdx
+++ b/docs/changelog/1-6.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Factory Release 1.6"
 description: "To-do list tool, improved remote Droids, and browser tools"
+draft: true
 ---
 
 Factory 1.6 introduces a new To-Do List Tool for multi-step work, several improvements to remote Droids, plus Browser Tools to navigate and interact with the web from Factory.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -175,24 +175,26 @@
             ]
           }
         ]
-      },
-      {
-        "tab": "Changelog",
-        "groups": [
-          {
-            "group": "Changelog",
-            "pages": [
-              "changelog/1-6",
-              "changelog/1-5",
-              "changelog/1-4",
-              "changelog/1-3",
-              "changelog/1-2",
-              "changelog/1-1"
-            ]
-          }
-        ]
       }
     ]
+  },
+  "_hiddenTabs": {
+    "changelog": {
+      "tab": "Changelog",
+      "groups": [
+        {
+          "group": "Changelog",
+          "pages": [
+            "changelog/1-6",
+            "changelog/1-5",
+            "changelog/1-4",
+            "changelog/1-3",
+            "changelog/1-2",
+            "changelog/1-1"
+          ]
+        }
+      ]
+    }
   },
   "logo": {
     "light": "/logo/light.svg",


### PR DESCRIPTION
## Summary
- remove the changelog tab from navigation while storing config under _hiddenTabs
- mark existing changelog pages as draft so they stay hidden

## Testing
- mintlify dev
