### PR TITLE
docs/skills section

### DIFF
--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -199,7 +199,7 @@ You can create skills from scratch for Factory, or reuse existing skills you alr
 </AccordionGroup>
 
 
-# Skills cookbook
+## Cookbook
 
 The cookbook provides opinionated skill templates aimed at common enterprise software workflows.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -63,17 +63,30 @@ Each **skill** lives in its own directory under one of these roots:
 - Workspace: `<repo>/.factory/skills/<skill-name>/SKILL.md`
 - Personal: `~/.factory/skills/<skill-name>/SKILL.md`
 
-In large monorepos, keep all skills under the root `.factory/skills/` directory and organize them by folder name, for example:
+In large monorepos, you can either:
 
-```text
-.factory/skills/
-  frontend/
-    SKILL.md
-  payments-service/
-    SKILL.md
-  data-warehouse-querying/
-    SKILL.md
-```
+- Keep a **single, shared** skills folder at the root:
+
+  ```text
+  .factory/skills/
+    frontend/
+      SKILL.md
+    payments-service/
+      SKILL.md
+    data-warehouse-querying/
+      SKILL.md
+  ```
+
+- Or add **per-project** `.factory` folders so skills live alongside each subproject:
+
+  ```text
+  services/payments/.factory/skills/
+    payments-service/
+      SKILL.md
+  apps/frontend/.factory/skills/
+    dashboard-ui/
+      SKILL.md
+  ```
 
 Project skills are the primary way to share and standardize capabilities inside an engineering org; personal skills are ideal for individual workflows or experiments.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -17,6 +17,28 @@ Use skills when you want the agent to:
 - **Be consistent across sessions** – run the same playbook every time you ask for "frontend change" or "new service integration".
 - **Scale safely** – let more people use automation without needing to be experts in the codebase or infrastructure.
 
+<Steps>
+  <Step title="Create a skill folder">
+    Under your repo, create a directory in `.factory/skills/`, for example
+    `.factory/skills/frontend-ui-integration/`.
+  </Step>
+  <Step title="Add SKILL.md or skill.mdx">
+    Inside the folder, create `SKILL.md` or `skill.mdx` with YAML frontmatter
+    (`name`, `description`) and markdown instructions that define the
+    capability, inputs, and success criteria.
+  </Step>
+  <Step title="Add supporting files (optional)">
+    Co-locate any types, schemas, or checklists the Droid should use when the
+    skill is active (for example `types.ts`, `schemas/`, or
+    `rollout-checklist.md`).
+  </Step>
+  <Step title="Restart and use">
+    Restart `droid` or your integration so it rescans skills, then describe
+    your task normally. The Droid will automatically invoke matching skills
+    when they apply.
+  </Step>
+</Steps>
+
 ## What is a skill?
 
 At the file-system level, a skill is a **directory** (e.g. `.factory/skills/frontend-ui-integration/`) that contains:
@@ -126,6 +148,41 @@ See the following examples:
 - `cli/configuration/skills/service-integration` – Skill for extending an existing service and wiring it into a complex monorepo
 - `cli/configuration/skills/data-querying` – Skill for safely querying internal data services and producing shareable artifacts
 - `cli/configuration/skills/internal-tools` – Skill for building or extending internal tools (admin panels, support consoles, engineering utilities)
+
+<CardGroup cols={2}>
+  <Card
+    title="Frontend UI integration"
+    href="/cli/configuration/skills/frontend-ui-integration"
+    icon="layout"
+  >
+    Implement typed, tested frontend flows against existing backend APIs using
+    your design system, routing, and testing conventions.
+  </Card>
+  <Card
+    title="Service integration in complex codebases"
+    href="/cli/configuration/skills/service-integration"
+    icon="layers"
+  >
+    Extend or wire backend services in a shared monorepo while respecting
+    ownership boundaries, observability, and rollout requirements.
+  </Card>
+  <Card
+    title="Internal data querying"
+    href="/cli/configuration/skills/data-querying"
+    icon="database"
+  >
+    Safely query internal analytics and data services, producing reproducible
+    queries and shareable analysis artifacts.
+  </Card>
+  <Card
+    title="Internal tools"
+    href="/cli/configuration/skills/internal-tools"
+    icon="settings"
+  >
+    Build or extend internal-facing tools (admin panels, consoles, utilities)
+    with strong RBAC, audit logging, and operational safeguards.
+  </Card>
+</CardGroup>
 
 In practice, each skill folder can also contain **supporting utilities** the agent may use alongside the core prompt template – for example:
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -1,0 +1,89 @@
+---
+title: Skills
+description: Define reusable, composable capabilities for Droids to reliably execute complex software engineering workflows.
+---
+
+# 1 · Skills overview
+
+Skills let you package up **capabilities + context + guardrails** into reusable units that Droids can invoke as part of a larger plan.
+
+- A skill describes **what problem it solves**, **what inputs it expects**, and **what success looks like**.
+- Each skill includes **clear instructions, constraints, and examples** tuned to a narrow domain.
+- Skills are **tool- and model-agnostic** – they work across CLI Droids, custom droids, and headless Droid Exec.
+
+In an enterprise software org, skills are the building blocks you use to:
+
+- Standardize how Droids do **frontend implementation, API integrations, data querying, and internal tooling**
+- Encode **team conventions, safety rules, and SLAs** once, then reuse everywhere
+- Make complex workflows **discoverable, composable, and auditable**
+
+You can create skills from scratch for Factory, or reuse existing skills you already invested in for other agents by importing them and wiring them into your droid configuration.
+
+
+# 2 · Best practices
+
+## 2.1 Keep each skill narrow and outcome-focused
+
+- Design skills around a **single responsibility** (e.g., "implement a typed React UI for an existing endpoint"), not "build the whole feature".
+- Define a **crisp success criterion**: what artifacts should exist when the skill finishes (files changed, tests added, docs updated, approvals gathered).
+- Prefer several small skills composed by a Droid over one giant "do everything" skill.
+
+## 2.2 Make inputs explicit and structured
+
+- Document required inputs: repo path, services involved, APIs, schemas, feature flag names, etc.
+- Use **structured fields** (e.g., JSON snippets, bullet lists, tables) instead of long prose when describing APIs or data models.
+- For security-sensitive workflows, include explicit **"never do"** constraints and escalation conditions.
+
+## 2.3 Encode team conventions and guardrails
+
+- Bake in your **testing, observability, and rollout requirements** so the skill always follows them.
+- Reference your existing **AGENTS.md**, runbooks, and design docs instead of inlining everything.
+- Require **proof artifacts**: tests, screenshots, log queries, or links to dashboards depending on the domain.
+
+## 2.4 Design for enterprise constraints
+
+- Assume **large monorepos, multiple services, and layered approvals**.
+- Be explicit about **which directories** Droids may touch, which languages/frameworks are in-bounds, and which are not.
+- Include guidance for **cross-team dependencies** – when to stub, when to coordinate with another team, and when to stop and ask.
+
+## 2.5 Make skills composable
+
+- Prefer **idempotent** skills: safe to rerun on the same branch/PR.
+- Design skills to produce **machine-parseable output** where possible (e.g., a short summary block that other skills can consume).
+- Keep skills **stateless** beyond the current branch: no hidden assumptions about prior runs.
+
+## 2.6 Operate with verification and safety
+
+- Always include a **"Verification"** section that lists commands Droids must run before completing the skill.
+- Call out **fallbacks** when verification fails (rollback steps, feature flags, or canary paths).
+- For production-adjacent skills, require that Droids **open PRs but never merge** without human review.
+
+
+# 3 · Skills cookbook
+
+The cookbook provides opinionated skill templates aimed at common enterprise software workflows.
+
+We focus on four families of skills:
+
+1. **Frontend implementation skills** – building UI surfaces that integrate with existing APIs
+2. **Integration skills for complex codebases** – extending or wiring together services in large monorepos
+3. **Internal data querying skills** – safe, auditable access to internal analytics or data services
+4. **Internal tools skills** – building small but robust internal apps that improve developer and operator workflows
+
+See the following examples:
+
+- `cli/configuration/skills/frontend-ui-integration` – Frontend skill for implementing a typed UI workflow against an existing backend API
+- `cli/configuration/skills/service-integration` – Skill for extending an existing service and wiring it into a complex monorepo
+- `cli/configuration/skills/data-querying` – Skill for safely querying internal data services and producing shareable artifacts
+- `cli/configuration/skills/internal-tools` – Skill for building or extending internal tools (admin panels, support consoles, engineering utilities)
+
+In practice, each skill folder can also contain **supporting utilities** the agent may use alongside the core prompt template – for example:
+
+- `SKILL.md` or `skill.mdx` – the main skill specification
+- `types.ts` or `types.py` – shared types for APIs and events the skill cares about
+- `schemas/` – JSON/YAML schemas or OpenAPI snippets referenced by the skill
+- `checklists.md` – reusable validation or rollout checklists
+
+These co-located files give the agent a predictable, structured bundle of context to work from when the skill is invoked.
+
+Use these as starting points and adapt the inputs, constraints, and verification steps to match your stack and governance requirements.

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -5,7 +5,7 @@ description: Define reusable, composable capabilities for Droids to reliably exe
 
 # 1 · Skills overview
 
