### PR TITLE
docs: add setup instructions and frontmatter to skill cookbooks

### DIFF
--- a/docs/cli/configuration/skills/ai-data-analyst.mdx
+++ b/docs/cli/configuration/skills/ai-data-analyst.mdx
@@ -26,8 +26,6 @@ To use this skill with Factory, create the following directory structure in your
 
 2. **Copy the skill content below into `.factory/skills/ai-data-analyst/SKILL.md` (or `skill.mdx`)**
 
-3. **Restart your Factory droid** to discover the new skill
-
 <Tip>
 When you ask Factory to perform data analysis, create visualizations, or build statistical models, it will automatically invoke this skill based on the task description.
 </Tip>

--- a/docs/cli/configuration/skills/ai-data-analyst.mdx
+++ b/docs/cli/configuration/skills/ai-data-analyst.mdx
@@ -5,14 +5,42 @@ description: A reusable skill for performing comprehensive data analysis, visual
 
 This skill enables Droids to act as an AI-powered data analyst, performing exploratory data analysis, statistical modeling, data visualization, and generating insights from structured and unstructured data. Unlike point-solution data analysis tools, this skill runs entirely in your local environment with full Python ecosystem access and customization capabilities.
 
-The folder that contains this skill definition can also include **supporting utilities** the Droid may call, for example:
+## Setup Instructions
 
-- `SKILL.md` / `ai-data-analyst.mdx` – this skill spec
-- `visualization-templates.md` – common chart types and when to use them
-- `statistical-methods.md` – reference for statistical tests and their assumptions
-- `example-analyses.md` – example workflows for common analysis patterns
+To use this skill with Factory, create the following directory structure in your repository:
+
+```
+.factory/skills/ai-data-analyst/
+├── SKILL.md
+├── visualization-templates.md (optional)
+├── statistical-methods.md (optional)
+└── example-analyses.md (optional)
+```
+
+### Quick Start
+
+1. **Create the skill directory:**
+   ```bash
+   mkdir -p .factory/skills/ai-data-analyst
+   ```
+
+2. **Copy the skill content below into `.factory/skills/ai-data-analyst/SKILL.md` (or `skill.mdx`)**
+
+3. **Restart your Factory droid** to discover the new skill
+
+<Tip>
+When you ask Factory to perform data analysis, create visualizations, or build statistical models, it will automatically invoke this skill based on the task description.
+</Tip>
+
+## Skill Definition
+
+Copy the following content into `.factory/skills/ai-data-analyst/SKILL.md`:
 
 ```md
+---
+name: ai-data-analyst
+description: Perform comprehensive data analysis, statistical modeling, and data visualization by writing and executing self-contained Python scripts. Use when you need to analyze datasets, perform statistical tests, create visualizations, or build predictive models with reproducible, code-based workflows.
+---
 # Skill: AI data analyst
 
 ## Purpose

--- a/docs/cli/configuration/skills/data-querying.mdx
+++ b/docs/cli/configuration/skills/data-querying.mdx
@@ -26,8 +26,6 @@ To use this skill with Factory, create the following directory structure in your
 
 2. **Copy the skill content below into `.factory/skills/data-querying/SKILL.md` (or `skill.mdx`)**
 
-3. **Restart your Factory droid** to discover the new skill
-
 <Tip>
 When you ask Factory to query internal data or analyze metrics, it will automatically invoke this skill based on the task description.
 </Tip>

--- a/docs/cli/configuration/skills/data-querying.mdx
+++ b/docs/cli/configuration/skills/data-querying.mdx
@@ -5,13 +5,42 @@ description: A reusable skill for safely querying internal analytics and data se
 
 Use this skill when Droids need to answer questions using **internal data sources** – analytics warehouses, reporting databases, or internal data APIs – in a way that is safe, auditable, and reproducible.
 
-The skill directory can also host **data utilities** that the agent can leverage, such as:
+## Setup Instructions
 
-- `metrics.md` – definitions and references for key metrics/dimensions (with links to the canonical dbt models or warehouse docs)
-- `examples.sql` – small, illustrative queries against trusted models or marts
-- `data-governance.md` – data-classification guidance and safe-sharing checklists
+To use this skill with Factory, create the following directory structure in your repository:
+
+```
+.factory/skills/data-querying/
+├── SKILL.md
+├── metrics.md (optional)
+├── examples.sql (optional)
+└── data-governance.md (optional)
+```
+
+### Quick Start
+
+1. **Create the skill directory:**
+   ```bash
+   mkdir -p .factory/skills/data-querying
+   ```
+
+2. **Copy the skill content below into `.factory/skills/data-querying/SKILL.md` (or `skill.mdx`)**
+
+3. **Restart your Factory droid** to discover the new skill
+
+<Tip>
+When you ask Factory to query internal data or analyze metrics, it will automatically invoke this skill based on the task description.
+</Tip>
+
+## Skill Definition
+
+Copy the following content into `.factory/skills/data-querying/SKILL.md`:
 
 ```md
