### PR TITLE
fix: update callback URL for gitlab self-hosted settings

### DIFF
--- a/docs/onboarding/integrating-with-your-engineering-system/gitlab-self-hosted.mdx
+++ b/docs/onboarding/integrating-with-your-engineering-system/gitlab-self-hosted.mdx
@@ -19,8 +19,9 @@ This guide provides detailed instructions for integrating Factory with your self
     1. In your GitLab instance, go to Admin Area \> Applications.
     2. Click "Add new application" and fill in the details:
         - Name: `Factory Integration`
-        - Redirect URI: `https://app.factory.ai/api/integrations/redirect/gitlab-sh`
+        - Redirect URI: `https://api.factory.ai/api/integrations/redirect/gitlab-sh/callback`
         - Trusted: yes
+        - Confidential: yes
         - Scopes:
           - `api`
           - `read_api`


### PR DESCRIPTION
Callback URL needs to be updated after new web app launch.