-Skills are how you turn "a very smart, very fast engineer" into **a reliable member of your team**.
+Skills are how you turn "a very smart, very fast engineer" into **a teammate who follows your playbook every time**.
 
 Instead of re-explaining the same workflows in every prompt, you capture them once as a skill: a small, reusable bundle of **capability + context + guardrails** that Droids can invoke as part of a larger plan.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -255,10 +255,10 @@ See the following examples:
 In practice, each skill folder can also contain **supporting utilities** the agent may use alongside the core prompt template – for example:
 
 - `SKILL.md` or `skill.mdx` – the main skill specification
-- `types.ts` or `types.py` – shared types for APIs and events the skill cares about
-- `schemas/` – JSON/YAML schemas or OpenAPI snippets referenced by the skill
+- `references.md` – links and pointers to types, APIs, and modules that already exist in your codebase
+- `schemas/` – JSON/YAML schemas or OpenAPI snippets referenced by the skill (not the source-of-truth service code)
 - `checklists.md` – reusable validation or rollout checklists
 
-These co-located files give the agent a predictable, structured bundle of context to work from when the skill is invoked.
+These co-located files give the agent a predictable, structured bundle of context to work from when the skill is invoked, without duplicating or relocating production code.
 
 Use these as starting points and adapt the inputs, constraints, and verification steps to match your stack and governance requirements.

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -5,7 +5,7 @@ description: Define reusable, composable capabilities for Droids to reliably exe
 
 Skills let you capture the way your engineering org wants work to be done and package it as reusable capabilities that Droids can invoke on demand.
 
-# 1 · Skills overview
+# Skills overview
 
 Skills are how you turn a general-purpose Droid into **a specialist teammate that follows your engineering playbook every time**.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -3,6 +3,8 @@ title: Skills
 description: Define reusable, composable capabilities for Droids to reliably execute complex software engineering workflows.
 ---
 
+Skills let you capture the way your engineering org wants work to be done and package it as reusable capabilities that Droids can invoke on demand.
+
 # 1 · Skills overview
 
 Skills are how you turn a general-purpose Droid into **a specialist teammate that follows your engineering playbook every time**.
@@ -15,7 +17,7 @@ Use skills when you want the agent to:
 - **Be consistent across sessions** – run the same playbook every time you ask for "frontend change" or "new service integration".
 - **Scale safely** – let more people use automation without needing to be experts in the codebase or infrastructure.
 
-## 1.1 What is a skill?
+## 1.1 · What is a skill?
 
 At the file-system level, a skill is a **directory** (e.g. `.factory/skills/frontend-ui-integration/`) that contains:
 
@@ -30,7 +32,14 @@ Conceptually, each skill defines:
 
 Skills are **model-invoked**: the Droid decides when to use them based on the skill description and the current task, rather than you typing a specific command.
 
-## 1.2 How skills differ from other configuration
+| Scope         | Location                        | Purpose                                                                 |
+| ------------- | ------------------------------- | ----------------------------------------------------------------------- |
+| **Workspace** | `<repo>/.factory/skills/`       | Project skills shared with teammates; checked into git.                |
+| **Personal**  | `~/.factory/skills/` (planned)  | Private skills that follow you across projects (not yet available).    |
+
+Project skills are the primary way to share and standardize capabilities inside an engineering org.
+
+## 1.2 · How skills differ from other configuration
 
 Skills sit alongside other ways of shaping Droid behavior:
 
@@ -50,7 +59,7 @@ In practice you might:
 - Use a custom droid to define which tools/models are allowed in CI.
 - Use a skill to encode "how to safely roll out a canary deployment" using that API and droid configuration.
 
-## 1.3 Why skills matter in enterprise codebases
+## 1.3 · Why skills matter in enterprise codebases
 
 Skills are especially valuable in enterprise environments where you need to:
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -30,40 +30,7 @@ Skills are **model-invoked**: the Droid decides when to use them based on the sk
 
 ## Skill file format
 
-Skills are defined in Markdown with YAML frontmatter.
-
-```md
----
-name: frontend-ui-integration
-description: Implement typed, tested frontend flows against existing backend APIs.
----
-
-# Frontend UI integration
-
-## Instructions
-
-Implement or extend a user-facing workflow in our primary web application.
-
-- Use existing design system components
-- Wire API calls through the existing data layer
-- Handle loading, empty, error, and success states
-
-## Inputs
-
-- Feature description (user story)
-- Target route/component path
-- Backend APIs and types
-
-## Verification
-
-- `pnpm lint`
-- `pnpm test -- --runInBand --watch=false`
-- `pnpm typecheck`
-```
-
-You can also include additional frontmatter fields such as `allowed-tools` in future iterations; for now, `name` and `description` are the key fields that help Droids discover and use your skill.
-
-For very small, focused capabilities, a **micro skill** can be just a short SKILL.md:
+Skills are defined in Markdown with YAML frontmatter. A small, focused skill can be just a short `SKILL.md`:
 
 ```md
 ---
@@ -79,6 +46,8 @@ description: Summarize the staged git diff in 3–5 bullets. Use when the user a
 2. Summarize the changes in 3–5 bullets, focusing on user-visible behavior.
 3. Call out any migrations, risky areas, or tests that should be run.
 ```
+
+You can also include additional frontmatter fields such as `allowed-tools` in future iterations; for now, `name` and `description` are the key fields that help Droids discover and use your skill.
 
 ## Where skills live
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -17,7 +17,7 @@ Use skills when you want the agent to:
 - **Be consistent across sessions** – run the same playbook every time you ask for "frontend change" or "new service integration".
 - **Scale safely** – let more people use automation without needing to be experts in the codebase or infrastructure.
 
-## 1.1 · What is a skill?
+## What is a skill?
 
 At the file-system level, a skill is a **directory** (e.g. `.factory/skills/frontend-ui-integration/`) that contains:
 
@@ -39,7 +39,7 @@ Skills are **model-invoked**: the Droid decides when to use them based on the sk
 
 Project skills are the primary way to share and standardize capabilities inside an engineering org.
 
