### PR TITLE
docs: add cookbook links to skill families and remove redundant examples list

### DIFF
--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -205,23 +205,13 @@ The cookbook provides opinionated skill templates aimed at common enterprise sof
 
 We focus on seven families of skills:
 
-1. **Frontend implementation skills** – building UI surfaces that integrate with existing APIs
-2. **Integration skills for complex codebases** – extending or wiring together services in large monorepos
-3. **Internal data querying skills** – safe, auditable access to internal analytics or data services
-4. **Internal tools skills** – building small but robust internal apps that improve developer and operator workflows
-5. **Vibe coding skills** – rapidly prototyping and building complete modern web applications from scratch (Lovable/Bolt/v0 replacement)
-6. **AI data analyst skills** – comprehensive data analysis, visualization, and statistical modeling (data analyst tool replacement)
-7. **Product management skills** – assisting with PRDs, feature analysis, and PM workflows (PM tool augmentation)
-
-See the following examples:
-
-- `cli/configuration/skills/frontend-ui-integration` – Frontend skill for implementing a typed UI workflow against an existing backend API
-- `cli/configuration/skills/service-integration` – Skill for extending an existing service and wiring it into a complex monorepo
-- `cli/configuration/skills/data-querying` – Skill for safely querying internal data services and producing shareable artifacts
-- `cli/configuration/skills/internal-tools` – Skill for building or extending internal tools (admin panels, support consoles, engineering utilities)
-- `cli/configuration/skills/vibe-coding` – Skill for rapidly prototyping and building complete modern web applications from scratch
-- `cli/configuration/skills/ai-data-analyst` – Skill for performing data analysis, statistical modeling, and visualization
-- `cli/configuration/skills/product-management` – Skill for assisting with PRDs, feature analysis, and product planning
+1. **[Frontend implementation skills](/cli/configuration/skills/frontend-ui-integration)** – building UI surfaces that integrate with existing APIs
+2. **[Integration skills for complex codebases](/cli/configuration/skills/service-integration)** – extending or wiring together services in large monorepos
+3. **[Internal data querying skills](/cli/configuration/skills/data-querying)** – safe, auditable access to internal analytics or data services
+4. **[Internal tools skills](/cli/configuration/skills/internal-tools)** – building small but robust internal apps that improve developer and operator workflows
+5. **[Vibe coding skills](/cli/configuration/skills/vibe-coding)** – rapidly prototyping and building complete modern web applications from scratch (Lovable/Bolt/v0 replacement)
+6. **[AI data analyst skills](/cli/configuration/skills/ai-data-analyst)** – comprehensive data analysis, visualization, and statistical modeling (data analyst tool replacement)
+7. **[Product management skills](/cli/configuration/skills/product-management)** – assisting with PRDs, feature analysis, and PM workflows (PM tool augmentation)
 
 <CardGroup cols={2}>
   <Card


### PR DESCRIPTION
Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
