### PR TITLE
fix(docs): fix nested code block rendering in skill definitions

### DIFF
--- a/docs/cli/configuration/skills/ai-data-analyst.mdx
+++ b/docs/cli/configuration/skills/ai-data-analyst.mdx
@@ -34,7 +34,7 @@ When you ask Factory to perform data analysis, create visualizations, or build s
 
 Copy the following content into `.factory/skills/ai-data-analyst/SKILL.md`:
 
-```md
+````md
 ---
 name: ai-data-analyst
 description: Perform comprehensive data analysis, statistical modeling, and data visualization by writing and executing self-contained Python scripts. Use when you need to analyze datasets, perform statistical tests, create visualizations, or build predictive models with reproducible, code-based workflows.
@@ -390,4 +390,4 @@ This skill can be combined with:
 - **Internal data querying**: To fetch data from warehouses or databases for analysis.
 - **Web app builder**: To create interactive dashboards displaying analysis results.
 - **Internal tools**: To build analysis tools for non-technical stakeholders.
-```
+````

--- a/docs/cli/configuration/skills/product-management.mdx
+++ b/docs/cli/configuration/skills/product-management.mdx
@@ -34,7 +34,7 @@ When you ask Factory to help with PRDs, feature analysis, roadmap planning, or r
 
 Copy the following content into `.factory/skills/product-management/SKILL.md`:
 
-```md
+````md
 ---
 name: product-management
 description: Assist with core product management activities including writing PRDs, analyzing features, synthesizing user research, planning roadmaps, and communicating product decisions. Use when you need help with PM documentation, analysis, or planning workflows that integrate with your codebase.
@@ -581,4 +581,4 @@ This skill can be combined with:
 - **AI data analyst**: To perform deeper quantitative analysis for feature decisions.
 - **Frontend UI integration**: To implement features designed in PRDs.
 - **Internal tools**: To build PM tools like feature flag dashboards or metrics viewers.
-```
+````

--- a/docs/cli/configuration/skills/vibe-coding.mdx
+++ b/docs/cli/configuration/skills/vibe-coding.mdx
@@ -34,7 +34,7 @@ When you ask Factory to rapidly prototype or build a web application from scratc
 
 Copy the following content into `.factory/skills/vibe-coding/SKILL.md`:
 
-```md
+````md
 ---
 name: vibe-coding
 description: Rapidly prototype and build modern, responsive web applications from scratch using current frameworks and libraries. Use when you want to quickly create a new web app with full local control, creative flow, and modern best practices. Local alternative to Lovable, Bolt, and v0.
@@ -283,4 +283,4 @@ This skill can be combined with:
 - **Service integration**: When the web app needs to call existing backend services.
 - **Internal tools**: When building internal admin panels or dashboards.
 - **Data querying**: When the app needs to display analytics or reports.
-```
+````


### PR DESCRIPTION
## Description
This PR fixes a markdown rendering issue in the some of the skill definition documentation pages. 

The markdown blocks contain nested code blocks (using ` ``` `), which were breaking the outer code blocks that also used 3 backticks. This caused the content to be rendered incorrectly on the documentation site.

## Changes
- Updated the outer code blocks to use 4 backticks (` ```` `) in the 4 affected documentations:
  - `docs/cli/configuration/skills/vibe-coding.mdx`
  - `docs/cli/configuration/skills/product-management.mdx`
  - `docs/cli/configuration/skills/ai-data-analyst.mdx`

## Verification
- Verified locally by running `mintlify dev`.
- Confirmed that the "Skill Definition" blocks now render correctly as a single, continuous code block containing the nested markdown.