### PR TITLE
docs: add Homebrew installation option

### DIFF
--- a/docs/cli/getting-started/quickstart.mdx
+++ b/docs/cli/getting-started/quickstart.mdx
@@ -21,6 +21,10 @@ Make sure you have:
 curl -fsSL https://app.factory.ai/cli | sh
 ```
 
+```bash Homebrew
+brew install --cask droid
+```
+
 ```powershell Windows
 irm https://app.factory.ai/cli/windows | iex
 ```


### PR DESCRIPTION
Adds Homebrew as an installation option in the quickstart guide.

```bash
brew install --cask droid
```

Reference: https://formulae.brew.sh/cask/droid