### PR TITLE
feat: add GitHub Action to post changelogs to Discord

### DIFF
--- a/.github/scripts/parse-changelog.js
+++ b/.github/scripts/parse-changelog.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+function parseChangelog(filePath) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  
+  // Extract the first <Update> block
+  const updateMatch = content.match(/<Update\s+label="([^"]+)"\s+rss=\{\{\s*title:\s*"([^"]+)",\s*description:\s*"([^"]+)"\s*\}\}>([\s\S]*?)<\/Update>/);
+  
+  if (!updateMatch) {
+    console.error('No update block found');
+    process.exit(1);
+  }
+  
+  const [, date, title, description, body] = updateMatch;
+  
+  // Extract version number
+  const versionMatch = body.match(/`([^`]+)`/);
+  const version = versionMatch ? versionMatch[1] : '';
+  
+  // Extract sections
+  const newFeaturesMatch = body.match(/## New features\s*([\s\S]*?)(?=##|\s*<\/Update>|$)/);
+  const bugFixesMatch = body.match(/## Bug fixes\s*([\s\S]*?)(?=##|\s*<\/Update>|$)/);
+  const enhancementsMatch = body.match(/## New features and enhancements\s*([\s\S]*?)(?=##|\s*<\/Update>|$)/);
+  const stabilityMatch = body.match(/## Bug fixes and stability\s*([\s\S]*?)(?=##|\s*<\/Update>|$)/);
+  
+  // Extract bullet points
+  function extractBullets(text) {
+    if (!text) return [];
+    const bullets = [];
+    const lines = text.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('* **')) {
+        // Extract bold title and description
+        const match = trimmed.match(/\*\s+\*\*([^*]+)\*\*:?\s*-?\s*(.*)/);
+        if (match) {
+          bullets.push(`• ${match[1]}${match[2] ? ': ' + match[2] : ''}`);
+        }
+      } else if (trimmed.startsWith('* ')) {
+        bullets.push(`• ${trimmed.substring(2)}`);
+      }
+    }
+    return bullets;
+  }
+  
+  const newFeatures = extractBullets(newFeaturesMatch?.[1] || enhancementsMatch?.[1] || '');
+  const bugFixes = extractBullets(bugFixesMatch?.[1] || stabilityMatch?.[1] || '');
+  
+  // Get changelog URL
+  const fileName = path.basename(filePath, '.mdx');
+  const changelogUrl = `https://docs.factory.ai/changelog/${fileName}`;
+  
+  // Build Discord message
+  let message = `📝 **New Factory Changelog`;
+  if (version) {
+    message += `: ${version}**`;
+  } else {
+    message += `**`;
+  }
+  message += ` (${date})\n\n`;
+  
+  if (newFeatures.length > 0) {
+    message += `**New features**\n`;
+    message += newFeatures.slice(0, 5).join('\n') + '\n\n';
+  }
+  
+  if (bugFixes.length > 0) {
+    message += `**Bug fixes**\n`;
+    message += bugFixes.slice(0, 5).join('\n') + '\n\n';
+  }
+  
+  message += `View full changelog: ${changelogUrl}`;
+  
+  // Trim message to Discord's 2000 character limit
+  if (message.length > 2000) {
+    message = message.substring(0, 1950) + '...\n\n' + `View full changelog: ${changelogUrl}`;
+  }
+  
+  return message;
+}
+
+// Main execution
+if (require.main === module) {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error('Usage: node parse-changelog.js <path-to-changelog.mdx>');
+    process.exit(1);
+  }
+  
+  try {
+    const message = parseChangelog(filePath);
+    console.log(message);
+  } catch (error) {
+    console.error('Error parsing changelog:', error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { parseChangelog };

--- a/.github/workflows/changelog-to-discord.yml
+++ b/.github/workflows/changelog-to-discord.yml
@@ -1,0 +1,68 @@
+name: Post Changelog to Discord
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/changelog/*.mdx'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Get changed changelog files
+        id: changes
+        run: |
+          CHANGED_FILES=$(git diff --name-only HEAD^ HEAD | grep 'docs/changelog/' || echo "")
+          echo "Changed files: $CHANGED_FILES"
+          if [ -n "$CHANGED_FILES" ]; then
+            # Get the first changed file
+            FIRST_FILE=$(echo "$CHANGED_FILES" | head -n 1)
+            echo "file=$FIRST_FILE" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.file != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Parse changelog and post to Discord
+        if: steps.changes.outputs.file != ''
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          CHANGELOG_FILE: ${{ steps.changes.outputs.file }}
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL}" ]; then
+            echo "Discord webhook URL not provided. Skipping notification."
+            exit 0
+          fi
+
+          # Parse the changelog
+          MESSAGE=$(node .github/scripts/parse-changelog.js "$CHANGELOG_FILE")
+          
+          if [ -z "$MESSAGE" ]; then
+            echo "Failed to parse changelog"
+            exit 1
+          fi
+          
+          echo "Posting to Discord:"
+          echo "$MESSAGE"
+          
+          # Create JSON payload
+          PAYLOAD=$(jq -n --arg content "$MESSAGE" '{
+            content: $content
+          }')
+          
+          # Post to Discord
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$DISCORD_WEBHOOK_URL"
+          
+          echo "Successfully posted to Discord!"


### PR DESCRIPTION
Automatically posts changelog updates to Discord when MDX files in docs/changelog/ are updated on main branch. Includes parser script to extract and format changelog content.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
