### PR TITLE
docs: add default model configuration section to mixed models

### DIFF
--- a/docs/cli/configuration/mixed-models.mdx
+++ b/docs/cli/configuration/mixed-models.mdx
@@ -34,12 +34,20 @@ Different models excel at different tasks. Separating your spec mode model from 
 
 ## How to configure mixed models
 
-### Accessing the Configuration
+### Setting Your Default Model
 
-1. Run `droid` to start the CLI
-2. Enter `/model` to open the model selector
-3. Navigate to **"Configure Spec Mode Model"** (first option in the list)
-4. Press **Enter** to begin configuration
+1. Run `droid`
+2. Use `/model` to open the model selector
+3. Select your default model
+
+Your default model is used for most tasks—regular coding tasks and Specification Mode—unless you configure a separate spec mode model.
+
+### Accessing the Spec Mode Configuration
+
+To change or access the specification configuration:
+
+1. In `/model` (the model selector), navigate to **"Configure Spec Mode Model"**
+2. Press **Enter** to begin configuration
 
 ### Configuration Options
 


### PR DESCRIPTION
This PR improves the mixed models documentation by adding a clear section explaining how to set the default model before configuring a spec mode model.

## Changes

- Added **Setting Your Default Model** section with steps to configure the default model
- Clarifies that the default model is used for regular coding and Specification Mode unless a separate spec mode model is configured
- Renamed **Accessing the Configuration** to **Accessing the Spec Mode Configuration** for clarity
- Streamlined the configuration flow to follow a logical progression: default model first, then optional spec mode override

## Why

Makes it clearer that:
1. You always set a default model first
2. The default model handles all tasks by default
3. Configuring a spec mode model is optional

This helps users understand the foundational concept before diving into the optional spec mode configuration.