### PR TITLE
docs(hooks): fix co-authorship hook JSON escaping bug

### DIFF
--- a/docs/cli/configuration/hooks/git-workflows.mdx
+++ b/docs/cli/configuration/hooks/git-workflows.mdx
@@ -508,27 +508,27 @@ if echo "$commit_msg" | grep -qE "Co-authored-by:"; then
   exit 0
 fi
 
-# Add factory droid co-author
+# Add factory droid co-author with proper newline handling
 coauthor="Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
+modified_msg="${commit_msg}\n\n${coauthor}"
 
-# Modify command to include co-author
-modified_msg="$commit_msg
+# Build new command with properly escaped message
+new_command=$(echo "$command" | sed -E "s|(git commit.*-m[= ]*)[\"']([^\"']+)[\"']|\1|")
+new_command="${new_command} -m \"${modified_msg}\""
 
-$coauthor"
-
-# Return modified command via JSON output
-cat << EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "allow",
-    "permissionDecisionReason": "Adding co-author to commit",
-    "updatedInput": {
-      "command": "$(echo "$command" | sed -E "s/(git commit.*-m[= ]*)[\"']([^\"']+)[\"']/\1\"$modified_msg\"/")"
+# Use jq to properly construct JSON with escaped strings
+jq -n \
+  --arg cmd "$new_command" \
+  '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow",
+      "permissionDecisionReason": "Adding co-author to commit",
+      "updatedInput": {
+        "command": $cmd
+      }
     }
-  }
-}
-EOF
+  }'
 
 exit 0
 ```


### PR DESCRIPTION
## Problem

The co-authorship hook example in the git-workflows documentation had critical bugs that would prevent it from working:

1. **Literal newlines in JSON output** - The `modified_msg` variable contained actual newlines, which broke the JSON structure
2. **Broken sed command** - The sed replacement tried to embed multiline strings with special characters directly, causing command failure
3. **Shell expansion issues** - Variable expansion with newlines corrupted the final JSON output

## Solution

Fixed by using `jq -n` with `--arg` to properly handle string escaping and JSON construction:

- Use `\n\n` for newlines in bash variable instead of literal newlines
- Extract and rebuild the git command without trying to embed complex multiline strings in sed
- Let jq handle all JSON escaping automatically

This ensures the hook will work correctly when adding co-author trailers to git commits.