### PR TITLE
docs: update HuggingFace to reference Inference Providers

### DIFF
--- a/docs/cli/byok/huggingface.mdx
+++ b/docs/cli/byok/huggingface.mdx
@@ -1,9 +1,9 @@
 ---
 title: Hugging Face
-description: Connect to models hosted on Hugging Face's Inference API
+description: Connect to models hosted on Hugging Face's Inference Providers
 ---
 
-Connect to thousands of models hosted on Hugging Face's Inference API and Inference Endpoints.
+Connect to thousands of models hosted on Hugging Face's Inference Providers. Learn more in the [Inference Providers documentation](https://huggingface.co/docs/inference-providers/en/index).
 
 <Note>
   **Model Performance**: Models below 30 billion parameters have shown significantly lower performance on agentic coding tasks. While HuggingFace hosts many smaller models that can be useful for experimentation, they are generally not recommended for production coding work. Consider using models with 30B+ parameters for complex software engineering tasks.
@@ -40,7 +40,7 @@ Configuration examples for `~/.factory/config.json`:
 
 1. Sign up at [huggingface.co](https://huggingface.co)
 2. Get your token from [huggingface.co/settings/tokens](https://huggingface.co/settings/tokens)
-3. Browse models at [huggingface.co/models](https://huggingface.co/models)
+3. Browse models at [huggingface.co/models](https://huggingface.co/models?pipeline_tag=text-generation&inference_provider=all&sort=trending)
 4. Add desired models to your configuration
 
 ## Notes


### PR DESCRIPTION
Updates HuggingFace documentation to use the correct terminology and resources:

- Replace "Inference API" with "Inference Providers" throughout
- Remove mention of "Inference Endpoints"
- Add link to Inference Providers documentation
- Update model browsing link to filtered view for text-generation models