### PR TITLE
docs: update hooks guide and settings for v0.27.4

### DIFF
--- a/docs/cli/configuration/hooks-guide.mdx
+++ b/docs/cli/configuration/hooks-guide.mdx
@@ -8,14 +8,6 @@ Droid hooks are user-defined shell commands that execute at various points
 in Droid's lifecycle. Hooks provide deterministic control over Droid's behavior, ensuring certain actions always happen rather than relying on
 Droid to choose to run them.
 
-<Warning>
-  **Experimental Feature**: Hooks are currently experimental. To use hooks:
-  1. Run `/settings` command
-  2. Navigate to the "Hooks" setting
-  3. Toggle it from "Disabled" to "Enabled"
-  4. The `/hooks` command will become available after enabling
-</Warning>
-
 <Tip>
   For reference documentation on hooks, see [Hooks reference](/reference/hooks-reference).
 </Tip>

--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -40,6 +40,7 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 | `specSaveEnabled` | `true`, `false` | `false` | Persist spec outputs to disk. |
 | `specSaveDir` | File path | `.factory/docs` | Directory used when `specSaveEnabled` is `true`. |
 | `enableCustomDroids` | `true`, `false` | `false` | Toggle the experimental Custom Droids feature. |
+| `showThinkingInMainView` | `true`, `false` | `false` | Display AI thinking/reasoning blocks in the main chat view. |
 
 ### Model
 


### PR DESCRIPTION
- Remove experimental feature warning from hooks guide (hooks now always enabled)
- Add showThinkingInMainView setting to settings reference