### PR TITLE
ci: add GitHub Action to create Linear tickets from changelog

### DIFF
--- a/.github/workflows/changelog-to-linear.yml
+++ b/.github/workflows/changelog-to-linear.yml
@@ -53,6 +53,10 @@ jobs:
           const { LINEAR_API_KEY, LINEAR_TEAM_ID, LINEAR_ASSIGNEE_ID, LINEAR_PROJECT_ID, LINEAR_LABEL_ID, CHANGELOG_FILE } = process.env;
 
           function parseChangelog(filePath) {
+            if (!filePath || !fs.existsSync(filePath)) {
+              console.error(`Changelog file not found: ${filePath}`);
+              return null;
+            }
             const content = fs.readFileSync(filePath, 'utf-8');
             const updateMatch = content.match(/<Update\s+label="([^"]+)"[^>]*>([\s\S]*?)<\/Update>/);
             if (!updateMatch) return null;
@@ -93,8 +97,12 @@ jobs:
                 let responseData = '';
                 res.on('data', chunk => responseData += chunk);
                 res.on('end', () => {
-                  const parsed = JSON.parse(responseData);
-                  parsed.errors ? reject(new Error(JSON.stringify(parsed.errors))) : resolve(parsed.data);
+                  try {
+                    const parsed = JSON.parse(responseData);
+                    parsed.errors ? reject(new Error(JSON.stringify(parsed.errors))) : resolve(parsed.data);
+                  } catch (e) {
+                    reject(new Error(`Failed to parse Linear API response: ${responseData.substring(0, 200)}`));
+                  }
                 });
               });
               req.on('error', reject);


### PR DESCRIPTION
Automatically creates Linear tickets for new features when changelog files are updated and merged to main.

## What it does
- Triggers on push to main when `docs/changelog/*.mdx` files change
- Parses the newest `<Update>` block for features under `## New features` or `## Improvements`
- Creates Linear tickets via GraphQL API with:
  - Title: `[version] Feature Name`
  - Description with changelog context
  - Due date 7 days from creation
  - Optional: assignee, project, and label

## Required secrets
- `LINEAR_API_KEY` - Linear API key
- `LINEAR_TEAM_ID` - Team to create issues in

## Optional secrets
- `LINEAR_ASSIGNEE_ID` - Auto-assign tickets
- `LINEAR_PROJECT_ID` - Add to a project
- `LINEAR_LABEL_ID` - Apply a label