### PR TITLE
Remove Windows PATH instructions from docs

### DIFF
--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -78,8 +78,6 @@ curl -fsSL https://app.factory.ai/cli | sh
 
 ```powershell Windows
 irm https://app.factory.ai/cli/windows | iex
-$env:PATH += ";$Env:USERPROFILE\bin"
-setx PATH "$Env:Path;$Env:USERPROFILE\bin"
 ```
 
 </CodeGroup>

--- a/docs/cli/getting-started/overview.mdx
+++ b/docs/cli/getting-started/overview.mdx
@@ -20,8 +20,6 @@ curl -fsSL https://app.factory.ai/cli | sh
 
 ```powershell Windows
 irm https://app.factory.ai/cli/windows | iex
-$env:PATH += ";$Env:USERPROFILE\bin"
-setx PATH "$Env:Path;$Env:USERPROFILE\bin"
 ```
 
 </CodeGroup>
@@ -35,7 +33,6 @@ cd /path/to/your/project
 
 # Start interactive session
 droid
-
 ```
 
 </CodeGroup>

--- a/docs/cli/getting-started/quickstart.mdx
+++ b/docs/cli/getting-started/quickstart.mdx
@@ -22,13 +22,6 @@ curl -fsSL https://app.factory.ai/cli | sh
 
 ```powershell Windows
 irm https://app.factory.ai/cli/windows | iex
-
-# Add to PATH (required)
-# Current session:
-$env:PATH += ";$Env:USERPROFILE\bin"
-# Persist for your user:
-setx PATH "$Env:Path;$Env:USERPROFILE\bin"
-# Then restart your terminal or IDE to pick up the change
 ```
 
 </CodeGroup>
@@ -41,9 +34,7 @@ Then navigate to your project and start the droid CLI.
 cd /path/to/your/project
 
 # Start interactive session
-
 droid
-
 ```
 
 </CodeGroup>


### PR DESCRIPTION
The correct instructions are already shown in the installation script.