### PR TITLE
docs: add CLIProxyAPI community builds

### DIFF
--- a/community-builds.md
+++ b/community-builds.md
@@ -4,3 +4,5 @@ A curated list of community-built examples and projects using Factory. To add yo
 
 - [here-now](https://github.com/fredrivett/here-now) - Minimal webpage hit counter — show how many people are here/now by [fredrivett](https://github.com/fredrivett)
 - [factory-mcp](https://github.com/iannuttall/factory-mcp) - Community-built Factory MCP integration to search our docs by [iannuttall](https://github.com/iannuttall)
+- [Factory CLI with ChatGPT Codex / Claude subscription via CLIProxyAPI](https://gist.github.com/chandika/c4b64c5b8f5e29f6112021d46c159fdd) - Guide to run Factory CLI against Claude Code Max or ChatGPT Codex through CLIProxyAPI by [chandika](https://github.com/chandika)
+- [Factory CLI with Claude subscription via CLIProxyAPI](https://gist.github.com/ben-vargas/9f1a14ac5f78d10eba56be437b7c76e5) - Setup instructions for using Factory CLI with Claude Code Max through CLIProxyAPI by [ben-vargas](https://github.com/ben-vargas)

--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -26,17 +26,20 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 
 | Setting | Options | Default | Description |
 | ------- | ------- | ------- | ----------- |
-| `model` | `sonnet`, `opus`, `GPT-5` | `sonnet` | The AI model used by droid |
+| `model` | `sonnet`, `opus`, `GPT-5`, `gpt-5-codex` | `sonnet` | The default AI model used by droid |
 | `diffMode` | `github`, `diff` | `github` | How code changes are displayed |
 | `persistToCloud` | `true`, `false` | `false` | Sync CLI sessions to Factory web UI |
 
 ### Model
 
-Choose the AI model that powers your droid:
+Choose the default AI model that powers your droid:
 
 - **`sonnet`** - Balanced performance and speed (recommended)
 - **`opus`** - Most capable model for complex tasks  
 - **`GPT-5`** - Latest OpenAI model
+- **`gpt-5-codex`** - Advanced coding-focused model
+
+[You can also add custom models and BYOK.](/cli/configuration/byok)
 
 ### Diff mode
 
@@ -66,5 +69,6 @@ When enabled, syncs your CLI sessions to your Factory web sessions so you can vi
 
 ### Need more?
 
-• [CLI Reference](/cli/configuration/cli-reference) – command flags & options
-• [IDE Integrations](/cli/configuration/ide-integrations) – editor-specific setup
+- [CLI Reference](/cli/configuration/cli-reference) – command flags & options
+- [IDE Integrations](/cli/configuration/ide-integrations) – editor-specific setup
+- [Custom models & BYOK](/cli/configuration/byok) - add custom models and API keys


### PR DESCRIPTION
## Summary
- add community build entries linking to CLIProxyAPI setup guides
- highlight chandika and ben-vargas gists for Claude subscription usage

## Testing
- not run