### PR TITLE
docs: move cookbooks from Features to Guides section

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,17 +106,9 @@
                 "pages": [
                   "cli/configuration/skills",
                   {
-                    "group": "Cookbook",
-                    "pages": [
-                      "cli/configuration/skills/frontend-ui-integration",
-                      "cli/configuration/skills/service-integration",
-                      "cli/configuration/skills/data-querying",
-                      "cli/configuration/skills/internal-tools",
-                      "cli/configuration/skills/vibe-coding",
-                      "cli/configuration/skills/ai-data-analyst",
-                      "cli/configuration/skills/product-management",
-                      "cli/configuration/skills/browser"
-                    ]
+                    "icon": "arrow-up-right-from-square",
+                    "title": "Cookbook",
+                    "href": "/guides/cookbooks/skills/frontend-ui-integration"
                   }
                 ]
               },
@@ -127,17 +119,9 @@
                 "pages": [
                   "cli/configuration/hooks-guide",
                   {
-                    "group": "Cookbook",
-                    "pages": [
-                      "cli/configuration/hooks/auto-formatting",
-                      "cli/configuration/hooks/code-validation",
-                      "cli/configuration/hooks/documentation-sync",
-                      "cli/configuration/hooks/git-workflows",
-                      "cli/configuration/hooks/logging-analytics",
-                      "cli/configuration/hooks/notifications",
-                      "cli/configuration/hooks/session-automation",
-                      "cli/configuration/hooks/testing-automation"
-                    ]
+                    "icon": "arrow-up-right-from-square",
+                    "title": "Cookbook",
+                    "href": "/guides/cookbooks/hooks/auto-formatting"
                   }
                 ]
               },
@@ -146,14 +130,9 @@
                 "pages": [
                   "cli/droid-exec/overview",
                   {
-                    "group": "Cookbook",
-                    "pages": [
-                      "cli/droid-exec/cookbook/code-review",
-                      "cli/droid-exec/cookbook/refactor-imports",
-                      "cli/droid-exec/cookbook/refactor-error-messages",
-                      "cli/droid-exec/cookbook/refactor-fix-lint",
-                      "cli/droid-exec/cookbook/document-automation"
-                    ]
+                    "icon": "arrow-up-right-from-square",
+                    "title": "Cookbook",
+                    "href": "/guides/cookbooks/droid-exec/code-review"
                   }
                 ]
               }
@@ -233,6 +212,47 @@
             "pages": [
               "guides/building/droid-exec-tutorial",
               "guides/building/droid-vps-setup"
+            ]
+          },
+          {
+            "group": "Cookbooks",
+            "pages": [
+              {
+                "group": "Droid Exec",
+                "pages": [
+                  "cli/droid-exec/cookbook/code-review",
+                  "cli/droid-exec/cookbook/refactor-imports",
+                  "cli/droid-exec/cookbook/refactor-error-messages",
+                  "cli/droid-exec/cookbook/refactor-fix-lint",
+                  "cli/droid-exec/cookbook/document-automation"
+                ]
+              },
+              {
+                "group": "Skills",
+                "pages": [
+                  "cli/configuration/skills/frontend-ui-integration",
+                  "cli/configuration/skills/service-integration",
+                  "cli/configuration/skills/data-querying",
+                  "cli/configuration/skills/internal-tools",
+                  "cli/configuration/skills/vibe-coding",
+                  "cli/configuration/skills/ai-data-analyst",
+                  "cli/configuration/skills/product-management",
+                  "cli/configuration/skills/browser"
+                ]
+              },
+              {
+                "group": "Hooks",
+                "pages": [
+                  "cli/configuration/hooks/auto-formatting",
+                  "cli/configuration/hooks/code-validation",
+                  "cli/configuration/hooks/documentation-sync",
+                  "cli/configuration/hooks/git-workflows",
+                  "cli/configuration/hooks/logging-analytics",
+                  "cli/configuration/hooks/notifications",
+                  "cli/configuration/hooks/session-automation",
+                  "cli/configuration/hooks/testing-automation"
+                ]
+              }
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -108,7 +108,7 @@
                   {
                     "icon": "arrow-up-right-from-square",
                     "title": "Cookbook",
-                    "href": "/guides/cookbooks/skills/frontend-ui-integration"
+                    "href": "/cli/configuration/skills/frontend-ui-integration"
                   }
                 ]
               },
@@ -121,7 +121,7 @@
                   {
                     "icon": "arrow-up-right-from-square",
                     "title": "Cookbook",
-                    "href": "/guides/cookbooks/hooks/auto-formatting"
+                    "href": "/cli/configuration/hooks/auto-formatting"
                   }
                 ]
               },
@@ -132,7 +132,7 @@
                   {
                     "icon": "arrow-up-right-from-square",
                     "title": "Cookbook",
-                    "href": "/guides/cookbooks/droid-exec/code-review"
+                    "href": "/cli/droid-exec/cookbook/code-review"
                   }
                 ]
               }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -278,16 +278,7 @@
     "light": "/logo/light.png",
     "dark": "/logo/dark.svg"
   },
-  "topbarLinks": [
-    {
-      "name": "Guides",
-      "url": "/guides/building/droid-exec-tutorial"
-    },
-    {
-      "name": "Changelog",
-      "url": "/changelog/1-9"
-    }
-  ],
+  "topbarLinks": [],
   "navbar": {
     "links": []
   },


### PR DESCRIPTION
## Summary
Move cookbook navigation from Features sidebar to Guides tab for better organization.

## Changes
- Added new "Cookbooks" group in Guides tab with expandable subgroups for Droid Exec, Skills, and Hooks
- Replaced cookbook dropdown menus in Features section with external link icons that redirect to the Guides cookbooks section