+---
+name: data-querying
+description: Query internal data services to answer well-scoped questions, producing results and artifacts that are safe to share and easy to re-run. Use when stakeholders need metrics, trends, or data slices from internal warehouses, marts, or reporting APIs.
+---
 # Skill: Internal data querying
 
 ## Purpose

--- a/docs/cli/configuration/skills/frontend-ui-integration.mdx
+++ b/docs/cli/configuration/skills/frontend-ui-integration.mdx
@@ -5,16 +5,42 @@ description: A reusable skill for implementing typed, tested frontend workflows 
 
 This skill is designed for large enterprise frontends (React/TypeScript, Next.js, or similar) where Droids implement or extend user-facing flows against existing backend APIs.
 
-The folder that contains this skill definition can also include **supporting utilities** the Droid may call, for example:
+## Setup Instructions
 
-- `SKILL.md` / `frontend-ui-integration.mdx` – this skill spec
-- `references.md` – pointers to existing TypeScript types, API modules, and routes in your codebase
-- `design-system.md` – design-system usage guidelines or component maps
-- `accessibility-checklist.md` – reusable accessibility and performance checklists
-- `design-system.md` – design-system usage guidelines or component maps
-- `accessibility-checklist.md` – reusable accessibility and performance checklists
+To use this skill with Factory, create the following directory structure in your repository:
+
+```
+.factory/skills/frontend-ui-integration/
+├── SKILL.md
+├── references.md (optional)
+├── design-system.md (optional)
+└── accessibility-checklist.md (optional)
+```
+
+### Quick Start
+
+1. **Create the skill directory:**
+   ```bash
+   mkdir -p .factory/skills/frontend-ui-integration
+   ```
+
+2. **Copy the skill content below into `.factory/skills/frontend-ui-integration/SKILL.md` (or `skill.mdx`)**
+
+3. **Restart your Factory droid** to discover the new skill
+
+<Tip>
+When you ask Factory to implement a UI feature, it will automatically invoke this skill based on the task description.
+</Tip>
+
+## Skill Definition
+
+Copy the following content into `.factory/skills/frontend-ui-integration/SKILL.md`:
 
 ```md
+---
+name: frontend-ui-integration
+description: Implement or extend a user-facing workflow in a web application, integrating with existing backend APIs. Use when the feature is primarily a UI/UX change backed by existing APIs, affects only the web frontend, and requires following design system, routing, and testing conventions.
+---
 # Skill: Frontend UI integration
 
 ## Purpose

--- a/docs/cli/configuration/skills/frontend-ui-integration.mdx
+++ b/docs/cli/configuration/skills/frontend-ui-integration.mdx
@@ -26,8 +26,6 @@ To use this skill with Factory, create the following directory structure in your
 
 2. **Copy the skill content below into `.factory/skills/frontend-ui-integration/SKILL.md` (or `skill.mdx`)**
 
-3. **Restart your Factory droid** to discover the new skill
-
 <Tip>
 When you ask Factory to implement a UI feature, it will automatically invoke this skill based on the task description.
 </Tip>

--- a/docs/cli/configuration/skills/internal-tools.mdx
+++ b/docs/cli/configuration/skills/internal-tools.mdx
@@ -26,8 +26,6 @@ To use this skill with Factory, create the following directory structure in your
 
 2. **Copy the skill content below into `.factory/skills/internal-tools/SKILL.md` (or `skill.mdx`)**
 
-3. **Restart your Factory droid** to discover the new skill
-
 <Tip>
 When you ask Factory to build or extend internal tools like admin panels or operational dashboards, it will automatically invoke this skill based on the task description.
 </Tip>

--- a/docs/cli/configuration/skills/internal-tools.mdx
+++ b/docs/cli/configuration/skills/internal-tools.mdx
@@ -5,13 +5,42 @@ description: A reusable skill for building and extending internal tools that sup
 
 Use this skill when Droids are building or extending **internal-facing applications** – admin panels, support consoles, operational dashboards, or engineering utilities – where reliability and safety matter more than surface polish.
 
-The internal-tools skill folder can also include **helper artifacts** the agent should use, for example:
+## Setup Instructions
 
-- `rbac.md` – summaries of standard RBAC roles and permission matrices, plus links to the authoritative policy definitions
-- `audit-patterns.md` – patterns for confirmations, approvals, and audit logging
-- `operations-checklist.md` – checklists for operational readiness and incident handling
+To use this skill with Factory, create the following directory structure in your repository:
+
+```
+.factory/skills/internal-tools/
+├── SKILL.md
+├── rbac.md (optional)
+├── audit-patterns.md (optional)
+└── operations-checklist.md (optional)
+```
+
+### Quick Start
+
+1. **Create the skill directory:**
+   ```bash
+   mkdir -p .factory/skills/internal-tools
+   ```
+
+2. **Copy the skill content below into `.factory/skills/internal-tools/SKILL.md` (or `skill.mdx`)**
+
+3. **Restart your Factory droid** to discover the new skill
+
+<Tip>
+When you ask Factory to build or extend internal tools like admin panels or operational dashboards, it will automatically invoke this skill based on the task description.
+</Tip>
+
+## Skill Definition
+
+Copy the following content into `.factory/skills/internal-tools/SKILL.md`:
 
 ```md
