### PR TITLE
Improve issue Slack notifications

### DIFF
--- a/.github/workflows/issue-label-slack.yml
+++ b/.github/workflows/issue-label-slack.yml
@@ -1,0 +1,121 @@
+name: Issue label Slack notifier
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.action == 'opened' || github.event.action == 'labeled'
+    steps:
+      - name: Determine Slack channel
+        id: route
+        uses: actions/github-script@v7
+        env:
+          LABEL_WEBHOOK_MAP: ${{ vars.ISSUE_LABEL_WEBHOOK_MAP }}
+          DEFAULT_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          script: |
+            const mapInput = (process.env.LABEL_WEBHOOK_MAP || '').trim();
+            const mappings = new Map();
+            if (mapInput) {
+              for (const line of mapInput.split(/\r?\n/)) {
+                if (!line.trim()) continue;
+                const [labelName, webhookUrl] = line.split('=');
+                if (labelName && webhookUrl) {
+                  mappings.set(labelName.trim(), webhookUrl.trim());
+                }
+              }
+            }
+
+            const defaultWebhook = (process.env.DEFAULT_WEBHOOK || '').trim();
+            const action = context.payload.action;
+            const issueLabels = (context.payload.issue.labels || []).map(label => label.name).filter(Boolean);
+            const candidates = [];
+
+            if (action === 'labeled' && context.payload.label?.name) {
+              candidates.push(context.payload.label.name);
+            }
+
+            for (const name of issueLabels) {
+              if (!candidates.includes(name)) {
+                candidates.push(name);
+              }
+            }
+
+            if (candidates.length === 0) {
+              core.setFailed('No labels available to determine Slack webhook.');
+              return;
+            }
+
+            let webhook;
+            let matchedLabel;
+            for (const candidate of candidates) {
+              if (mappings.has(candidate)) {
+                webhook = mappings.get(candidate);
+                matchedLabel = candidate;
+                break;
+              }
+            }
+
+            if (!webhook) {
+              webhook = defaultWebhook;
+              matchedLabel = candidates[0];
+            }
+
+            if (!webhook) {
+              core.setFailed('No Slack webhook matched and no default webhook provided.');
+              return;
+            }
+
+            core.setOutput('webhook', webhook);
+            core.setOutput('label', matchedLabel);
+
+      - name: Add 👀 reaction
+        if: github.event.action == 'labeled'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              content: 'eyes'
+            });
+
+      - name: Send Slack notification
+        env:
+          WEBHOOK_URL: ${{ steps.route.outputs.webhook }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          if [ -z "${WEBHOOK_URL}" ]; then
+            echo "Slack webhook URL not provided." >&2
+            exit 1
+          fi
+
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq is required but not available" >&2
+            exit 1
+          fi
+
+          payload=$(jq -n --arg url "$ISSUE_URL" --arg title "$ISSUE_TITLE" '{
+            text: $url,
+            unfurl_links: true,
+            unfurl_media: true,
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<\($url)|\($title)>"
+                }
+              }
+            ]
+          }')
+
+          curl -X POST -H 'Content-type: application/json' --data "$payload" "$WEBHOOK_URL"

--- a/README.md
+++ b/README.md
@@ -10,25 +10,29 @@ Our agent, Droid, is top performing in terminal benchmarks.
 
 <p align="left"><strong>The agent-native development platform built for shipping software faster.</strong></p>
 