-## 1.2 · How skills differ from other configuration
+## How skills differ from other configuration
 
 Skills sit alongside other ways of shaping Droid behavior:
 
@@ -59,7 +59,7 @@ In practice you might:
 - Use a custom droid to define which tools/models are allowed in CI.
 - Use a skill to encode "how to safely roll out a canary deployment" using that API and droid configuration.
 
-## 1.3 · Why skills matter in enterprise codebases
+## Why skills matter in enterprise codebases
 
 Skills are especially valuable in enterprise environments where you need to:
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -3,8 +3,6 @@ title: Skills
 description: Capture the way your engineering org wants work done and package it as reusable capabilities Droids can invoke on demand.
 ---
 
-# Skills overview
-
 Skills are how you turn a general-purpose Droid into **a specialist teammate that follows your engineering playbook every time**.
 
 Instead of re-explaining the same workflows in every prompt, you capture them once as a skill: a reusable bundle of **capability + context + guardrails** that Droids can invoke as part of a larger plan.

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -5,17 +5,27 @@ description: Define reusable, composable capabilities for Droids to reliably exe
 
 # 1 · Skills overview
 
-Skills let you package up **capabilities + context + guardrails** into reusable units that Droids can invoke as part of a larger plan.
+Skills are how you turn "a very smart, very fast engineer" into **a reliable member of your team**.
 
-- A skill describes **what problem it solves**, **what inputs it expects**, and **what success looks like**.
-- Each skill includes **clear instructions, constraints, and examples** tuned to a narrow domain.
-- Skills are **tool- and model-agnostic** – they work across CLI Droids, custom droids, and headless Droid Exec.
+Instead of re-explaining the same workflows in every prompt, you capture them once as a skill: a small, reusable bundle of **capability + context + guardrails** that Droids can invoke as part of a larger plan.
 
-In an enterprise software org, skills are the building blocks you use to:
+Use skills when you want the agent to:
 
-- Standardize how Droids do **frontend implementation, API integrations, data querying, and internal tooling**
-- Encode **team conventions, safety rules, and SLAs** once, then reuse everywhere
-- Make complex workflows **discoverable, composable, and auditable**
+- **Behave like your team** – follow your architecture, testing, security, and rollout norms by default.
+- **Be consistent across sessions** – run the same playbook every time you ask for "frontend change" or "new service integration".
+- **Scale safely** – let more people use automation without needing to be experts in the codebase or infrastructure.
+
+Concretely, a skill defines:
+
+- **What problem it solves** – e.g., "add a typed React surface for an existing API" or "wire a service into our event bus".
+- **What inputs it expects** – feature description, services, APIs, time ranges, risk level, etc.
+- **What success looks like** – required artifacts, tests, verification commands, and safety checks.
+
+Skills are **tool- and model-agnostic** – they work across CLI Droids, custom droids, and headless Droid Exec – and are especially valuable in enterprise environments where:
+
+- You need to standardize how Droids do **frontend implementation, service integrations, data querying, and internal tools**.
+- You want to encode **team conventions, safety rules, and SLAs** once, then reuse them across projects.
+- You care that workflows are **discoverable, composable, and auditable**, not just "it worked once in a chat".
 
 You can create skills from scratch for Factory, or reuse existing skills you already invested in for other agents by importing them and wiring them into your droid configuration.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -1,15 +1,13 @@
 ---
 title: Skills
-description: Define reusable, composable capabilities for Droids to reliably execute complex software engineering workflows.
+description: Capture the way your engineering org wants work done and package it as reusable capabilities Droids can invoke on demand.
 ---
-
-Skills let you capture the way your engineering org wants work to be done and package it as reusable capabilities that Droids can invoke on demand.
 
 # Skills overview
 
 Skills are how you turn a general-purpose Droid into **a specialist teammate that follows your engineering playbook every time**.
 
-Instead of re-explaining the same workflows in every prompt, you capture them once as a skill: a small, reusable bundle of **capability + context + guardrails** that Droids can invoke as part of a larger plan.
+Instead of re-explaining the same workflows in every prompt, you capture them once as a skill: a reusable bundle of **capability + context + guardrails** that Droids can invoke as part of a larger plan.
 
 Use skills when you want the agent to:
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -212,10 +212,10 @@ We focus on four families of skills:
 
 See the following examples:
 
-- `cli/configuration/skills/frontend-ui-integration` – Frontend skill for implementing a typed UI workflow against an existing backend API
-- `cli/configuration/skills/service-integration` – Skill for extending an existing service and wiring it into a complex monorepo
-- `cli/configuration/skills/data-querying` – Skill for safely querying internal data services and producing shareable artifacts
-- `cli/configuration/skills/internal-tools` – Skill for building or extending internal tools (admin panels, support consoles, engineering utilities)
+- [Frontend UI integration](/cli/configuration/skills/frontend-ui-integration) – Frontend skill for implementing a typed UI workflow against an existing backend API
+- [Service integration](/cli/configuration/skills/service-integration) – Skill for extending an existing service and wiring it into a complex monorepo
+- [Internal data querying](/cli/configuration/skills/data-querying) – Skill for safely querying internal data services and producing shareable artifacts
+- [Internal tools](/cli/configuration/skills/internal-tools) – Skill for building or extending internal tools (admin panels, support consoles, engineering utilities)
 
 <CardGroup cols={2}>
   <Card

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -5,7 +5,7 @@ description: Define reusable, composable capabilities for Droids to reliably exe
 
 # 1 · Skills overview
 
-Skills are how you turn "a very smart, very fast engineer" into **a teammate who follows your playbook every time**.
+Skills are how you turn a general-purpose Droid into **a specialist teammate that follows your engineering playbook every time**.
 
 Instead of re-explaining the same workflows in every prompt, you capture them once as a skill: a small, reusable bundle of **capability + context + guardrails** that Droids can invoke as part of a larger plan.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -15,17 +15,48 @@ Use skills when you want the agent to:
 - **Be consistent across sessions** – run the same playbook every time you ask for "frontend change" or "new service integration".
 - **Scale safely** – let more people use automation without needing to be experts in the codebase or infrastructure.
 
-Concretely, a skill defines:
+## 1.1 What is a skill?
+
+At the file-system level, a skill is a **directory** (e.g. `.factory/skills/frontend-ui-integration/`) that contains:
+
+- A primary spec like `SKILL.md` or `skill.mdx` with frontmatter + markdown instructions
+- Optional supporting files (types, schemas, checklists) that the Droid can read when the skill is active
+
+Conceptually, each skill defines:
 
 - **What problem it solves** – e.g., "add a typed React surface for an existing API" or "wire a service into our event bus".
 - **What inputs it expects** – feature description, services, APIs, time ranges, risk level, etc.
 - **What success looks like** – required artifacts, tests, verification commands, and safety checks.
 
-Skills are **tool- and model-agnostic** – they work across CLI Droids, custom droids, and headless Droid Exec – and are especially valuable in enterprise environments where:
+Skills are **model-invoked**: the Droid decides when to use them based on the skill description and the current task, rather than you typing a specific command.
 
