### PR TITLE
docs: remove Ultra tier from pricing page

### DIFF
--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -12,8 +12,7 @@ Factory measures usage through Standard Tokens. Cached tokens are billed at one-
 | -------- | --------------------------------------------- | ------------- |
 | **Free** | BYOK                                          | $0            | 
 | **Pro**  | 10 million (+10 million bonus tokens)         | $20           |
-| **Max**  | 100 million (+100 million bonus tokens)       | $200          |
-| **Ultra**| 1 billion (+1 billion bonus tokens)           | $2,000        | 
+| **Max**  | 100 million (+100 million bonus tokens)       | $200          | 
 
 Overage is billed at $2.70 per million Factory Standard Tokens.
 


### PR DESCRIPTION
Removes the Ultra tier ($2,000/month for 1B tokens) from the public-facing pricing documentation as it should no longer be displayed to customers.

Requested by Eno in Slack.