### PR TITLE
docs: add CLI v0.53.0-v0.55.2 changelog entries

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -29,8 +29,7 @@ rss: true
   ## Bug fixes
 
   * **`/review` default branch** - Fixed the `/review` command to correctly identify and use the repository's default branch
-  * **Bug reporting AWS auth** - Upgraded the bug reporting skill to support the latest AWS authentication requirements
-  * **npm leak check** - Fixed an issue with the npm leak check mechanism
+  * **Authentication** - Fixed several issues around authentication persistence and stability
 
 </Update>
 
@@ -59,6 +58,7 @@ rss: true
   ## Bug fixes
 
   * **AskUser tool improvements** - Questionnaire parsing now supports bullets/`1)` numbering, ignores headers/code fences, normalizes multi-word topics. AskUser can now run alongside TodoWrite with other tools deferred properly. Fixed TUI input handling via `KeypressProvider` subscription
+  * **Windows UI** - Improved autonomy/spec mode status text rendering on Windows terminals
 
 </Update>
 
@@ -73,6 +73,7 @@ rss: true
 
   * **Settings.json corruption prevention** - Settings file now uses atomic writes to prevent corruption
   * **Terminal info disabled** - Disabled getTerminalInfo to prevent issues
+  * **Authentication stability** - Bundled keychain dependency in packaged builds to reduce flaky sign-in setups
 
 </Update>
 


### PR DESCRIPTION
Adds changelog entries for CLI releases from January 16-23:

- **v0.53.0** (Jan 16): /readiness-report in exec mode, settings.json atomic writes
- **v0.54.0** (Jan 20): OTEL metrics, optional readiness-report model switching, AskUser improvements
- **v0.55.0** (Jan 21): Autonomy mode reskin, agent-browser integration
- **v0.55.1** (Jan 22): OTEL tracing, /review default branch fix, bug reporting improvements
- **v0.55.2** (Jan 23): Marketplace auto-updates, --allow-background-processes flag