### PR TITLE
docs: update droid exec CLI options and models

### DIFF
--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -75,6 +75,10 @@ Supported models (examples):
 - claude-haiku-4-5-20251001
 - glm-4.6
 
+<Note>
+See the [model table](/pricing#pricing-table) for the full list of available models and their costs.
+</Note>
+
 ## Installation
 
 <Steps>
@@ -331,7 +335,7 @@ droid exec --cwd /home/runner/work/repo "Map internal packages and dump graphviz
 
 ## Models and reasoning effort
 
-Choose a model with `-m` and adjust reasoning with `-r`:
+Choose a model with `-m` and adjust reasoning with `-r`. See the [model table](/pricing#pricing-table) for available models.
 
 ```bash
 droid exec -m claude-sonnet-4-5-20250929 -r medium -f plan.md

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -46,26 +46,34 @@ Usage: droid exec [options] [prompt]
 Execute a single command (non-interactive mode)
 
 Arguments:
-  prompt                          The prompt to execute
+  prompt                            The prompt to execute
 
 Options:
-  -o, --output-format <format>    Output format (default: "text")
-  -f, --file <path>               Read prompt from file
-  --auto <level>                  Autonomy level: low|medium|high
-  --skip-permissions-unsafe       Skip ALL permission checks (unsafe)
-  -s, --session-id <id>           Existing session to continue (requires a prompt)
-  -m, --model <id>                Model ID to use
-  -r, --reasoning-effort <level>  Reasoning effort: off|low|medium|high
-  --cwd <path>                    Working directory path
-  -h, --help                      display help for command
+  -o, --output-format <format>      Output format: text|json|stream-json (default: "text")
+  --input-format <format>           Input format: stream-json|stream-jsonrpc for multi-turn
+  -f, --file <path>                 Read prompt from file
+  --auto <level>                    Autonomy level: low|medium|high
+  --skip-permissions-unsafe         Skip ALL permission checks (unsafe)
+  -s, --session-id <id>             Existing session to continue (requires a prompt)
+  -m, --model <id>                  Model ID to use
+  -r, --reasoning-effort <level>    Reasoning effort: none|off|low|medium|high
+  --spec-model <id>                 Model ID to use for spec mode
+  --use-spec                        Start in specification mode
+  --enabled-tools <ids>             Enable specific tools (comma or space separated)
+  --disabled-tools <ids>            Disable specific tools (comma or space separated)
+  --list-tools                      List available tools and exit
+  --cwd <path>                      Working directory path
+  -h, --help                        display help for command
 ```
 
 Supported models (examples):
 
 - gpt-5-codex (default)
 - gpt-5-2025-08-07
-- claude-sonnet-4-20250514
+- claude-sonnet-4-5-20250929
 - claude-opus-4-1-20250805
+- claude-haiku-4-5-20251001
+- glm-4.6
 
 ## Installation
 
@@ -261,6 +269,20 @@ $ droid exec "run ls command" --output-format stream-json
 The `debug` format is a deprecated alias for `stream-json` and works identically.
 </Note>
 
+### stream-jsonrpc (multi-turn)
+For SDK integration and multi-turn conversations, use the JSON-RPC streaming protocol:
+
+```bash
+droid exec --input-format stream-jsonrpc --output-format stream-jsonrpc --auto low
+```
+
+This mode reads JSONL messages from stdin and outputs JSON-RPC formatted responses, enabling:
+- Multi-turn conversations within a single exec invocation
+- Dynamic mode switching during execution
+- Full tool access like the interactive TUI
+
+Send messages via stdin in JSONL format and receive structured JSON-RPC responses.
+
 Key event types:
 - **system** - Session initialization with available tools and model
 - **message** - User or assistant text messages
@@ -312,7 +334,38 @@ droid exec --cwd /home/runner/work/repo "Map internal packages and dump graphviz
 Choose a model with `-m` and adjust reasoning with `-r`:
 
 ```bash
-droid exec -m claude-sonnet-4-20250514 -r medium -f plan.md
+droid exec -m claude-sonnet-4-5-20250929 -r medium -f plan.md
+```
+
+Use `--use-spec` to start in specification mode, where the agent plans before executing:
+
+```bash
+droid exec --use-spec --auto low "refactor the auth module"
+```
+
+You can also use a different model for the spec phase:
+
+```bash
+droid exec --use-spec --spec-model claude-haiku-4-5-20251001 --auto medium "implement feature X"
+```
+
+### Tool controls
+
+List available tools for a model:
+
+```bash
+droid exec --list-tools
+droid exec --model gpt-5-codex --list-tools --output-format json
+```
+
+Enable or disable specific tools:
+
+```bash
+# Enable additional tools
+droid exec --enabled-tools ApplyPatch "refactor files"
+
+# Disable specific tools
+droid exec --auto medium --disabled-tools execute-cli "run edits only"
 ```
 
 ### Custom models

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -68,11 +68,13 @@ Options:
 
 Supported models (examples):
 
-- gpt-5-codex (default)
-- gpt-5-2025-08-07
+- gpt-5.1-codex (default)
+- gpt-5.1
 - claude-sonnet-4-5-20250929
+- claude-opus-4-5-20251101
 - claude-opus-4-1-20250805
 - claude-haiku-4-5-20251001
+- gemini-3-pro-preview
 - glm-4.6
 
 <Note>

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -68,12 +68,11 @@ Options:
 
 Supported models (examples):
 
-- gpt-5.1-codex (default)
-- gpt-5.1
+- claude-opus-4-5-20251101 (default)
 - claude-sonnet-4-5-20250929
-- claude-opus-4-5-20251101
-- claude-opus-4-1-20250805
 - claude-haiku-4-5-20251001
+- gpt-5.1-codex
+- gpt-5.1
 - gemini-3-pro-preview
 - glm-4.6
 

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -46,24 +46,24 @@ Usage: droid exec [options] [prompt]
 Execute a single command (non-interactive mode)
 
 Arguments:
-  prompt                            The prompt to execute
+  prompt                          The prompt to execute
 
 Options:
-  -o, --output-format <format>      Output format: text|json|stream-json (default: "text")
-  --input-format <format>           Input format: stream-json|stream-jsonrpc for multi-turn
-  -f, --file <path>                 Read prompt from file
-  --auto <level>                    Autonomy level: low|medium|high
-  --skip-permissions-unsafe         Skip ALL permission checks (unsafe)
-  -s, --session-id <id>             Existing session to continue (requires a prompt)
-  -m, --model <id>                  Model ID to use
-  -r, --reasoning-effort <level>    Reasoning effort: none|off|low|medium|high
-  --spec-model <id>                 Model ID to use for spec mode
-  --use-spec                        Start in specification mode
-  --enabled-tools <ids>             Enable specific tools (comma or space separated)
-  --disabled-tools <ids>            Disable specific tools (comma or space separated)
-  --list-tools                      List available tools and exit
-  --cwd <path>                      Working directory path
-  -h, --help                        display help for command
+  -o, --output-format <format>    Output format (default: "text")
+  --input-format <format>         Input format: stream-json for multi-turn sessions
+  -f, --file <path>               Read prompt from file
+  --auto <level>                  Autonomy level: low|medium|high
+  --skip-permissions-unsafe       Skip ALL permission checks - allows all permissions (unsafe)
+  -s, --session-id <id>           Existing session to continue (requires a prompt)
+  -m, --model <id>                Model ID to use
+  -r, --reasoning-effort <level>  Reasoning effort (defaults per model)
+  --spec-model <id>               Model ID to use for spec mode
+  --use-spec                      Start in spec mode
+  --enabled-tools <ids>           Enable specific tools (comma or space separated list)
+  --disabled-tools <ids>          Disable specific tools (comma or space separated list)
+  --list-tools                    List available tools for the selected model and exit
+  --cwd <path>                    Working directory path
+  -h, --help                      display help for command
 ```
 
 Supported models (examples):

--- a/docs/guides/building/droid-exec-tutorial.mdx
+++ b/docs/guides/building/droid-exec-tutorial.mdx
@@ -107,7 +107,7 @@ function runDroidExec(prompt: string, repoPath: string) {
 **`-m` (model)**: Choose your AI model
 - `glm-4.6` - Fast, cheap (default)
 - `gpt-5-codex` - Most powerful for complex code
-- `claude-sonnet-4-5` - Best balance of speed and capability
+- `claude-sonnet-4-5-20250929` - Best balance of speed and capability
 
 **`-r` (reasoning)**: Control thinking depth
 - `off` - No reasoning, fastest

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -38,25 +38,26 @@ The CLI operates in two modes:
 
 Customize droid's behavior with command-line flags:
 
-| Flag                             | Description                                                                                                  | Example                                                  |
-| :------------------------------- | :----------------------------------------------------------------------------------------------------------- | :------------------------------------------------------- |
-| `-f, --file <path>`              | Read prompt from a file                                                                                      | `droid exec -f plan.md`                                  |
-| `-m, --model <id>`               | Select a specific model (see [model IDs](#available-models))                                                 | `droid exec -m claude-opus-4-1-20250805`                 |
-| `-s, --session-id <id>`          | Continue an existing session                                                                                 | `droid exec -s session-abc123`                           |
-| `--auto <level>`                 | Set [autonomy level](#autonomy-levels) (`low`, `medium`, `high`)                                             | `droid exec --auto medium "run tests"`                   |
-| `--enabled-tools <ids>`          | Force-enable specific tools (comma or space separated)                                                       | `droid exec --enabled-tools ApplyPatch,Bash`             |
-| `--disabled-tools <ids>`         | Disable specific tools for this run                                                                          | `droid exec --disabled-tools execute-cli`                |
-| `--list-tools`                   | Print available tools and exit                                                                               | `droid exec --list-tools`                                |
-| `-o, --output-format <format>`   | Output format (`text`, `json`, `stream-json`)                                                                | `droid exec -o json "document API"`                      |
-| `--input-format <format>`        | Input format (`stream-json` for multi-turn)                                                                  | `droid exec --input-format stream-json -o stream-json`   |
-| `-r, --reasoning-effort <level>` | Override reasoning effort (`off`, `none`, `low`, `medium`, `high`)                                           | `droid exec -r high "debug flaky test"`                  |
-| `--spec-model <id>`              | Use a different model for specification planning                                                             | `droid exec --spec-model claude-sonnet-4-5-20250929`     |
-| `--use-spec`                     | Start in specification mode (plan before executing)                                                          | `droid exec --use-spec "add user profiles"`              |
-| `--skip-permissions-unsafe`      | Skip all permission prompts (⚠️ use with extreme caution)                                                    | `droid exec --skip-permissions-unsafe`                   |
-| `--cwd <path>`                   | Execute from a specific working directory                                                                    | `droid exec --cwd ../service "run tests"`                |
-| `--delegation-url <url>`         | Override delegation service endpoint                                                                         | `droid exec --delegation-url https://custom.factory.ai`  |
-| `-v, --version`                  | Display CLI version                                                                                          | `droid -v`                                               |
-| `-h, --help`                     | Show help information                                                                                        | `droid --help`                                           |
+| Flag                                 | Description                                                                                                  | Example                                                    |
+| :----------------------------------- | :----------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------- |
+| `-f, --file <path>`                  | Read prompt from a file                                                                                      | `droid exec -f plan.md`                                    |
+| `-m, --model <id>`                   | Select a specific model (see [model IDs](#available-models))                                                 | `droid exec -m claude-opus-4-1-20250805`                   |
+| `-s, --session-id <id>`              | Continue an existing session                                                                                 | `droid exec -s session-abc123`                             |
+| `--auto <level>`                     | Set [autonomy level](#autonomy-levels) (`low`, `medium`, `high`)                                             | `droid exec --auto medium "run tests"`                     |
+| `--enabled-tools <ids>`              | Force-enable specific tools (comma or space separated)                                                       | `droid exec --enabled-tools ApplyPatch,Bash`               |
+| `--disabled-tools <ids>`             | Disable specific tools for this run                                                                          | `droid exec --disabled-tools execute-cli`                  |
+| `--list-tools`                       | Print available tools and exit                                                                               | `droid exec --list-tools`                                  |
+| `-o, --output-format <format>`       | Output format (`text`, `json`, `stream-json`, `stream-jsonrpc`)                                              | `droid exec -o json "document API"`                        |
+| `--input-format <format>`            | Input format (`stream-json`, `stream-jsonrpc` for multi-turn)                                                | `droid exec --input-format stream-jsonrpc -o stream-jsonrpc` |
+| `-r, --reasoning-effort <level>`     | Override reasoning effort (`off`, `none`, `low`, `medium`, `high`)                                           | `droid exec -r high "debug flaky test"`                    |
+| `--spec-model <id>`                  | Use a different model for specification planning                                                             | `droid exec --spec-model claude-sonnet-4-5-20250929`       |
+| `--spec-reasoning-effort <level>`    | Override reasoning effort for spec mode                                                                      | `droid exec --use-spec --spec-reasoning-effort high`       |
+| `--use-spec`                         | Start in specification mode (plan before executing)                                                          | `droid exec --use-spec "add user profiles"`                |
+| `--skip-permissions-unsafe`          | Skip all permission prompts (⚠️ use with extreme caution)                                                    | `droid exec --skip-permissions-unsafe`                     |
+| `--cwd <path>`                       | Execute from a specific working directory                                                                    | `droid exec --cwd ../service "run tests"`                  |
+| `--delegation-url <url>`             | URL for delegated sessions (Slack thread or Linear issue)                                                    | `droid exec --delegation-url <slack-or-linear-url>`        |
+| `-v, --version`                      | Display CLI version                                                                                          | `droid -v`                                                 |
+| `-h, --help`                         | Show help information                                                                                        | `droid --help`                                             |
 
 <Tip>
   Use `--output-format json` for scripting and automation, allowing you to parse droid's responses programmatically.


### PR DESCRIPTION
Updates droid exec documentation with:

- Add missing CLI options: --input-format, --spec-model, --use-spec, --spec-reasoning-effort, --enabled-tools, --disabled-tools, --list-tools
- Update model list with current models (claude-sonnet-4-5-20250929, claude-haiku-4-5-20251001, glm-4.6)
- Add stream-jsonrpc output format documentation
- Update reasoning effort values to include 'none'
- Add tool controls section with examples
- Fix delegation-url description
- Update model name in droid-exec-tutorial to full ID