### PR TITLE
fix: update changelog topbar link to cli-updates

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -262,7 +262,7 @@
     },
     {
       "name": "Changelog",
-      "url": "/changelog/1-9"
+      "url": "/changelog/cli-updates"
     }
   ],
   "navbar": {


### PR DESCRIPTION
Updates the topbar Changelog link to point to `/changelog/cli-updates` instead of `/changelog/1-9`.

This ensures the topbar links to the RSS-enabled CLI updates page rather than the release notes.