-- You need to standardize how Droids do **frontend implementation, service integrations, data querying, and internal tools**.
-- You want to encode **team conventions, safety rules, and SLAs** once, then reuse them across projects.
-- You care that workflows are **discoverable, composable, and auditable**, not just "it worked once in a chat".
+## 1.2 How skills differ from other configuration
+
+Skills sit alongside other ways of shaping Droid behavior:
+
+- **Custom droids** – define *which* model and tools to use and at what autonomy level; they are full agent configurations.
+- **Custom slash commands** – are **user-invoked** macros you call explicitly (e.g., `/review-pr`); they don’t automatically trigger based on the task.
+- **MCP servers** – expose external systems (APIs, databases, SaaS tools) as tools; they are about *connecting* resources, not encoding your workflow.
+
+Skills are different because they:
+
+- Package **how work should be done** (your engineering playbook) as reusable capabilities.
+- Are **discoverable and composable** – the Droid can chain multiple skills inside a plan.
+- Can sit on top of tools, custom droids, and MCP servers to orchestrate them safely.
+
+In practice you might:
+
+- Use MCP to expose your internal deployment API.
+- Use a custom droid to define which tools/models are allowed in CI.
+- Use a skill to encode "how to safely roll out a canary deployment" using that API and droid configuration.
+
+## 1.3 Why skills matter in enterprise codebases
+
+Skills are especially valuable in enterprise environments where you need to:
+
+- Standardize how Droids do **frontend implementation, service integrations, data querying, and internal tools**.
+- Encode **team conventions, safety rules, and SLAs** once, then reuse them across projects.
+- Make automation **discoverable, auditable, and shareable** via git, not just "whatever happened in one chat".
 
 You can create skills from scratch for Factory, or reuse existing skills you already invested in for other agents by importing them and wiring them into your droid configuration.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -92,46 +92,46 @@ Skills are especially valuable in enterprise environments where you need to:
 You can create skills from scratch for Factory, or reuse existing skills you already invested in for other agents by importing them and wiring them into your droid configuration.
 
 
-# 2 · Best practices
+# Best practices
 
-## 2.1 Keep each skill narrow and outcome-focused
+## Keep each skill narrow and outcome-focused
 
 - Design skills around a **single responsibility** (e.g., "implement a typed React UI for an existing endpoint"), not "build the whole feature".
 - Define a **crisp success criterion**: what artifacts should exist when the skill finishes (files changed, tests added, docs updated, approvals gathered).
 - Prefer several small skills composed by a Droid over one giant "do everything" skill.
 
-## 2.2 Make inputs explicit and structured
+## Make inputs explicit and structured
 
 - Document required inputs: repo path, services involved, APIs, schemas, feature flag names, etc.
 - Use **structured fields** (e.g., JSON snippets, bullet lists, tables) instead of long prose when describing APIs or data models.
 - For security-sensitive workflows, include explicit **"never do"** constraints and escalation conditions.
 
-## 2.3 Encode team conventions and guardrails
+## Encode team conventions and guardrails
 
 - Bake in your **testing, observability, and rollout requirements** so the skill always follows them.
 - Reference your existing **AGENTS.md**, runbooks, and design docs instead of inlining everything.
 - Require **proof artifacts**: tests, screenshots, log queries, or links to dashboards depending on the domain.
 
-## 2.4 Design for enterprise constraints
+## Design for enterprise constraints
 
 - Assume **large monorepos, multiple services, and layered approvals**.
 - Be explicit about **which directories** Droids may touch, which languages/frameworks are in-bounds, and which are not.
 - Include guidance for **cross-team dependencies** – when to stub, when to coordinate with another team, and when to stop and ask.
 
-## 2.5 Make skills composable
+## Make skills composable
 
 - Prefer **idempotent** skills: safe to rerun on the same branch/PR.
 - Design skills to produce **machine-parseable output** where possible (e.g., a short summary block that other skills can consume).
 - Keep skills **stateless** beyond the current branch: no hidden assumptions about prior runs.
 
-## 2.6 Operate with verification and safety
+## Operate with verification and safety
 
 - Always include a **"Verification"** section that lists commands Droids must run before completing the skill.
 - Call out **fallbacks** when verification fails (rollback steps, feature flags, or canary paths).
 - For production-adjacent skills, require that Droids **open PRs but never merge** without human review.
 
 
-# 3 · Skills cookbook
+# Skills cookbook
 
 The cookbook provides opinionated skill templates aimed at common enterprise software workflows.
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -17,6 +17,103 @@ Use skills when you want the agent to:
 - **Be consistent across sessions** – run the same playbook every time you ask for "frontend change" or "new service integration".
 - **Scale safely** – let more people use automation without needing to be experts in the codebase or infrastructure.
 
+## What is a skill?
+
+At the file-system level, a skill is a **directory** (e.g. `.factory/skills/frontend-ui-integration/`) that contains:
+
+- A primary spec like `SKILL.md` or `skill.mdx` with frontmatter + markdown instructions
+- Optional supporting files (types, schemas, checklists) that the Droid can read when the skill is active
+
+Conceptually, each skill defines:
+
+- **What problem it solves** – e.g., "add a typed React surface for an existing API" or "wire a service into our event bus".
+- **What inputs it expects** – feature description, services, APIs, time ranges, risk level, etc.
+- **What success looks like** – required artifacts, tests, verification commands, and safety checks.
+
+Skills are **model-invoked**: the Droid decides when to use them based on the skill description and the current task, rather than you typing a specific command.
+
+## Skill file format
+
+Skills are defined in Markdown with YAML frontmatter.
+
+```md
+---
+name: frontend-ui-integration
+description: Implement typed, tested frontend flows against existing backend APIs.
+---
+
+# Frontend UI integration
+
+## Instructions
+
+Implement or extend a user-facing workflow in our primary web application.
+
+- Use existing design system components
+- Wire API calls through the existing data layer
+- Handle loading, empty, error, and success states
+
+## Inputs
+
+- Feature description (user story)
+- Target route/component path
+- Backend APIs and types
+
+## Verification
+
+- `pnpm lint`
+- `pnpm test -- --runInBand --watch=false`
+- `pnpm typecheck`
+```
+
+You can also include additional frontmatter fields such as `allowed-tools` in future iterations; for now, `name` and `description` are the key fields that help Droids discover and use your skill.
+
+For very small, focused capabilities, a **micro skill** can be just a short SKILL.md:
+
+```md
+---
+name: summarize-diff
+description: Summarize the staged git diff in 3–5 bullets. Use when the user asks for a summary of pending changes.
+---
+
+# Summarize Diff
+
+## Instructions
+
+1. Run `git diff --staged`.
+2. Summarize the changes in 3–5 bullets, focusing on user-visible behavior.
+3. Call out any migrations, risky areas, or tests that should be run.
+```
+
+## Where skills live
+
+Skills are discovered from a small set of well-known locations:
+
+| Scope         | Location                            | Purpose                                                                 |
+| ------------- | ----------------------------------- | ----------------------------------------------------------------------- |
+| **Workspace** | `<repo>/.factory/skills/`           | Project skills shared with teammates; checked into git.                 |
+| **Personal**  | `~/.factory/skills/`                | Private skills that follow you across projects on your machine.         |
+
+Each **skill** lives in its own directory under one of these roots:
+
+- Workspace: `<repo>/.factory/skills/<skill-name>/SKILL.md`
+- Personal: `~/.factory/skills/<skill-name>/SKILL.md`
+
+In large monorepos, keep all skills under the root `.factory/skills/` directory and organize them by folder name, for example:
+
+```text
+.factory/skills/
+  frontend/
+    SKILL.md
+  payments-service/
+    SKILL.md
+  data-warehouse-querying/
+    SKILL.md
+```
+
+Project skills are the primary way to share and standardize capabilities inside an engineering org; personal skills are ideal for individual workflows or experiments.
+
+## Quickstart
+
 <Steps>
   <Step title="Create a skill folder">
     Under your repo, create a directory in `.factory/skills/`, for example
@@ -38,28 +135,6 @@ Use skills when you want the agent to:
     when they apply.
   </Step>
 </Steps>
