### PR TITLE
docs: add v0.27.2 feature documentation

### DIFF
--- a/docs/cli/configuration/ide-integrations.mdx
+++ b/docs/cli/configuration/ide-integrations.mdx
@@ -97,6 +97,19 @@ Factory provides two ways to work with JetBrains IDEs:
 
 Run `droid` from your IDE's integrated terminal, and all features will be active.
 
+### The `/ide` Command
+
+Use the `/ide` command within droid to manage your IDE integrations:
+
+```
+/ide
+```
+
+This command will:
+- Show the current extension version if installed
+- Prompt to install the extension if not yet installed
+- Works with VS Code, Cursor, and Windsurf
+
 ## Troubleshooting
 
 ### VS Code extension not installing

--- a/docs/cli/configuration/mcp.mdx
+++ b/docs/cli/configuration/mcp.mdx
@@ -204,7 +204,14 @@ Type `/mcp` within droid to open an interactive UI for managing MCP servers.
 
 ## Configuration
 
-MCP server configurations are stored in `~/.factory/mcp.json`. The configuration includes:
+MCP server configurations can be stored at two levels:
+
+- **User-level**: `~/.factory/mcp.json` - applies to all projects
+- **Project-level**: `.factory/mcp.json` - applies only to the current project
+
+Project-level configurations are merged with user-level configurations, allowing you to define project-specific MCP servers that are automatically available when working in that project.
+
+The configuration includes:
 
 - **Name**: Unique identifier for the server
 - **Type**: Server type (`stdio` or `http`)


### PR DESCRIPTION
Adds documentation for new features in CLI v0.27.2:

- **Project-level MCP configs**: Documents `.factory/mcp.json` for project-specific MCP server configurations
- **`/ide` command**: Documents the new command for managing VS Code, Cursor, and Windsurf IDE integrations