### PR TITLE
internal seo improvements 2

### DIFF
--- a/docs/cli/byok/overview.mdx
+++ b/docs/cli/byok/overview.mdx
@@ -1,7 +1,8 @@
 ---
-title: Overview
+title: Bring Your Own Key (BYOK)
+sidebarTitle: Overview
 description: Connect your own API keys, use open source models, or run local models
-keywords: ['byok', 'bring your own key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted']
+keywords: ['byok', 'bring your own key', 'own api key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted', 'use own key', 'personal key', 'own key']
 ---
 
 Factory CLI supports custom model configurations through BYOK (Bring Your Own Key). Use your own OpenAI or Anthropic keys, connect to any open source model providers, or run models locally on your hardware. Once configured, switch between models using the `/model` command.

--- a/docs/cli/configuration/byok.mdx
+++ b/docs/cli/configuration/byok.mdx
@@ -1,7 +1,7 @@
 ---
 title: Bring Your Own Key
 description: Connect your own API keys, use open source models, or run local models
-keywords: ['byok', 'bring your own key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted']
+keywords: ['byok', 'bring your own key', 'own api key', 'api key', 'custom models', 'local models', 'open source', 'self-hosted', 'use own key', 'personal key', 'own key']
 ---
 
 Factory CLI supports custom model configurations through BYOK (Bring Your Own Key). Use your own OpenAI or Anthropic keys, connect to any open source model providers (like OpenRouter), or run models locally on your hardware. Once configured, switch between models using the `/model` command.

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Pricing"
+title: "Pricing & Models"
 description: "Model pricing in Standard Tokens"
+keywords: ['pricing', 'models', 'model id', 'model pricing', 'tokens', 'standard tokens', 'multiplier', 'cost', 'plans', 'subscription']
 ---
 
 ## Pricing Tiers
@@ -22,19 +23,17 @@ Different models have different multipliers applied to calculate Standard Token 
 
 ### Pricing Table
 
-| Model             | Multiplier |
-| ----------------- | ---------- |
-| Droid Core        | 0.25×      |
-| Claude Haiku 4.5  | 0.4×       |
-| GPT-5             | 0.5×       |
-| GPT-5-Codex       | 0.5×       |
-| GPT-5.1           | 0.5×       |
-| GPT-5.1-Codex     | 0.5×       |
-| Gemini 2.5 Pro    | 0.5×       |
-| Claude Sonnet 4   | 1.2×       |
-| Claude Sonnet 4.5 | 1.2×       |
-| Claude Opus 4.1   | 6×         |
+| Model                    | Model ID                     | Multiplier |
+| ------------------------ | ---------------------------- | ---------- |
+| Droid Core               | `glm-4.6`                    | 0.25×      |
+| Claude Haiku 4.5         | `claude-haiku-4-5-20251001`  | 0.4×       |
+| GPT-5.1                  | `gpt-5.1`                    | 0.5×       |
+| GPT-5.1-Codex            | `gpt-5.1-codex`              | 0.5×       |
+| Gemini 3 Pro             | `gemini-3-pro-preview`       | 0.8×       |
+| Claude Sonnet 4.5        | `claude-sonnet-4-5-20250929` | 1.2×       |
+| Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 1.2×       |
+| Claude Opus 4.1          | `claude-opus-4-1-20250805`   | 6×         |
 
 ## Thinking About Tokens
 
-As a reference point, using GPT-5-Codex at its 0.5× multiplier alongside our typical cache ratio of 4–8× means your effective Standard Token usage goes dramatically further than raw on-demand calls. Switching to very expensive models frequently—or rotating models often enough to invalidate the cache—will lower that benefit, but most workloads see materially higher usage ceilings compared with buying capacity directly from individual model providers. Our aim is for you to run your workloads without worrying about token math; the plans are designed so common usage patterns outperform comparable direct offerings.
+As a reference point, using GPT-5.1-Codex at its 0.5× multiplier alongside our typical cache ratio of 4–8× means your effective Standard Token usage goes dramatically further than raw on-demand calls. Switching to very expensive models frequently—or rotating models often enough to invalidate the cache—will lower that benefit, but most workloads see materially higher usage ceilings compared with buying capacity directly from individual model providers. Our aim is for you to run your workloads without worrying about token math; the plans are designed so common usage patterns outperform comparable direct offerings.

--- a/docs/web/machine-connection/factory-bridge/model-context-protocol.mdx
+++ b/docs/web/machine-connection/factory-bridge/model-context-protocol.mdx
@@ -1,6 +1,8 @@
 ---
-title: Model Context Protocol (MCP)
-description: Extend Factory's capabilities with custom tools and data sources using Model Context Protocol
+title: MCP with Factory Bridge
+sidebarTitle: Model Context Protocol
+description: Configure MCP servers for Factory Bridge desktop app on macOS and Windows
+keywords: ['factory bridge', 'bridge mcp', 'desktop app', 'web platform', 'mcp config file', 'mcp.json']
 ---
 
 ## What is MCP?

--- a/docs/web/machine-connection/factory-bridge/model-context-protocol.mdx
+++ b/docs/web/machine-connection/factory-bridge/model-context-protocol.mdx
@@ -2,7 +2,7 @@
 title: MCP with Factory Bridge
 sidebarTitle: Model Context Protocol
 description: Configure MCP servers for Factory Bridge desktop app on macOS and Windows
-keywords: ['factory bridge', 'bridge mcp', 'desktop app', 'web platform', 'mcp config file', 'mcp.json']
+keywords: ['factory bridge', 'bridge mcp']
 ---
 
 ## What is MCP?


### PR DESCRIPTION
- **docs: differentiate Factory Bridge MCP page for better CLI search ranking**
- **docs: improve search ranking for CLI BYOK and MCP pages**
- **docs: update pricing page with current models and model IDs**