-
-## What is a skill?
-
-At the file-system level, a skill is a **directory** (e.g. `.factory/skills/frontend-ui-integration/`) that contains:
-
-- A primary spec like `SKILL.md` or `skill.mdx` with frontmatter + markdown instructions
-- Optional supporting files (types, schemas, checklists) that the Droid can read when the skill is active
-
-Conceptually, each skill defines:
-
-- **What problem it solves** – e.g., "add a typed React surface for an existing API" or "wire a service into our event bus".
-- **What inputs it expects** – feature description, services, APIs, time ranges, risk level, etc.
-- **What success looks like** – required artifacts, tests, verification commands, and safety checks.
-
-Skills are **model-invoked**: the Droid decides when to use them based on the skill description and the current task, rather than you typing a specific command.
-
-| Scope         | Location                        | Purpose                                                                 |
-| ------------- | ------------------------------- | ----------------------------------------------------------------------- |
-| **Workspace** | `<repo>/.factory/skills/`       | Project skills shared with teammates; checked into git.                |
-| **Personal**  | `~/.factory/skills/` (planned)  | Private skills that follow you across projects (not yet available).    |
-
-Project skills are the primary way to share and standardize capabilities inside an engineering org.
 
 ## How skills differ from other configuration
 
@@ -94,41 +169,56 @@ You can create skills from scratch for Factory, or reuse existing skills you alr
 
 # Best practices
 
