### PR TITLE
docs: improve search ranking for CLI BYOK and MCP pages

### DIFF
--- a/docs/cli/byok/overview.mdx
+++ b/docs/cli/byok/overview.mdx
@@ -1,7 +1,8 @@
 ---
-title: Overview
+title: Bring Your Own Key (BYOK)
+sidebarTitle: Overview
 description: Connect your own API keys, use open source models, or run local models
-keywords: ['byok', 'bring your own key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted']
+keywords: ['byok', 'bring your own key', 'own api key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted', 'use own key', 'personal key', 'own key']
 ---
 
 Factory CLI supports custom model configurations through BYOK (Bring Your Own Key). Use your own OpenAI or Anthropic keys, connect to any open source model providers, or run models locally on your hardware. Once configured, switch between models using the `/model` command.

--- a/docs/cli/configuration/byok.mdx
+++ b/docs/cli/configuration/byok.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Key
 description: Connect your own API keys, use open source models, or run local models
-keywords: ['byok', 'bring your own key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted']
+keywords: ['byok', 'bring your own key', 'own api key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted', 'use own key', 'personal key', 'own key']
 ---
 
 Factory CLI supports custom model configurations through BYOK (Bring Your Own Key). Use your own OpenAI or Anthropic keys, connect to any open source model providers (like OpenRouter), or run models locally on your hardware. Once configured, switch between models using the `/model` command.

--- a/docs/web/machine-connection/factory-bridge/model-context-protocol.mdx
+++ b/docs/web/machine-connection/factory-bridge/model-context-protocol.mdx
@@ -2,7 +2,7 @@
 title: MCP with Factory Bridge
 sidebarTitle: Model Context Protocol
 description: Configure MCP servers for Factory Bridge desktop app on macOS and Windows
-keywords: ['factory bridge', 'bridge mcp', 'desktop app', 'web platform', 'mcp config file', 'mcp.json']
+keywords: ['factory bridge', 'bridge mcp']
 ---
 
 ## What is MCP?


### PR DESCRIPTION
- Update BYOK overview title to 'Bring Your Own Key (BYOK)' for better search ranking
- Differentiate Factory Bridge MCP page title and keywords
- Add more BYOK keywords to CLI pages

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>