### PR TITLE
docs: update personal override path

### DIFF
--- a/docs/cli/configuration/agents-md.mdx
+++ b/docs/cli/configuration/agents-md.mdx
@@ -55,7 +55,7 @@ Agents look for AGENTS.md in this order (first match wins):
 1. `./AGENTS.md` in the **current working directory**
 2. The nearest parent directory up to the repo root
 3. Any `AGENTS.md` in sub-folders the agent is working inside
-4. Personal override: `~/.config/AGENTS.md`
+4. Personal override: `~/.factory/AGENTS.md`
 
 <Note>
   Multiple files can coexist. The closer one to the file being edited takes


### PR DESCRIPTION
## Summary
- update personal override path in AGENTS.md documentation to point to ~/.factory/AGENTS.md

## Testing
- not run (docs-only change)