-## Keep each skill narrow and outcome-focused
+<AccordionGroup>
+  <Accordion title="Keep each skill narrow and outcome-focused">
+    Design skills around a **single responsibility** (e.g., "implement a typed
+    React UI for an existing endpoint"), not "build the whole feature".
+    Define a **crisp success criterion**: what artifacts should exist when the
+    skill finishes (files changed, tests added, docs updated, approvals
+    gathered). Prefer several small skills composed by a Droid over one giant
+    "do everything" skill.
+  </Accordion>
 
-- Design skills around a **single responsibility** (e.g., "implement a typed React UI for an existing endpoint"), not "build the whole feature".
-- Define a **crisp success criterion**: what artifacts should exist when the skill finishes (files changed, tests added, docs updated, approvals gathered).
-- Prefer several small skills composed by a Droid over one giant "do everything" skill.
+  <Accordion title="Make inputs explicit and structured">
+    Document required inputs: repo path, services involved, APIs, schemas,
+    feature flag names, etc. Use **structured fields** (JSON snippets, bullet
+    lists, tables) instead of long prose when describing APIs or data models.
+    For security-sensitive workflows, include explicit **"never do"**
+    constraints and escalation conditions.
+  </Accordion>
 
-## Make inputs explicit and structured
+  <Accordion title="Encode team conventions and guardrails">
+    Bake in your **testing, observability, and rollout requirements** so the
+    skill always follows them. Reference your existing **AGENTS.md**, runbooks,
+    and design docs instead of inlining everything. Require **proof
+    artifacts**: tests, screenshots, log queries, or links to dashboards
+    depending on the domain.
+  </Accordion>
 
-- Document required inputs: repo path, services involved, APIs, schemas, feature flag names, etc.
-- Use **structured fields** (e.g., JSON snippets, bullet lists, tables) instead of long prose when describing APIs or data models.
-- For security-sensitive workflows, include explicit **"never do"** constraints and escalation conditions.
+  <Accordion title="Design for enterprise constraints">
+    Assume **large monorepos, multiple services, and layered approvals**. Be
+    explicit about **which directories** Droids may touch, which
+    languages/frameworks are in-bounds, and which are not. Include guidance for
+    **cross-team dependencies** – when to stub, when to coordinate with
+    another team, and when to stop and ask.
+  </Accordion>
 
-## Encode team conventions and guardrails
+  <Accordion title="Make skills composable">
+    Prefer **idempotent** skills: safe to rerun on the same branch/PR. Design
+    skills to produce **machine-parseable output** where possible (for example,
+    a short summary block that other skills can consume). Keep skills
+    **stateless** beyond the current branch: no hidden assumptions about prior
+    runs.
+  </Accordion>
 
-- Bake in your **testing, observability, and rollout requirements** so the skill always follows them.
-- Reference your existing **AGENTS.md**, runbooks, and design docs instead of inlining everything.
-- Require **proof artifacts**: tests, screenshots, log queries, or links to dashboards depending on the domain.
-
-## Design for enterprise constraints
-
-- Assume **large monorepos, multiple services, and layered approvals**.
-- Be explicit about **which directories** Droids may touch, which languages/frameworks are in-bounds, and which are not.
-- Include guidance for **cross-team dependencies** – when to stub, when to coordinate with another team, and when to stop and ask.
-
-## Make skills composable
-
-- Prefer **idempotent** skills: safe to rerun on the same branch/PR.
-- Design skills to produce **machine-parseable output** where possible (e.g., a short summary block that other skills can consume).
-- Keep skills **stateless** beyond the current branch: no hidden assumptions about prior runs.
-
-## Operate with verification and safety
-
-- Always include a **"Verification"** section that lists commands Droids must run before completing the skill.
-- Call out **fallbacks** when verification fails (rollback steps, feature flags, or canary paths).
-- For production-adjacent skills, require that Droids **open PRs but never merge** without human review.
+  <Accordion title="Operate with verification and safety">
+    Always include a **"Verification"** section that lists commands Droids
+    must run before completing the skill. Call out **fallbacks** when
+    verification fails (rollback steps, feature flags, or canary paths). For
+    production-adjacent skills, require that Droids **open PRs but never
+    merge** without human review.
+  </Accordion>
+</AccordionGroup>
 
 
 # Skills cookbook

--- a/docs/cli/configuration/skills/data-querying.mdx
+++ b/docs/cli/configuration/skills/data-querying.mdx
@@ -1,0 +1,88 @@
+---
+title: Internal data querying skill
+description: A reusable skill for safely querying internal analytics and data services and producing shareable, reproducible artifacts.
+---
+
+# Internal data querying skill
+
+Use this skill when Droids need to answer questions using **internal data sources** – analytics warehouses, reporting databases, or internal data APIs – in a way that is safe, auditable, and reproducible.
+
+The skill directory can also host **data utilities** that the agent can leverage, such as:
+
+- `metrics.md` – canonical metric and dimension definitions
+- `examples.sql` – sample queries against trusted models or marts
+- `data-governance.md` – data-classification guidance and safe-sharing checklists
+
+```md
+# Skill: Internal data querying
+
+## Purpose
+
+Query internal data services to answer well-scoped questions, producing results and artifacts that are safe to share and easy to re-run.
+
+## When to use this skill
+
+- A stakeholder asks for **metrics, trends, or slices** that rely on internal data.
+- The answers can be derived from existing **warehouses, marts, or reporting APIs**.
+- The request needs a **reproducible query** and not an ad-hoc manual export.
+
+## Inputs
+
+- **Business question**: one or two sentences describing what we want to know.
+- **Time range and filters**: date boundaries, customer segments, environments, etc.
+- **Source systems**: names of warehouses, schemas, or APIs to use.
+- **Data sensitivity notes**: whether PII, financial data, or regulated data is involved.
+
+## Out of scope
+
+- Direct queries against production OLTP databases unless explicitly allowed.
+- Creating new pipelines or ingestion jobs.
+- Sharing raw PII or secrets outside approved destinations.
+
+## Conventions
+
+- Use the **preferred query layer** (e.g., dbt models, semantic layer, analytics API) instead of raw tables when available.
+- Follow established **naming and folder conventions** for saved queries or analysis notebooks.
+- Respect internal **data classification and access control** policies.
+
+## Required behavior
+
+1. Translate the business question into a precise query spec (metrics, dimensions, filters).
+2. Choose appropriate sources and explain tradeoffs if multiple options exist.
+3. Write queries that are performant and cost-conscious for the target system.
+4. Produce both **results** and a **re-runnable query artifact** (SQL, API call, notebook, or dashboard link).
+
+## Required artifacts
+
+- Query text (SQL, DSL, or API request) checked into the appropriate repo or folder.
+- A short **analysis summary** capturing methodology, assumptions, and caveats.
+- Links to any **dashboards, notebooks, or reports** created.
+
+## Implementation checklist
+
+1. Clarify the business question, time range, and filters.
+2. Identify the best data source(s) based on freshness, completeness, and governance.
+3. Draft the query, validate it on a limited time window or sample.
+4. Check for joins, filters, and aggregations that could distort the answer; fix as needed.
+5. Save the query in the approved location with a descriptive name.
+6. Capture results and summarize key findings and limitations.
+
+## Verification
+
+Use whatever validation mechanisms exist for your data stack, for example:
+
+- `dbt test` in the relevant project
+- Unit or regression tests for custom metrics or transformations
+- Manual spot checks against known benchmarks or historical reports
+
+The skill is complete when:
+
+- The query runs successfully within acceptable time and cost bounds.
+- Results match expectations or known reference points (within reasonable tolerance).
+- The query and results are documented enough for another engineer or analyst to reuse.
+
+## Safety and escalation
+
+- If the query touches **sensitive or regulated data**, confirm that the destination (PR, doc, ticket) is an approved location before including any sample rows.
+- If you identify data quality issues, file or update a data-quality ticket and call them out prominently in the analysis summary.
+```

--- a/docs/cli/configuration/skills/data-querying.mdx
+++ b/docs/cli/configuration/skills/data-querying.mdx
@@ -7,8 +7,8 @@ Use this skill when Droids need to answer questions using **internal data source
 
 The skill directory can also host **data utilities** that the agent can leverage, such as:
 
-- `metrics.md` – canonical metric and dimension definitions
-- `examples.sql` – sample queries against trusted models or marts
+- `metrics.md` – definitions and references for key metrics/dimensions (with links to the canonical dbt models or warehouse docs)
+- `examples.sql` – small, illustrative queries against trusted models or marts
 - `data-governance.md` – data-classification guidance and safe-sharing checklists
 
 ```md

--- a/docs/cli/configuration/skills/data-querying.mdx
+++ b/docs/cli/configuration/skills/data-querying.mdx
@@ -3,8 +3,6 @@ title: Internal data querying skill
 description: A reusable skill for safely querying internal analytics and data services and producing shareable, reproducible artifacts.
 ---
 
-# Internal data querying skill
-
 Use this skill when Droids need to answer questions using **internal data sources** – analytics warehouses, reporting databases, or internal data APIs – in a way that is safe, auditable, and reproducible.
 
 The skill directory can also host **data utilities** that the agent can leverage, such as:

--- a/docs/cli/configuration/skills/frontend-ui-integration.mdx
+++ b/docs/cli/configuration/skills/frontend-ui-integration.mdx
@@ -1,0 +1,93 @@
+---
+title: Frontend UI integration skill
+description: A reusable skill for implementing typed, tested frontend workflows against existing backend APIs in enterprise codebases.
+---
+
+# Frontend UI integration skill
+
+This skill is designed for large enterprise frontends (React/TypeScript, Next.js, or similar) where Droids implement or extend user-facing flows against existing backend APIs.
+
+Use it when you want consistent, production-quality UI changes that respect your design system, routing, and testing standards.
+
+The folder that contains this skill definition can also include **supporting utilities** the Droid may call, for example:
+
+- `SKILL.md` / `frontend-ui-integration.mdx` – this skill spec
+- `types.ts` – shared TypeScript types for common API shapes
+- `design-system.md` – design-system usage guidelines or component maps
+- `accessibility-checklist.md` – reusable accessibility and performance checklists
+
+```md
+# Skill: Frontend UI integration
+
+## Purpose
+
+Implement or extend a user-facing workflow in our primary web application, integrating with **existing backend APIs** and following our **design system, routing, and testing conventions**.
+
+## When to use this skill
+
+- The feature is primarily a **UI/UX change** backed by one or more existing APIs.
+- The backend contracts, auth model, and core business rules **already exist**.
+- The change affects **only** the web frontend (no schema or service ownership changes).
+
+## Inputs
+
+- **Feature description**: short narrative of the user flow and outcomes.
+- **Relevant APIs**: endpoints, request/response types, and links to source definitions.
+- **Target routes/components**: paths, component names, or feature modules.
+- **Design references**: Figma links or existing screens to mirror.
+- **Guardrails**: performance limits, accessibility requirements, and any security constraints.
+
+## Out of scope
+
+- Creating new backend services or changing persistent data models.
+- Modifying authentication/authorization flows.
+- Introducing new frontend frameworks or design systems.
+
+## Conventions
+
+- **Framework**: React with TypeScript.
+- **Routing**: use the existing router and route layout patterns.
+- **Styling**: use the in-house design system components (Buttons, Inputs, Modals, Toasts, etc.).
+- **State management**: prefer the existing state libraries (e.g., React Query, Redux, Zustand) and follow established patterns.
+
+## Required behavior
+
+1. Implement the UI changes with **strong typing** for all props and API responses.
+2. Handle loading, empty, error, and success states using existing primitives.
+3. Ensure the UI is **keyboard accessible** and screen-reader friendly.
+4. Respect feature flags and rollout mechanisms where applicable.
+
+## Required artifacts
+
+- Updated components and hooks in the appropriate feature module.
+- **Unit tests** for core presentation logic.
+- **Integration or component tests** for the new flow (e.g., React Testing Library, Cypress, Playwright) where the repo already uses them.
+- Minimal **CHANGELOG or PR description text** summarizing the behavior change (to be placed in the PR, not this file).
+
+## Implementation checklist
+
+1. Locate the relevant feature module and existing components.
+2. Confirm the backend APIs and types, updating shared TypeScript types if needed.
+3. Implement the UI, wiring in API calls via the existing data layer.
+4. Add or update tests to cover the new behavior and edge cases.
+5. Run the required validation commands (see below).
+
+## Verification
+
+Run the following (adjust commands to match the project):
+
+- `pnpm lint`
+- `pnpm test -- --runInBand --watch=false`
+- `pnpm typecheck` (if configured separately)
+
+The skill is complete when:
+
+- All tests, linters, and type checks pass.
+- The new UI behaves as specified across normal, error, and boundary cases.
+- No unrelated files or modules are modified.
+
+## Safety and escalation
+
+- If the requested change requires backend contract changes, **stop** and request a backend-focused task instead.
+- If design references conflict with existing accessibility standards, favor accessibility and highlight the discrepancy in the PR description.
+```

--- a/docs/cli/configuration/skills/frontend-ui-integration.mdx
+++ b/docs/cli/configuration/skills/frontend-ui-integration.mdx
@@ -3,8 +3,6 @@ title: Frontend UI integration skill
 description: A reusable skill for implementing typed, tested frontend workflows against existing backend APIs in enterprise codebases.
 ---
 
-# Frontend UI integration skill
-
 This skill is designed for large enterprise frontends (React/TypeScript, Next.js, or similar) where Droids implement or extend user-facing flows against existing backend APIs.
 
 Use it when you want consistent, production-quality UI changes that respect your design system, routing, and testing standards.

--- a/docs/cli/configuration/skills/frontend-ui-integration.mdx
+++ b/docs/cli/configuration/skills/frontend-ui-integration.mdx
@@ -5,12 +5,12 @@ description: A reusable skill for implementing typed, tested frontend workflows 
 
 This skill is designed for large enterprise frontends (React/TypeScript, Next.js, or similar) where Droids implement or extend user-facing flows against existing backend APIs.
 
-Use it when you want consistent, production-quality UI changes that respect your design system, routing, and testing standards.
-
 The folder that contains this skill definition can also include **supporting utilities** the Droid may call, for example:
 
 - `SKILL.md` / `frontend-ui-integration.mdx` – this skill spec
-- `types.ts` – shared TypeScript types for common API shapes
+- `references.md` – pointers to existing TypeScript types, API modules, and routes in your codebase
+- `design-system.md` – design-system usage guidelines or component maps
+- `accessibility-checklist.md` – reusable accessibility and performance checklists
 - `design-system.md` – design-system usage guidelines or component maps
 - `accessibility-checklist.md` – reusable accessibility and performance checklists
 

--- a/docs/cli/configuration/skills/internal-tools.mdx
+++ b/docs/cli/configuration/skills/internal-tools.mdx
@@ -3,8 +3,6 @@ title: Internal tools skill
 description: A reusable skill for building and extending internal tools that support engineers, operators, and support teams.
 ---
 
-# Internal tools skill
-
 Use this skill when Droids are building or extending **internal-facing applications** – admin panels, support consoles, operational dashboards, or engineering utilities – where reliability and safety matter more than surface polish.
 
 The internal-tools skill folder can also include **helper artifacts** the agent should use, for example:

--- a/docs/cli/configuration/skills/internal-tools.mdx
+++ b/docs/cli/configuration/skills/internal-tools.mdx
@@ -1,0 +1,87 @@
+---
+title: Internal tools skill
+description: A reusable skill for building and extending internal tools that support engineers, operators, and support teams.
+---
+
+# Internal tools skill
+
+Use this skill when Droids are building or extending **internal-facing applications** – admin panels, support consoles, operational dashboards, or engineering utilities – where reliability and safety matter more than surface polish.
+
+The internal-tools skill folder can also include **helper artifacts** the agent should use, for example:
+
+- `rbac.md` – standard RBAC role definitions and permission matrices
+- `audit-patterns.md` – patterns for confirmations, approvals, and audit logging
+- `operations-checklist.md` – checklists for operational readiness and incident handling
+
+```md
+# Skill: Internal tools development
+
+## Purpose
+
+Design, implement, or extend internal tools that help employees operate the system safely and efficiently, while respecting access controls and audit requirements.
+
+## When to use this skill
+
+- The audience is **internal staff** (engineers, SREs, support, operations, finance, etc.).
+- The tool interacts with **production-adjacent systems** (feature flags, incidents, customer data, billing, etc.).
+- The change is scoped to internal workflows and does not directly alter customer-facing UX.
+
+## Inputs
+
+- **User personas** and teams who will use the tool.
+- **Workflows** to support (create/update actions, approvals, review flows).
+- **Systems touched**: services, queues, flags, and data stores.
+- **Risk classification**: what can go wrong if the tool misbehaves or is misused.
+
+## Out of scope
+
+- Tools that require new identity providers or SSO integrations.
+- Changes that bypass existing approval or change-management processes.
+- Direct manual-write tooling for core financial or compliance systems without explicit approval.
+
+## Conventions
+
+- Use the **standard stack** for internal tools (framework, component library, backend pattern) already used in the repo.
+- Apply **role-based access control** and logging patterns consistently.
+- Prefer **read-only views and guarded actions** (confirmation dialogs, requiring justification text, etc.) for high-risk operations.
+
+## Required behavior
+
+1. Implement flows that make the happy path fast while making destructive actions clearly intentional.
+2. Ensure all state changes are logged with **who**, **what**, and **when**, and link to existing audit/logging infrastructure.
+3. Provide clear feedback on success, errors, and partial failures.
+4. Design for operational debugging: include ids, timestamps, and links to related systems.
+
+## Required artifacts
+
+- Frontend and backend changes in the appropriate internal-tools modules.
+- **Automated tests** for critical operations (at least unit tests; integration tests where harnesses exist).
+- Baseline **operational runbook entry** or link explaining how to use the tool and what to do when it fails, if required by your team.
+
+## Implementation checklist
+
+1. Clarify workflow boundaries and risk level with stakeholders.
+2. Identify existing components, endpoints, and patterns to reuse.
+3. Implement the UI, backend handlers, and data access using established abstractions.
+4. Add safeguards: confirmations, rate limiting, or approvals depending on risk.
+5. Wire up logging and metrics so usage and failures are visible.
+6. Add or update tests and any required runbook entries.
+
+## Verification
+
+Run the standard validation commands for the relevant apps/services (tests, lint, type checks). In addition:
+
+- Exercise both **happy paths and failure modes** in a safe environment.
+- Confirm that audit logs and metrics reflect actions accurately.
+
+The skill is complete when:
+
+- Validation commands pass.
+- Flows behave correctly in staging or an equivalent environment.
+- Stakeholders can perform their target workflows without manual DB access or unsafe workarounds.
+
+## Safety and escalation
+
+- If an operation could cause **irreversible data loss or external customer impact**, require higher-level approvals and consider additional controls (dual control, time-boxed access, or break-glass procedures).
+- If you discover that existing internal tools bypass critical controls, document this clearly and escalate through the appropriate risk or security channel.
+```

--- a/docs/cli/configuration/skills/internal-tools.mdx
+++ b/docs/cli/configuration/skills/internal-tools.mdx
@@ -7,7 +7,7 @@ Use this skill when Droids are building or extending **internal-facing applicati
 
 The internal-tools skill folder can also include **helper artifacts** the agent should use, for example:
 
-- `rbac.md` – standard RBAC role definitions and permission matrices
+- `rbac.md` – summaries of standard RBAC roles and permission matrices, plus links to the authoritative policy definitions
 - `audit-patterns.md` – patterns for confirmations, approvals, and audit logging
 - `operations-checklist.md` – checklists for operational readiness and incident handling
 

--- a/docs/cli/configuration/skills/service-integration.mdx
+++ b/docs/cli/configuration/skills/service-integration.mdx
@@ -1,0 +1,92 @@
+---
+title: Service integration skill
+description: A reusable skill for extending existing services and wiring integrations in complex enterprise codebases.
+---
+
+# Service integration skill
+
+Use this skill when a feature requires changes to one or more backend services in a **shared, multi-team codebase** – for example, adding a new endpoint, publishing an event, or calling out to a dependency owned by another team.
+
+The surrounding skill folder is a good place to keep **integration utilities** the agent can reuse, such as:
+
+- `SKILL.md` – this service-integration skill specification
+- `schemas/` – common event and API schemas (e.g., JSON, Protobuf, or OpenAPI)
+- `patterns.md` – examples of approved integration patterns
+- `observability-checklist.md` – standard logging/metrics/tracing helpers or checklists
+
+```md
+# Skill: Service integration in a complex codebase
+
+## Purpose
+
+Extend or integrate with existing services in our main backend codebase while preserving ownership boundaries, reliability standards, and observability requirements.
+
+## When to use this skill
+
+- The change requires adding or modifying a backend API, job, or event.
+- The service lives in a **shared monorepo** with clear ownership and domain boundaries.
+- The work may require coordination with other teams, but the main implementation happens in our services.
+
+## Inputs
+
+- **Business requirement**: short description of the user or system behavior change.
+- **Primary service(s)**: names/paths of the services and domains involved.
+- **Existing contracts**: relevant API schemas, events, or message formats.
+- **Non-functional requirements**: latency, error budget, data retention, and throughput expectations.
+- **Change management**: rollout strategy, feature flags, or migration plan.
+
+## Out of scope
+
+- Greenfield systems that require new infrastructure or data stores.
+- Cross-region or cross-cloud replication design.
+- Changes that conflict with established ownership boundaries without prior approval.
+
+## Conventions
+
+- Follow the **domain boundaries** and module layout described in `AGENTS.md` and internal architecture docs.
+- Use existing **configuration, logging, metrics, and tracing** patterns.
+- Reuse established **error handling** and **retry/backoff** utilities.
+
+## Required behavior
+
+1. Introduce new APIs, jobs, or events using existing framework patterns.
+2. Maintain backwards compatibility wherever possible; if breaking changes are required, document migration steps.
+3. Ensure all new behavior is observable via logs, metrics, and/or traces.
+4. Respect existing security and privacy requirements (authN/Z, PII handling, data residency).
+
+## Required artifacts
+
+- Code changes in the relevant service(s) and domain modules.
+- **Unit tests** for core logic and boundary conditions.
+- **Integration or contract tests** for new or modified interfaces, where harnesses exist.
+- Updated **runbooks or design docs** only if required by your team's process (link from the PR description instead of duplicating here).
+
+## Implementation checklist
+
+1. Identify ownership and confirm which service(s) should change.
+2. Map the data and control flow across services and dependencies.
+3. Design the integration surface (API, event, or job) and validate it against existing conventions.
+4. Implement the change, keeping related files and modules co-located.
+5. Add or update tests at the appropriate layers (unit, integration, contract).
+6. Ensure logs/metrics/traces make the new behavior debuggable in production.
+7. Wire in feature flags or configuration for safe rollout if necessary.
+
+## Verification
+
+Run the service-level validation commands, for example:
+
+- `pnpm test --filter <service>` or `pytest` in the service directory
+- `pnpm lint` or equivalent linter for the language in use
+- Any existing **contract or integration test suites** referenced from `AGENTS.md` or service docs
+
+The skill is complete when:
+
+- All relevant tests and linters pass.
+- The new integration behaves correctly in local or staging environments.
+- Observability signals (logs, metrics, traces) show the expected behavior without noisy regressions.
+
+## Safety and escalation
+
+- If the change touches **shared schemas, core auth logic, billing, or compliance-critical data**, stop and request explicit human approval and design review.
+- If dependencies owned by other teams need changes, create or update their tickets and clearly document assumptions and contract expectations in the PR.
+```

--- a/docs/cli/configuration/skills/service-integration.mdx
+++ b/docs/cli/configuration/skills/service-integration.mdx
@@ -3,8 +3,6 @@ title: Service integration skill
 description: A reusable skill for extending existing services and wiring integrations in complex enterprise codebases.
 ---
 
-# Service integration skill
-
 Use this skill when a feature requires changes to one or more backend services in a **shared, multi-team codebase** – for example, adding a new endpoint, publishing an event, or calling out to a dependency owned by another team.
 
 The surrounding skill folder is a good place to keep **integration utilities** the agent can reuse, such as:

--- a/docs/cli/configuration/skills/service-integration.mdx
+++ b/docs/cli/configuration/skills/service-integration.mdx
@@ -8,9 +8,9 @@ Use this skill when a feature requires changes to one or more backend services i
 The surrounding skill folder is a good place to keep **integration utilities** the agent can reuse, such as:
 
 - `SKILL.md` – this service-integration skill specification
-- `schemas/` – common event and API schemas (e.g., JSON, Protobuf, or OpenAPI)
-- `patterns.md` – examples of approved integration patterns
-- `observability-checklist.md` – standard logging/metrics/tracing helpers or checklists
+- `schemas/` – representative event and API schemas (e.g., JSON, Protobuf, or OpenAPI) or trimmed examples, not the canonical service definitions
+- `patterns.md` – examples of approved integration patterns and links to the real implementations
+- `observability-checklist.md` – standard logging/metrics/tracing checklists
 
 ```md
 # Skill: Service integration in a complex codebase

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,6 +73,7 @@
                       "cli/configuration/custom-slash-commands",
                       "cli/configuration/ide-integrations",
                       "cli/configuration/custom-droids",
+                      "cli/configuration/skills",
                       "cli/configuration/agents-md",
                       "cli/configuration/settings",
                       "cli/configuration/mixed-models",
@@ -92,6 +93,16 @@
                               "cli/configuration/hooks/notifications",
                               "cli/configuration/hooks/session-automation",
                               "cli/configuration/hooks/testing-automation"
+                        ]
+                      }
+                      ,
+                      {
+                        "group": "Skills Cookbook",
+                        "pages": [
+                          "cli/configuration/skills/frontend-ui-integration",
+                          "cli/configuration/skills/service-integration",
+                          "cli/configuration/skills/data-querying",
+                          "cli/configuration/skills/internal-tools"
                             ]
                           }
                         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,7 +73,21 @@
                       "cli/configuration/custom-slash-commands",
                       "cli/configuration/ide-integrations",
                       "cli/configuration/custom-droids",
