### PR TITLE
docs: add browser automation skill cookbook entry

### DIFF
--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -213,6 +213,7 @@ We focus on seven families of skills:
 5. **[Vibe coding skills](/cli/configuration/skills/vibe-coding)** – rapidly prototyping and building complete modern web applications from scratch (Lovable/Bolt/v0 replacement)
 6. **[AI data analyst skills](/cli/configuration/skills/ai-data-analyst)** – comprehensive data analysis, visualization, and statistical modeling (data analyst tool replacement)
 7. **[Product management skills](/cli/configuration/skills/product-management)** – assisting with PRDs, feature analysis, and PM workflows (PM tool augmentation)
+8. **[Browser automation skills](/cli/configuration/skills/browser)** – launching Chrome via CDP, navigating live tabs, evaluating DOM state, and collecting screenshots or selectors without running an MCP server
 
 <CardGroup cols={2}>
   <Card
@@ -272,6 +273,14 @@ We focus on seven families of skills:
   >
     Assist with product management workflows including writing PRDs, analyzing
     features, synthesizing research, and planning roadmaps.
+  </Card>
+  <Card
+    title="Browser automation"
+    href="/cli/configuration/skills/browser"
+    icon="browser"
+  >
+    Launch Chrome with remote debugging, drive tabs, evaluate DOM state, and
+    capture screenshots or selectors without deploying extra infrastructure.
   </Card>
 </CardGroup>
 

