### PR TITLE
docs: add v0.22.6 CLI changelog

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -9,12 +9,12 @@ rss: true
 
   ## New features
 
-  * **MCP Revamp**: Complete overhaul of Model Context Protocol implementation
+  * **MCP Revamp**: Complete overhaul of Model Context Protocol implementation ([docs updated](https://docs.factory.ai/cli/configuration/mcp))
 
   ## Bug fixes
 
-  * **Clear OpenAI organization field**: Fixed issue with OpenAI organization field
-  * **Restore Import (I) options in Droids (subagents) menu**: Restored import functionality in the Droids menu
+  * Fixed issue with OpenAI organization field
+  * Restore Import (I) options in Droids (subagents) menu
 </Update>
 
 <Update label="October 29" tags={["Bug fixes"]} rss={{ title: "CLI Updates", description: "Default model behavior improvements" }}>

--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,6 +4,27 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="October 30" tags={["New releases", "Bug fixes"]} rss={{ title: "CLI Updates", description: "MCP Revamp and OpenAI organization field fix" }}>
+  `v0.22.6`
+
+  ## New features
+
+  * **MCP Revamp**: Complete overhaul of Model Context Protocol implementation
+
+  ## Bug fixes
+
+  * **Clear OpenAI organization field**: Fixed issue with OpenAI organization field
+  * **Restore Import (I) options in Droids (subagents) menu**: Restored import functionality in the Droids menu
+</Update>
+
+<Update label="October 29" tags={["Bug fixes"]} rss={{ title: "CLI Updates", description: "Default model behavior improvements" }}>
+  `v0.22.5`
+
+  ## Bug fixes
+
+  * **Default Model Behavior**: Improved default model behavior
+</Update>
+
 <Update label="October 28" tags={["Bug fixes"]} rss={{ title: "CLI Updates", description: "Report previews and help text fixes" }}>
   `v0.22.4`
 


### PR DESCRIPTION
Adds v0.22.6 changelog entry with:
- MCP Revamp: Complete overhaul of Model Context Protocol implementation
- Improved default model behavior