### PR TITLE
docs: add CLI v0.33.0 changelog entry

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,12 +4,23 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="December 8" rss={{ title: "CLI Updates", description: "Autonomy mode fixes and file handling improvements" }}>
+  `v0.33.0`
+
+  ## Bug fixes
+
+  * Fixed autonomy mode not being properly set on tool confirmations
+  * Improved @-tagged file truncation by character count to prevent context overflow
+  * Updated Opus 4.5 pricing with dismissable notice
+  * Restored Figma MCP server to the registry
+
+</Update>
+
 <Update label="December 5" rss={{ title: "CLI Updates", description: "Readiness report command, ESC key improvements, and input fixes" }}>
   `v0.32.0`
 
   ## Bug fixes
 
-  * Press ESC to close the expanded tool result view
   * Press ESC to close the expanded tool result view
   * Improved input box cursor up/down movement with wrapped lines
   * Fixed Windows pasting issues


### PR DESCRIPTION
Adds changelog entry for CLI v0.33.0 (December 8).

## Changes
- Fixed autonomy mode not being properly set on tool confirmations
- Improved @-tagged file truncation by character count to prevent context overflow
- Updated Opus 4.5 pricing with dismissable notice
- Restored Figma MCP server to the registry

Also fixes duplicate ESC line in v0.32.0 entry.