--- a/docs/cli/configuration/skills/browser.mdx
+++ b/docs/cli/configuration/skills/browser.mdx
@@ -1,0 +1,148 @@
+---
+title: Browser automation skill
+description: Minimal Chrome DevTools Protocol helpers that let Droids start Chrome, navigate tabs, evaluate JavaScript, take screenshots, and capture DOM metadata without building a full MCP server.
+---
+
+<Note>
+  This cookbook is inspired by [Mario Zechner's “What if you don't need
+  MCP?”](https://mariozechner.at/posts/2025-11-02-what-if-you-dont-need-mcp/),
+  adapted into a reusable Factory skill so teams can share lightweight browser
+  helpers without standing up new services.
+</Note>
+
+The browser skill bundles a handful of executable scripts (`start.js`, `nav.js`, `eval.js`, `screenshot.js`, `pick.js`) plus a concise `SKILL.md`. Together they give Factory Droids a reliable way to spin up Chrome on port `9222`, drive an existing tab, scrape structured data, and capture visual evidence while staying entirely on the developer machine.
+
+## When to use this skill
+
+- You need **real-browser context** (authenticated sessions, production-only behavior, visual regressions) to complete a task.
+- You want to **inspect or extract DOM state** without building a dedicated MCP server.
+- You must **capture screenshots or DOM element metadata** as part of QA notes, bug triage, or documentation.
+- You prefer a **portable, git-tracked bundle** that any teammate can run locally with zero additional infrastructure.
+
+## What the scripts provide
+
+| Script          | Purpose                                                                                       | Typical usage                                                 |
+| --------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `start.js`      | Launches Chrome with remote debugging on `:9222`, with optional profile sync via `--profile`. | `~/.factory/skills/browser/start.js --profile`                |
+| `nav.js`        | Navigates the active tab or opens a new tab when `--new` is passed.                           | `~/.factory/skills/browser/nav.js https://example.com --new`  |
+| `eval.js`       | Runs arbitrary JavaScript (async supported) in the focused tab and prints structured results. | `~/.factory/skills/browser/eval.js "document.title"`          |
+| `screenshot.js` | Captures the current viewport to a timestamped PNG stored under `$TMPDIR`.                    | `~/.factory/skills/browser/screenshot.js`                     |
+| `pick.js`       | Injects a visual picker so you can click DOM nodes and return tag/id/class/text metadata.     | `~/.factory/skills/browser/pick.js "Click the submit button"` |
+
+All scripts rely on `puppeteer-core` and connect to a Chrome instance that you control. Because everything runs locally, existing cookies and auth tokens never leave your machine.
+
+## Setup
+
+<Steps>
+  <Step title="Create the skill folder">
+    Run `mkdir -p .factory/skills/browser`.
+  </Step>
+  <Step title="Copy scripts and package metadata">
+    Copy `start.js`, `nav.js`, `eval.js`, `screenshot.js`, `pick.js`, and
+    `package.json` into `.factory/skills/browser/` (or symlink to a shared
+    dotfiles repo).
+  </Step>
+  <Step title="Install dependencies">
+    Run `npm install --prefix .factory/skills/browser puppeteer-core`, then
+    `chmod +x .factory/skills/browser/*.js`.
+  </Step>
+  <Step title="Restart Droid">
+    Restart `droid` (or your IDE integration) so it rescans workspace skills and
+    discovers `browser`.
+  </Step>
+</Steps>
+
+## Skill definition
+
+Copy the following into `.factory/skills/browser/SKILL.md`:
+
+````md
+---
+name: browser
+description: Minimal Chrome DevTools Protocol tools for browser automation and scraping. Use when you need to start Chrome, navigate pages, execute JavaScript, take screenshots, or interactively pick DOM elements.
+---
+
+# Browser Tools
+
+Minimal CDP tools for collaborative site exploration and scraping.
+
+**IMPORTANT**: All scripts are located in `~/.factory/skills/browser/` and must be called with full paths.
+
+## Start Chrome
+
+```bash
+~/.factory/skills/browser/start.js              # Fresh profile
+~/.factory/skills/browser/start.js --profile    # Copy your profile (cookies, logins)
+```
+
+Start Chrome on `:9222` with remote debugging.
+
+## Navigate
+
+```bash
+~/.factory/skills/browser/nav.js https://example.com
+~/.factory/skills/browser/nav.js https://example.com --new
+```
+
+Navigate current tab or open new tab.
+
+## Evaluate JavaScript
+
+```bash
+~/.factory/skills/browser/eval.js 'document.title'
+~/.factory/skills/browser/eval.js 'document.querySelectorAll("a").length'
+```
+
+Execute JavaScript in active tab (async context).
+
+**IMPORTANT**: The code must be a single expression or use IIFE for multiple statements:
+
+- Single expression: `'document.title'`
+- Multiple statements: `'(() => { const x = 1; return x + 1; })()'`
+- Avoid newlines in the code string - keep it on one line
+
+## Screenshot
+
+```bash
+~/.factory/skills/browser/screenshot.js
+```
+
+Screenshot current viewport, returns temp file path.
+
+## Pick Elements
+
+```bash
+~/.factory/skills/browser/pick.js "Click the submit button"
+```
+
+Interactive element picker. Click to select, Cmd/Ctrl+Click for multi-select, Enter to finish.
+
+## Usage Notes
+
+- Start Chrome first before using other tools
+- The `--profile` flag syncs your actual Chrome profile so you're logged in everywhere
+- JavaScript evaluation runs in an async context in the page
+- Pick tool allows you to visually select DOM elements by clicking on them
+
+```
+
+## Workflow recipe
+
+1. **Start Chrome** with `start.js --profile` to mirror your authenticated state.
+2. **Drive navigation** via `nav.js https://target.app` or open secondary tabs with `--new`.
+3. **Inspect the DOM** using `eval.js` for quick counts, attribute checks, or extracting JSON payloads.
+4. **Capture artifacts** with `screenshot.js` for visual proof or `pick.js` when you need precise selectors or text snapshots.
+5. **Return the gathered evidence** (file paths, DOM metadata, query outputs) in your session summary or PR description.
+
+This workflow keeps the agent focused on the current browsing context and avoids shipping raw credentials or cookies outside your machine.
+
+## Verification
+
+- `~/.factory/skills/browser/start.js --profile` should print `✓ Chrome started on :9222 with your profile`.
+- `~/.factory/skills/browser/nav.js https://example.com` should confirm navigation.
+- `~/.factory/skills/browser/eval.js 'document.title'` should echo the current page title.
+- `~/.factory/skills/browser/screenshot.js` should output a valid PNG path under your system temp directory.
+
+If any step fails, rerun `start.js`, confirm Chrome is listening on `localhost:9222/json/version`, and ensure `puppeteer-core` is installed.
+```
+````

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,7 +86,8 @@
                           "cli/configuration/skills/internal-tools",
                           "cli/configuration/skills/vibe-coding",
                           "cli/configuration/skills/ai-data-analyst",
-                          "cli/configuration/skills/product-management"
+                          "cli/configuration/skills/product-management",
+                          "cli/configuration/skills/browser"
                         ]
                       }
                     ]


### PR DESCRIPTION
## Summary
- add a cookbook page for the browser automation skill plus Mario Zechner attribution
- link the browser skill from the skills index page and navigation metadata

## Testing
- npx --yes prettier@3.2.5 --check docs/cli/configuration/skills/browser.mdx
- python3 -m json.tool docs/docs.json >/tmp/docs.json.validate