### PR TITLE
feat: add docs sync workflow from factory-mono

### DIFF
--- a/.github/workflows/changelog-automation.yml
+++ b/.github/workflows/changelog-automation.yml
@@ -1,0 +1,154 @@
+name: Changelog Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_pr_number:
+        description: 'Release PR number from factory-mono'
+        required: true
+        type: string
+      release_pr_title:
+        description: 'Release PR title'
+        required: true
+        type: string
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get release PR details
+        id: release-info
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_MONO_PAT }}
+        run: |
+          echo "Fetching PR #${{ inputs.release_pr_number }} from factory-mono..."
+          
+          PR_BODY=$(gh pr view ${{ inputs.release_pr_number }} \
+            --repo Factory-AI/factory-mono \
+            --json body \
+            --jq '.body')
+          
+          echo "$PR_BODY" > release_pr_body.txt
+          echo "pr_title=${{ inputs.release_pr_title }}" >> $GITHUB_OUTPUT
+
+      - name: Setup droid CLI
+        run: |
+          curl -fsSL https://app.factory.ai/cli | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Generate changelog entry
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          PR_BODY=$(cat release_pr_body.txt)
+          
+          droid exec --auto low "
+          You are creating a changelog entry for the Factory CLI.
+          
+          Release PR #${{ inputs.release_pr_number }}: ${{ inputs.release_pr_title }}
+          
+          PR Body:
+          $PR_BODY
+          
+          STRICT RULES - VIOLATIONS MUST BLOCK ALL CHANGES:
+          1. Only include CLI/TUI changes - ignore web app, desktop, infrastructure
+          2. NEVER include anything behind a feature flag
+          3. Search for these patterns to identify feature-flagged items:
+             - featureFlag, feature_flag, FF_, FEATURE_FLAG
+             - isEnabled, flagEnabled, isFeatureEnabled
+             - 'behind flag', 'feature gated', 'gated behind'
+          4. If a PR item mentions ANY of these patterns, EXCLUDE it completely
+          5. Check that features are merged to main (not just dev branch)
+          6. If uncertain whether something is feature-flagged, EXCLUDE it
+          
+          Tasks:
+          1. First, write changelog-audit.md (gitignored) with:
+             - ALL items from the release PR
+             - Mark each as INCLUDED or EXCLUDED
+             - For excluded items, explain WHY (feature flag, non-CLI, etc.)
+             - This file is for internal review only and won't be committed
+          
+          2. Extract version number from the release title (e.g., 'Release 1.3.XXX' -> v1.3.XXX)
+          
+          3. Identify ONLY non-flagged CLI/TUI Improvements and CLI Fixes
+          
+          4. Open docs/changelog/cli-updates.mdx and add a new <Update> block at the TOP (after frontmatter):
+          
+          <Update label=\"<Month Day>\" rss={{ title: \"CLI Updates\", description: \"<brief summary>\" }}>
+            \`vX.X.X\`
+            
+            ## New features
+            
+            * **Feature name** - Description of the feature
+            
+            ## Bug fixes
+            
+            * Fixed issue description
+          </Update>
+          
+          5. Write changelog-summary.md with:
+             - Version number
+             - Count of items included vs excluded
+             - List of features added (public safe)
+             - List of fixes added (public safe)
+          
+          DO NOT commit or push changes.
+          DO NOT include changelog-audit.md in any commits.
+          "
+
+      - name: Check for feature flag violations
+        run: |
+          # Check the changelog file for any feature flag patterns
+          if grep -rqE "featureFlag|feature_flag|FF_|FEATURE_FLAG|isEnabled|flagEnabled|isFeatureEnabled|behind.flag|feature.gated" docs/changelog/cli-updates.mdx 2>/dev/null; then
+            echo "::error::Feature flag references detected in changelog!"
+            exit 1
+          fi
+          
+          # Also check for any internal codenames or sensitive patterns
+          if grep -rqE "internal|beta.only|experimental.flag" docs/changelog/cli-updates.mdx 2>/dev/null; then
+            echo "::warning::Potentially sensitive content detected - please review"
+          fi
+
+      - name: Create PR if changes exist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "$(git status --porcelain docs/changelog/)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            BRANCH="changelog-$(date +%Y%m%d-%H%M%S)"
+            git checkout -b $BRANCH
+            
+            # Only add the changelog file, NOT audit files
+            git add docs/changelog/cli-updates.mdx
+            git commit -m "docs: add CLI changelog for ${{ inputs.release_pr_title }}"
+            git push origin $BRANCH
+            
+            # Use summary for PR body (audit file stays local)
+            SUMMARY=$(cat changelog-summary.md 2>/dev/null || echo "Changelog entry created from factory-mono release.")
+            
+            gh pr create \
+              --title "Changelog: ${{ inputs.release_pr_title }}" \
+              --body "## Changelog Entry
+
+          Generated from factory-mono PR #${{ inputs.release_pr_number }}
+
+          $SUMMARY
+
+          ### Review Checklist
+          - [ ] Version number is correct
+          - [ ] Only CLI/TUI changes included
+          - [ ] No feature-flagged items
+          - [ ] Formatting matches existing entries"
+          else
+            echo "No changelog changes generated"
+          fi

--- a/.github/workflows/sync-docs-from-mono.yml
+++ b/.github/workflows/sync-docs-from-mono.yml
@@ -25,12 +25,13 @@ jobs:
       - name: Sync documentation
         env:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+          PAYLOAD_CHANGES: ${{ github.event.client_payload.changes }}
         run: |
           droid exec --auto low "
           You are syncing public documentation from our private codebase.
           
           Payload from factory-mono:
-          ${{ github.event.client_payload.changes }}
+          $PAYLOAD_CHANGES
           
           STRICT RULES - VIOLATIONS MUST BLOCK ALL CHANGES:
           1. NEVER document anything behind a feature flag
@@ -54,7 +55,7 @@ jobs:
 
       - name: Check for feature flag violations
         run: |
-          if grep -rq "feature.flag\|featureFlag\|FF_\|FEATURE_FLAG" --include="*.md" --include="*.mdx" docs/ 2>/dev/null; then
+          if grep -rqE "featureFlag|feature_flag|FF_|FEATURE_FLAG|isEnabled|flagEnabled" --include="*.md" --include="*.mdx" docs/ 2>/dev/null; then
             echo "::error::Feature flag references detected in docs!"
             exit 1
           fi

--- a/.github/workflows/sync-docs-from-mono.yml
+++ b/.github/workflows/sync-docs-from-mono.yml
@@ -1,12 +1,19 @@
 name: Sync Docs from Factory Mono
 
 on:
-  repository_dispatch:
-    types: [docs-sync]
+  workflow_run:
+    workflows: ["Changelog Automation"]
+    types: [completed]
   workflow_dispatch:
+    inputs:
+      release_pr_number:
+        description: 'Release PR number from factory-mono (optional for manual trigger)'
+        required: false
+        type: string
 
 jobs:
   sync-docs:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -17,6 +24,40 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get release info
+        id: release-info
+        env:
+          GH_TOKEN: ${{ secrets.FACTORY_MONO_PAT }}
+        run: |
+          # For workflow_run, get the most recent merged release PR
+          # For workflow_dispatch, use input or most recent
+          PR_NUM="${{ inputs.release_pr_number }}"
+          
+          if [ -z "$PR_NUM" ]; then
+            echo "Finding most recent release PR..."
+            RELEASE_PR=$(gh pr list \
+              --repo Factory-AI/factory-mono \
+              --state merged \
+              --search "Release in:title" \
+              --json number,title,body \
+              --limit 1)
+            
+            PR_NUM=$(echo "$RELEASE_PR" | jq -r '.[0].number')
+            PR_TITLE=$(echo "$RELEASE_PR" | jq -r '.[0].title')
+          else
+            PR_TITLE=$(gh pr view $PR_NUM --repo Factory-AI/factory-mono --json title --jq '.title')
+          fi
+          
+          echo "Processing release PR #$PR_NUM: $PR_TITLE"
+          
+          gh pr view $PR_NUM \
+            --repo Factory-AI/factory-mono \
+            --json body \
+            --jq '.body' > release_info.txt
+          
+          echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+
       - name: Setup droid CLI
         run: |
           curl -fsSL https://app.factory.ai/cli | sh
@@ -25,13 +66,14 @@ jobs:
       - name: Sync documentation
         env:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          PAYLOAD_CHANGES: ${{ github.event.client_payload.changes }}
         run: |
-          droid exec --auto low "
-          You are syncing public documentation from our private codebase.
+          RELEASE_INFO=$(cat release_info.txt)
           
-          Payload from factory-mono:
-          $PAYLOAD_CHANGES
+          droid exec --auto low "
+          You are syncing public documentation based on release PRs merged in factory-mono.
+          
+          Release PRs merged:
+          $RELEASE_INFO
           
           STRICT RULES - VIOLATIONS MUST BLOCK ALL CHANGES:
           1. NEVER document anything behind a feature flag
@@ -41,7 +83,7 @@ jobs:
           5. Settings must reflect current shipped behavior only
           
           Tasks:
-          1. Review the payload for what changed
+          1. Review the release PR descriptions for what changed
           2. Search docs/ for files referencing changed APIs/settings/models
           3. Update documentation to match current production state
           4. Verify all code examples are accurate
@@ -54,6 +96,7 @@ jobs:
           "
 
       - name: Check for feature flag violations
+        if: steps.check-releases.outputs.has_releases == 'true' && steps.check-processed.outputs.should_process == 'true'
         run: |
           if grep -rqE "featureFlag|feature_flag|FF_|FEATURE_FLAG|isEnabled|flagEnabled" --include="*.md" --include="*.mdx" docs/ 2>/dev/null; then
             echo "::error::Feature flag references detected in docs!"
@@ -61,6 +104,7 @@ jobs:
           fi
 
       - name: Create PR if changes exist
+        if: steps.check-releases.outputs.has_releases == 'true' && steps.check-processed.outputs.should_process == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -68,17 +112,20 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             
+            PR_NUMS="${{ steps.check-releases.outputs.pr_numbers }}"
             BRANCH="docs/sync-from-mono-$(date +%Y%m%d-%H%M%S)"
             git checkout -b $BRANCH
             git add docs/
-            git commit -m "docs: sync documentation from factory-mono"
+            git commit -m "docs: sync from factory-mono PR #${PR_NUMS}"
             git push origin $BRANCH
             
             SUMMARY=$(cat doc-audit-summary.md 2>/dev/null || echo "Documentation synced from factory-mono release.")
             
             gh pr create \
-              --title "Sync docs from factory-mono" \
+              --title "Sync docs from factory-mono PR #${PR_NUMS}" \
               --body "## Documentation Sync
+
+          Triggered by merged release PR(s) in factory-mono: #${PR_NUMS}
 
           $SUMMARY
 

--- a/.github/workflows/sync-docs-from-mono.yml
+++ b/.github/workflows/sync-docs-from-mono.yml
@@ -1,0 +1,91 @@
+name: Sync Docs from Factory Mono
+
+on:
+  repository_dispatch:
+    types: [docs-sync]
+  workflow_dispatch:
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup droid CLI
+        run: |
+          curl -fsSL https://app.factory.ai/cli | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Sync documentation
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          droid exec --auto low "
+          You are syncing public documentation from our private codebase.
+          
+          Payload from factory-mono:
+          ${{ github.event.client_payload.changes }}
+          
+          STRICT RULES - VIOLATIONS MUST BLOCK ALL CHANGES:
+          1. NEVER document anything behind a feature flag
+          2. Search for: featureFlag, feature_flag, FF_, isEnabled, flagEnabled
+          3. If you find ANY feature-flagged content, STOP and write ONLY to doc-audit-summary.md explaining what was blocked
+          4. Models in docs must match exactly what's in production
+          5. Settings must reflect current shipped behavior only
+          
+          Tasks:
+          1. Review the payload for what changed
+          2. Search docs/ for files referencing changed APIs/settings/models
+          3. Update documentation to match current production state
+          4. Verify all code examples are accurate
+          5. Write doc-audit-summary.md with:
+             - Files updated and why
+             - Any feature-flagged content you REJECTED
+             - Anything needing human review
+          
+          DO NOT commit or push changes.
+          "
+
+      - name: Check for feature flag violations
+        run: |
+          if grep -rq "feature.flag\|featureFlag\|FF_\|FEATURE_FLAG" --include="*.md" --include="*.mdx" docs/ 2>/dev/null; then
+            echo "::error::Feature flag references detected in docs!"
+            exit 1
+          fi
+
+      - name: Create PR if changes exist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "$(git status --porcelain docs/)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            
+            BRANCH="docs/sync-from-mono-$(date +%Y%m%d-%H%M%S)"
+            git checkout -b $BRANCH
+            git add docs/
+            git commit -m "docs: sync documentation from factory-mono"
+            git push origin $BRANCH
+            
+            SUMMARY=$(cat doc-audit-summary.md 2>/dev/null || echo "Documentation synced from factory-mono release.")
+            
+            gh pr create \
+              --title "Sync docs from factory-mono" \
+              --body "## Documentation Sync
+
+          $SUMMARY
+
+          ### Review Checklist
+          - [ ] No feature-flagged content included
+          - [ ] Models match production
+          - [ ] Examples are accurate
+          - [ ] No internal/sensitive information exposed"
+          else
+            echo "No documentation changes needed"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# Automation audit files (contain sensitive internal info)
 doc-audit-summary.md
+changelog-audit.md
+changelog-summary.md
+release_pr_body.txt
+release_info.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc-audit-summary.md


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically syncs documentation from the private factory-mono repo when releases are merged.

## Features

- **Trigger**: `repository_dispatch` from factory-mono (type: `docs-sync`)
- **Manual trigger**: `workflow_dispatch` for testing
- **Droid exec**: Analyzes payload and updates relevant docs
- **Feature flag protection**: Strict rules in prompt + grep safety check
- **Human review**: Creates PR for review, never auto-merges

## How it works

1. factory-mono release merges → triggers `repository_dispatch` with payload
2. Droid analyzes payload, searches docs/, makes updates
3. Grep check validates no feature flags in changes
4. PR created for human review

## To trigger from factory-mono

```bash
gh api repos/Factory-AI/factory/dispatches \
  -f event_type=docs-sync \
  -f client_payload[changes]="<summary of changes>"
```

## Files changed

- `.github/workflows/sync-docs-from-mono.yml` - new workflow
- `.gitignore` - added `doc-audit-summary.md` to prevent audit file from being committed