### PR TITLE
docs: update opus 4.5 multiplier to 2x

### DIFF
--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -32,7 +32,7 @@ Different models have different multipliers applied to calculate Standard Token 
 | GPT-5.1-Codex-Max        | `gpt-5.1-codex-max`          | 0.5×       |
 | Gemini 3 Pro             | `gemini-3-pro-preview`       | 0.8×       |
 | Claude Sonnet 4.5        | `claude-sonnet-4-5-20250929` | 1.2×       |
-| Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 1.2×       |
+| Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 2×         |
 | Claude Opus 4.1          | `claude-opus-4-1-20250805`   | 6×         |
 
 ## Thinking About Tokens


### PR DESCRIPTION
## Summary
- update Claude Opus 4.5 pricing multiplier to 2× in pricing docs

## Testing
- not run (docs-only change)