-                      "cli/configuration/skills",
+                      {
+                        "group": "Skills",
+                        "pages": [
+                          "cli/configuration/skills",
+                          {
+                            "group": "Cookbook",
+                            "pages": [
+                              "cli/configuration/skills/frontend-ui-integration",
+                              "cli/configuration/skills/service-integration",
+                              "cli/configuration/skills/data-querying",
+                              "cli/configuration/skills/internal-tools"
+                            ]
+                          }
+                        ]
+                      },
                       "cli/configuration/agents-md",
                       "cli/configuration/settings",
                       "cli/configuration/mixed-models",
@@ -95,15 +109,6 @@
                               "cli/configuration/hooks/testing-automation"
                             ]
                           }
-                        ]
-                      },
-                      {
-                        "group": "Skills Cookbook",
-                        "pages": [
-                          "cli/configuration/skills/frontend-ui-integration",
-                          "cli/configuration/skills/service-integration",
-                          "cli/configuration/skills/data-querying",
-                          "cli/configuration/skills/internal-tools"
                         ]
                       },
                       {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,9 +93,10 @@
                               "cli/configuration/hooks/notifications",
                               "cli/configuration/hooks/session-automation",
                               "cli/configuration/hooks/testing-automation"
+                            ]
+                          }
                         ]
