### PR TITLE
Improve issue Slack notifications

### DIFF
--- a/.github/workflows/issue-label-slack.yml
+++ b/.github/workflows/issue-label-slack.yml
@@ -75,11 +75,23 @@ jobs:
             core.setOutput('webhook', webhook);
             core.setOutput('label', matchedLabel);
 
+      - name: Add 👀 reaction
+        if: github.event.action == 'labeled'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              content: 'eyes'
+            });
+
       - name: Send Slack notification
         env:
           WEBHOOK_URL: ${{ steps.route.outputs.webhook }}
-          MESSAGE: >-
-            New issue labeled *${{ steps.route.outputs.label }}*: <${{ github.event.issue.html_url }}|${{ github.event.issue.title }}>
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           if [ -z "${WEBHOOK_URL}" ]; then
             echo "Slack webhook URL not provided." >&2
@@ -91,5 +103,19 @@ jobs:
             exit 1
           fi
 
-          payload=$(jq -n --arg text "$MESSAGE" '{text: $text}')
+          payload=$(jq -n --arg url "$ISSUE_URL" --arg title "$ISSUE_TITLE" '{
+            text: $url,
+            unfurl_links: true,
+            unfurl_media: true,
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "<\($url)|\($title)>"
+                }
+              }
+            ]
+          }')
+
           curl -X POST -H 'Content-type: application/json' --data "$payload" "$WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- add 👀 reaction to issues when labels are applied
- hyperlink issue titles in Slack messages while using unfurled URLs
- keep Slack payload minimal with block section only

## Testing
- docker run ghcr.io/rhysd/actionlint:latest *(fails: Docker daemon unavailable)*