### PR TITLE
Remove free tier references

### DIFF
--- a/docs/cli/byok/huggingface.mdx
+++ b/docs/cli/byok/huggingface.mdx
@@ -48,4 +48,4 @@ Add to `~/.factory/settings.json`:
 
 - Model names must match the exact Hugging Face repository ID
 - Some models require accepting license agreements on HF website first
-- Large models may not be available on free tier
+- Access to some large models may require a paid Hugging Face plan

--- a/docs/guides/power-user/memory-management.mdx
+++ b/docs/guides/power-user/memory-management.mdx
@@ -137,9 +137,8 @@ Create `.factory/memories.md` in your project root:
 
 ### Business Rules
 - Users belong to Organizations (multi-tenant)
-- Subscription tiers: Free, Pro, Enterprise
-- Free tier limited to 3 team members
-- Data retention: 90 days for Free, unlimited for paid
+- Subscription tiers: Pro, Enterprise
+- Data retention: Varies by subscription tier (see pricing)
 
 ### Key Entities
 - `User`: Individual accounts, can belong to multiple orgs

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -6,11 +6,10 @@ keywords: ['pricing', 'models', 'model id', 'model pricing', 'tokens', 'standard
 
 ## Pricing Tiers
 
-Factory measures usage through Standard Tokens. Cached tokens are billed at one-tenth of a Standard Token (10 cached tokens = 1 Standard Token). We offer two subscription plans:
+Factory measures usage through Standard Tokens. Cached tokens are billed at one-tenth of a Standard Token (10 cached tokens = 1 Standard Token). We offer the following subscription plans:
 
 | Plan     | Standard Tokens / Month                       | Price / Month |
 | -------- | --------------------------------------------- | ------------- |
-| **Free** | BYOK                                          | $0            | 
 | **Pro**  | 10 million (+10 million bonus tokens)         | $20           |
 | **Max**  | 100 million (+100 million bonus tokens)       | $200          |
 | **Ultra**| 1 billion (+1 billion bonus tokens)           | $2,000        | 

--- a/examples/power-user-skills/memory-capture/SKILL.md
+++ b/examples/power-user-skills/memory-capture/SKILL.md
@@ -125,13 +125,12 @@ Capture as:
 
 ### Domain Knowledge
 
-User says: "Note that free tier users are limited to 3 team members"
+User says: "Note that plan limits vary by tier—Pro allows up to 20 team members"
 
 Capture as:
 ```markdown
 ### Business Rules
 
-- Free tier: Limited to 3 team members
 - Pro tier: Up to 20 team members
 - Enterprise: Unlimited team members
 ```


### PR DESCRIPTION
## Summary
- remove references to the deprecated free tier across pricing and related docs
- update example memory capture guidance to mention only current paid tiers
- clarify BYOK guide language so large models require paid Hugging Face plans

## Testing
- not run (docs only)