-                      }
-                      ,
+                      },
                       {
                         "group": "Skills Cookbook",
                         "pages": [
@@ -103,8 +104,6 @@
                           "cli/configuration/skills/service-integration",
                           "cli/configuration/skills/data-querying",
                           "cli/configuration/skills/internal-tools"
-                            ]
-                          }
                         ]
                       },
                       {


### PR DESCRIPTION
- **docs: add skills docs and cookbook**
- **docs: improve skills overview**
- **docs: tweak skills overview wording**
- **docs: clarify skills audience in overview**
- **docs: expand skills overview and positioning**
- **docs: align skills overview with config docs format**
- **docs: simplify skills section headings**
- **docs: add steps and cards to skills overview**
- **docs: rename skills overview heading**
- **docs: remove numeric prefixes from skills headings**
- **docs: add quickstart and accordion best practices for skills**
- **docs: de-duplicate skills intro copy**
- **docs: drop redundant skills overview heading**
- **docs: simplify skill file format example**
- **docs: clarify skills layout options for monorepos**
- **docs: move skills cookbook group out of hooks**
- **docs: nest skills cookbook under skills section in nav**
- **docs: remove redundant H1s from skills cookbook pages**
- **docs: clarify skills folders hold utilities and references, not core code**
- **docs: fix cookbook links in skills page to use proper markdown links instead of code blocks**