+---
+name: internal-tools
+description: Design, implement, or extend internal tools that help employees operate the system safely and efficiently, while respecting access controls and audit requirements. Use when building for internal staff interacting with production-adjacent systems.
+---
 # Skill: Internal tools development
 
 ## Purpose

--- a/docs/cli/configuration/skills/product-management.mdx
+++ b/docs/cli/configuration/skills/product-management.mdx
@@ -26,8 +26,6 @@ To use this skill with Factory, create the following directory structure in your
 
 2. **Copy the skill content below into `.factory/skills/product-management/SKILL.md` (or `skill.mdx`)**
 
-3. **Restart your Factory droid** to discover the new skill
-
 <Tip>
 When you ask Factory to help with PRDs, feature analysis, roadmap planning, or research synthesis, it will automatically invoke this skill based on the task description.
 </Tip>

--- a/docs/cli/configuration/skills/product-management.mdx
+++ b/docs/cli/configuration/skills/product-management.mdx
@@ -5,14 +5,42 @@ description: A reusable skill for assisting with product management workflows in
 
 This skill enables Droids to act as a product management assistant, helping with the documentation, analysis, and planning activities that are core to the PM role. Unlike point-solution PM tools, this skill integrates directly with your development workflow, codebase, and documentation.
 
-The folder that contains this skill definition can also include **supporting utilities** the Droid may call, for example:
+## Setup Instructions
 
-- `SKILL.md` / `product-management.mdx` – this skill spec
-- `prd-template.md` – standard PRD template for your organization
-- `feature-analysis-framework.md` – frameworks for evaluating features (RICE, ICE, etc.)
-- `user-research-templates.md` – templates for research synthesis and insights
+To use this skill with Factory, create the following directory structure in your repository:
+
+```
+.factory/skills/product-management/
+├── SKILL.md
+├── prd-template.md (optional)
+├── feature-analysis-framework.md (optional)
+└── user-research-templates.md (optional)
+```
+
+### Quick Start
+
+1. **Create the skill directory:**
+   ```bash
+   mkdir -p .factory/skills/product-management
+   ```
+
+2. **Copy the skill content below into `.factory/skills/product-management/SKILL.md` (or `skill.mdx`)**
+
+3. **Restart your Factory droid** to discover the new skill
+
+<Tip>
+When you ask Factory to help with PRDs, feature analysis, roadmap planning, or research synthesis, it will automatically invoke this skill based on the task description.
+</Tip>
+
+## Skill Definition
+
+Copy the following content into `.factory/skills/product-management/SKILL.md`:
 
 ```md
+---
+name: product-management
+description: Assist with core product management activities including writing PRDs, analyzing features, synthesizing user research, planning roadmaps, and communicating product decisions. Use when you need help with PM documentation, analysis, or planning workflows that integrate with your codebase.
+---
 # Skill: Product management AI
 
 ## Purpose

--- a/docs/cli/configuration/skills/service-integration.mdx
+++ b/docs/cli/configuration/skills/service-integration.mdx
@@ -26,8 +26,6 @@ To use this skill with Factory, create the following directory structure in your
 
 2. **Copy the skill content below into `.factory/skills/service-integration/SKILL.md` (or `skill.mdx`)**
 
-3. **Restart your Factory droid** to discover the new skill
-
 <Tip>
 When you ask Factory to extend a backend service or wire an integration, it will automatically invoke this skill based on the task description.
 </Tip>

--- a/docs/cli/configuration/skills/service-integration.mdx
+++ b/docs/cli/configuration/skills/service-integration.mdx
@@ -5,14 +5,42 @@ description: A reusable skill for extending existing services and wiring integra
 
 Use this skill when a feature requires changes to one or more backend services in a **shared, multi-team codebase** – for example, adding a new endpoint, publishing an event, or calling out to a dependency owned by another team.
 
-The surrounding skill folder is a good place to keep **integration utilities** the agent can reuse, such as:
+## Setup Instructions
 
-- `SKILL.md` – this service-integration skill specification
-- `schemas/` – representative event and API schemas (e.g., JSON, Protobuf, or OpenAPI) or trimmed examples, not the canonical service definitions
-- `patterns.md` – examples of approved integration patterns and links to the real implementations
-- `observability-checklist.md` – standard logging/metrics/tracing checklists
+To use this skill with Factory, create the following directory structure in your repository:
+
+```
+.factory/skills/service-integration/
+├── SKILL.md
+├── schemas/ (optional)
+├── patterns.md (optional)
+└── observability-checklist.md (optional)
+```
+
+### Quick Start
+
+1. **Create the skill directory:**
+   ```bash
+   mkdir -p .factory/skills/service-integration
+   ```
+
+2. **Copy the skill content below into `.factory/skills/service-integration/SKILL.md` (or `skill.mdx`)**
+
+3. **Restart your Factory droid** to discover the new skill
+
+<Tip>
+When you ask Factory to extend a backend service or wire an integration, it will automatically invoke this skill based on the task description.
+</Tip>
+
+## Skill Definition
+
+Copy the following content into `.factory/skills/service-integration/SKILL.md`:
 
 ```md
