### PR TITLE
docs: fix cookbook links in skills page to use proper markdown links …

### DIFF
--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -212,10 +212,10 @@ We focus on four families of skills:
 
 See the following examples:
 
-- `cli/configuration/skills/frontend-ui-integration` – Frontend skill for implementing a typed UI workflow against an existing backend API
-- `cli/configuration/skills/service-integration` – Skill for extending an existing service and wiring it into a complex monorepo
-- `cli/configuration/skills/data-querying` – Skill for safely querying internal data services and producing shareable artifacts
-- `cli/configuration/skills/internal-tools` – Skill for building or extending internal tools (admin panels, support consoles, engineering utilities)
+- [Frontend UI integration](/cli/configuration/skills/frontend-ui-integration) – Frontend skill for implementing a typed UI workflow against an existing backend API
+- [Service integration](/cli/configuration/skills/service-integration) – Skill for extending an existing service and wiring it into a complex monorepo
+- [Internal data querying](/cli/configuration/skills/data-querying) – Skill for safely querying internal data services and producing shareable artifacts
+- [Internal tools](/cli/configuration/skills/internal-tools) – Skill for building or extending internal tools (admin panels, support consoles, engineering utilities)
 
 <CardGroup cols={2}>
   <Card


### PR DESCRIPTION
…instead of code blocks