### PR TITLE
fix: set canonical URL to docs.factory.ai for SEO

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -282,6 +282,11 @@
   "contextual": {
     "options": ["copy", "view", "chatgpt", "claude"]
   },
+  "seo": {
+    "metatags": {
+      "canonical": "https://docs.factory.ai"
+    }
+  },
   "integrations": {
     "mixpanel": {
       "projectToken": "f2846cc5dfc8931eb2d1e98383a748e5"


### PR DESCRIPTION
Fixes the canonical URL in docs to point to `https://docs.factory.ai` instead of the default Mintlify subdomain (`factory.mintlify.app`).

This improves SEO by ensuring search engines index the correct custom domain and prevents duplicate content issues.