### PR TITLE
docs: simplify Mixed models title

### DIFF
--- a/docs/cli/configuration/mixed-models.mdx
+++ b/docs/cli/configuration/mixed-models.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Specification: Mixed models"
+title: Mixed models
 description: Use a different AI model for Specification Mode planning than your default model for maximum flexibility and optimization.
 ---
 

--- a/docs/cli/configuration/mixed-models.mdx
+++ b/docs/cli/configuration/mixed-models.mdx
@@ -1,5 +1,5 @@
 ---
-title: Mixed models
+title: Mixed Models
 description: Use a different AI model for Specification Mode planning than your default model for maximum flexibility and optimization.
 ---
 


### PR DESCRIPTION
## Changes

This PR simplifies the Mixed models page title by removing the "Specification:" prefix.

### What changed:
- Title changed from "Specification: Mixed models" to "Mixed models"

### Why:
Cleaner, more concise title that's easier to read in navigation and page headers.