### PR TITLE
Fix dark mode hyperlink styling (DR-21)

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -168,3 +168,22 @@ a.text-primary.border-primary {
     color: #F27B2F !important;
     border-color: #F27B2F !important;
 }
+
+/* Hyperlinks in prose text content - orange underline in dark mode */
+/* Target links within text elements only, exclude cards */
+.dark .prose p a:not(.card a),
+.dark .prose li a:not(.card a),
+.dark .prose td a:not(.card a),
+.dark .prose dd a:not(.card a) {
+    color: #F27B2F !important;
+    text-decoration: underline !important;
+    text-decoration-color: #F27B2F !important;
+}
+
+.dark .prose p a:not(.card a):hover,
+.dark .prose li a:not(.card a):hover,
+.dark .prose td a:not(.card a):hover,
+.dark .prose dd a:not(.card a):hover {
+    color: #FF9C6E !important;
+    text-decoration-color: #FF9C6E !important;
+}


### PR DESCRIPTION
Fixes https://linear.app/factoryai/issue/DR-21/make-hyperlink-underlining-orange-in-dark-mode

## Changes
- Added orange color (#F27B2F) to hyperlinks within text content in dark mode
- Targets only links in paragraphs, lists, tables, and definition descriptions
- Excludes cards and other components to maintain their existing styling
- Added lighter orange hover state (#FF9C6E) for better UX

## Testing
Tested locally with `mintlify dev` to verify:
- Text hyperlinks show orange underline in dark mode
- Cards remain unaffected
- Hover states work correctly