+---
+name: service-integration
+description: Extend or integrate with existing services in a shared monorepo while preserving ownership boundaries, reliability standards, and observability requirements. Use when changes require adding or modifying backend APIs, jobs, or events in services with clear domain boundaries.
+---
 # Skill: Service integration in a complex codebase
 
 ## Purpose

--- a/docs/cli/configuration/skills/vibe-coding.mdx
+++ b/docs/cli/configuration/skills/vibe-coding.mdx
@@ -5,14 +5,42 @@ description: A reusable skill for rapidly prototyping and building modern web ap
 
 This skill enables Droids to act as a vibe coding partner, creating complete web applications from scratch on your local machine with speed and creativity. Unlike hosted builders like Lovable, Bolt, or v0, this skill works entirely in your local environment, giving you full control over the stack, deployment, and evolution of your application while maintaining the rapid, creative flow of vibe-based development.
 
-The folder that contains this skill definition can also include **supporting utilities** the Droid may call, for example:
+## Setup Instructions
 
-- `SKILL.md` / `vibe-coding.mdx` – this skill spec
-- `framework-references.md` – links to current documentation for React, Next.js, Vue, Svelte, etc.
-- `deployment-patterns.md` – common deployment options and checklists
-- `accessibility-checklist.md` – reusable accessibility and performance checklists
+To use this skill with Factory, create the following directory structure in your repository:
+
+```
+.factory/skills/vibe-coding/
+├── SKILL.md
+├── framework-references.md (optional)
+├── deployment-patterns.md (optional)
+└── accessibility-checklist.md (optional)
+```
+
+### Quick Start
+
+1. **Create the skill directory:**
+   ```bash
+   mkdir -p .factory/skills/vibe-coding
+   ```
+
+2. **Copy the skill content below into `.factory/skills/vibe-coding/SKILL.md` (or `skill.mdx`)**
+
+3. **Restart your Factory droid** to discover the new skill
+
+<Tip>
+When you ask Factory to rapidly prototype or build a web application from scratch, it will automatically invoke this skill based on the task description.
+</Tip>
+
+## Skill Definition
+
+Copy the following content into `.factory/skills/vibe-coding/SKILL.md`:
 
 ```md
+---
+name: vibe-coding
+description: Rapidly prototype and build modern, responsive web applications from scratch using current frameworks and libraries. Use when you want to quickly create a new web app with full local control, creative flow, and modern best practices. Local alternative to Lovable, Bolt, and v0.
+---
 # Skill: Vibe coding
 
 ## Purpose

--- a/docs/cli/configuration/skills/vibe-coding.mdx
+++ b/docs/cli/configuration/skills/vibe-coding.mdx
@@ -26,8 +26,6 @@ To use this skill with Factory, create the following directory structure in your
 
 2. **Copy the skill content below into `.factory/skills/vibe-coding/SKILL.md` (or `skill.mdx`)**
 
-3. **Restart your Factory droid** to discover the new skill
-
 <Tip>
 When you ask Factory to rapidly prototype or build a web application from scratch, it will automatically invoke this skill based on the task description.
 </Tip>


### PR DESCRIPTION
Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