-## ⚡️ Quick Links
+## Getting Started
+
+- [CLI Quickstart](https://docs.factory.ai/cli/getting-started/quickstart)
+- [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=Factory.factory-vscode-extension)
+
+## Quick Links
 
 - [Factory Website](https://factory.ai)
 - [Documentation](https://docs.factory.ai)
 - [CLI Overview](https://docs.factory.ai/cli/getting-started/overview)
-- [CLI Quickstart](https://docs.factory.ai/cli/getting-started/quickstart)
 - [Community Builds](./community-builds.md)
 
-## 💬 Community & Contributions
+## Community & Contributions
 
 - Join the community on [GitHub Discussions](https://github.com/Factory-AI/factory/discussions)
 - Share your workflows by opening a PR against [`community-builds.md`](./community-builds.md)
 - Bug/issue/feature request? [Open an issue](https://github.com/Factory-AI/factory/issues) or send a pull request
 
-## 🛠 Community Builds
+## Community Builds
 
 - [here-now](https://github.com/fredrivett/here-now) — Minimal webpage hit counter by [fredrivett](https://github.com/fredrivett)
 - [factory-mcp](https://github.com/iannuttall/factory-mcp) — Factory MCP integration demos by [iannuttall](https://github.com/iannuttall)
 
-## 📄 License
+## License
 
 Copyright © 2025 Factory AI. All rights reserved.

--- a/community-builds.md
+++ b/community-builds.md
@@ -4,3 +4,5 @@ A curated list of community-built examples and projects using Factory. To add yo
 
 - [here-now](https://github.com/fredrivett/here-now) - Minimal webpage hit counter — show how many people are here/now by [fredrivett](https://github.com/fredrivett)
 - [factory-mcp](https://github.com/iannuttall/factory-mcp) - Community-built Factory MCP integration to search our docs by [iannuttall](https://github.com/iannuttall)
+- [Factory CLI with ChatGPT Codex / Claude subscription via CLIProxyAPI](https://gist.github.com/chandika/c4b64c5b8f5e29f6112021d46c159fdd) - Guide to run Factory CLI against Claude Code Max or ChatGPT Codex through CLIProxyAPI by [chandika](https://github.com/chandika)
+- [Factory CLI with Claude subscription via CLIProxyAPI](https://gist.github.com/ben-vargas/9f1a14ac5f78d10eba56be437b7c76e5) - Setup instructions for using Factory CLI with Claude Code Max through CLIProxyAPI by [ben-vargas](https://github.com/ben-vargas)

--- a/docs/cli/configuration/ide-integrations.mdx
+++ b/docs/cli/configuration/ide-integrations.mdx
@@ -28,6 +28,10 @@ To install Droid on VS Code and popular forks like Cursor, Windsurf, and VSCodiu
 2. Open the integrated terminal
 3. Run `droid` - the extension will auto-install
 
+<Note>
+You can install the [VS Code Extension here](https://marketplace.visualstudio.com/items?itemName=Factory.factory-vscode-extension).
+</Note>
+
 ### JetBrains
 
 To install Droid on JetBrains IDEs like IntelliJ, PyCharm, Android Studio, WebStorm, PhpStorm and GoLand, find and install the Factory Droid plugin from the marketplace and restart your IDE.

--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -26,17 +26,20 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 
 | Setting | Options | Default | Description |
 | ------- | ------- | ------- | ----------- |
-| `model` | `sonnet`, `opus`, `GPT-5` | `sonnet` | The AI model used by droid |
+| `model` | `sonnet`, `opus`, `GPT-5`, `gpt-5-codex` | `sonnet` | The default AI model used by droid |
 | `diffMode` | `github`, `diff` | `github` | How code changes are displayed |
 | `persistToCloud` | `true`, `false` | `false` | Sync CLI sessions to Factory web UI |
 
 ### Model
 
-Choose the AI model that powers your droid:
+Choose the default AI model that powers your droid:
 
 - **`sonnet`** - Balanced performance and speed (recommended)
 - **`opus`** - Most capable model for complex tasks  
 - **`GPT-5`** - Latest OpenAI model
+- **`gpt-5-codex`** - Advanced coding-focused model
+
+[You can also add custom models and BYOK.](/cli/configuration/byok)
 
 ### Diff mode
 
@@ -66,5 +69,6 @@ When enabled, syncs your CLI sessions to your Factory web sessions so you can vi
 
 ### Need more?
 
-• [CLI Reference](/cli/configuration/cli-reference) – command flags & options
-• [IDE Integrations](/cli/configuration/ide-integrations) – editor-specific setup
+- [CLI Reference](/cli/configuration/cli-reference) – command flags & options
+- [IDE Integrations](/cli/configuration/ide-integrations) – editor-specific setup
+- [Custom models & BYOK](/cli/configuration/byok) - add custom models and API keys


### PR DESCRIPTION
## Summary
- add 👀 reaction to issues when labels are applied
- adjust Slack payload to hyperlink the issue title and rely on unfurled URL
- keep link unfurling enabled for better previews

## Testing
- docker run ghcr.io/rhysd/actionlint:latest *(fails: Docker daemon unavailable)*