### PR TITLE
docs: update default model description

### DIFF
--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -26,17 +26,20 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 
 | Setting | Options | Default | Description |
 | ------- | ------- | ------- | ----------- |
-| `model` | `sonnet`, `opus`, `GPT-5` | `sonnet` | The AI model used by droid |
+| `model` | `sonnet`, `opus`, `GPT-5`, `gpt-5-codex` | `sonnet` | The default AI model used by droid |
 | `diffMode` | `github`, `diff` | `github` | How code changes are displayed |
 | `persistToCloud` | `true`, `false` | `false` | Sync CLI sessions to Factory web UI |
 
 ### Model
 
-Choose the AI model that powers your droid:
+Choose the default AI model that powers your droid:
 
 - **`sonnet`** - Balanced performance and speed (recommended)
 - **`opus`** - Most capable model for complex tasks  
 - **`GPT-5`** - Latest OpenAI model
+- **`gpt-5-codex`** - Advanced coding-focused model
+
+[You can also add custom models and BYOK.](/cli/configuration/byok)
 
 ### Diff mode
 
@@ -66,5 +69,6 @@ When enabled, syncs your CLI sessions to your Factory web sessions so you can vi
 
 ### Need more?
 
-• [CLI Reference](/cli/configuration/cli-reference) – command flags & options
-• [IDE Integrations](/cli/configuration/ide-integrations) – editor-specific setup
+- [CLI Reference](/cli/configuration/cli-reference) – command flags & options
+- [IDE Integrations](/cli/configuration/ide-integrations) – editor-specific setup
+- [Custom models & BYOK](/cli/configuration/byok) - add custom models and API keys


### PR DESCRIPTION
## Summary
- clarify that the model setting refers to the default droid model
- add gpt-5-codex as an available option
- link to BYOK docs and list additional model resources