### PR TITLE
docs: document ESC key behavior for clearing input

### DIFF
--- a/docs/cli/getting-started/video-walkthrough.mdx
+++ b/docs/cli/getting-started/video-walkthrough.mdx
@@ -70,6 +70,7 @@ Press `Shift + ?` to open the help menu, which shows:
 |----------|--------|
 | `Enter` | Send message |
 | `\` + `Enter` (or `Shift + Enter`) | New line in message |
+| `Esc` (double tap) | Clear current input |
 | `Shift + ?` | Open help menu |
 | `Shift + Tab` | Cycle through autonomy modes |
 | `/` | Open command menu |

--- a/docs/cli/user-guides/auto-run.mdx
+++ b/docs/cli/user-guides/auto-run.mdx
@@ -85,7 +85,7 @@ Droid executes the entire sequence without pauses while still blocking obviously
 - The CLI detects command substitution or a dangerous pattern.
 - A tool requests something outside the session allowlist and you are in Auto (Low).
 - Droid needs clarity (e.g., missing context, ambiguous edits) and asks for input.
-- You manually interrupt with **Esc**.
+- You manually interrupt with **Esc** (single tap interrupts operations; double tap clears current input).
 
 ## Best practices
 


### PR DESCRIPTION
## Summary
Documents the double-tap ESC behavior for clearing input in the CLI.

## Changes
- Added ESC (double tap) to the Essential Keyboard Shortcuts table in video-walkthrough.mdx
- Updated the auto-run.mdx interruption section to clarify single tap interrupts operations while double tap clears current input

## Context
This addresses customer feedback about Ctrl+C behavior. Users were expecting Ctrl+C to clear input (like in Claude Code), but ESC is the proper key for that. This documentation makes it clearer that:
- ESC (single tap) interrupts operations
- ESC (double tap) clears current input  
- Ctrl+C exits droid

Related Slack thread: https://factory-ai.slack.com/archives/C0845L260FQ/p1761768339404409