### PR TITLE
docs: add bash mode documentation to CLI reference and overview

### DIFF
--- a/docs/cli/configuration/cli-reference.mdx
+++ b/docs/cli/configuration/cli-reference.mdx
@@ -109,7 +109,19 @@ Custom models configured via [BYOK](/cli/configuration/byok) use the format: `cu
 
 See [Choosing Your Model](/cli/user-guides/choosing-your-model) for detailed guidance on which model to use for different tasks.
 
-## Slash commands (interactive mode)
+## Interactive mode features
+
+### Bash mode
+
+Press `!` when the input is empty to toggle bash mode. In bash mode, commands execute directly in your shell without AI interpretation—useful for quick operations like checking `git status` or running `npm test`.
+
+- **Toggle on:** Press `!` (when input is empty)
+- **Execute commands:** Type any shell command and press Enter
+- **Toggle off:** Press `Esc` to return to normal AI chat mode
+
+The prompt changes from `>` to `$` when bash mode is active.
+
+### Slash commands
 
 Available when running `droid` in interactive mode. Type the command at the prompt:
 

--- a/docs/cli/getting-started/overview.mdx
+++ b/docs/cli/getting-started/overview.mdx
@@ -39,6 +39,10 @@ droid
 
 You're now connected to Factory's development agent from your terminal. [Try the 5-minute quickstart →](/cli/getting-started/quickstart)
 
+<Note>
+  **Quick tip:** Press `!` to toggle bash mode and run shell commands directly without AI interpretation. Press `Esc` to return to normal mode. See the [CLI Reference](/cli/configuration/cli-reference#bash-mode) for details.
+</Note>
+
 ## What `droid` brings to your workflow
 
 - **End-to-end feature development**: From planning to implementation to testing - droid handles the complete development lifecycle while keeping you in control through transparent review workflows.


### PR DESCRIPTION
Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
