### PR TITLE
docs: fix /install-gh-app to /install-github-app

### DIFF
--- a/docs/guides/droid-exec/code-review.mdx
+++ b/docs/guides/droid-exec/code-review.mdx
@@ -17,11 +17,11 @@ Set up automated code review for your repository using the Factory GitHub App. D
 
 ## Setup
 
-Use the `/install-gh-app` command to install the Factory GitHub App and configure the code review workflow:
+Use the `/install-github-app` command to install the Factory GitHub App and configure the code review workflow:
 
 ```bash
 droid
-> /install-gh-app
+> /install-github-app
 ```
 
 The guided flow will:
@@ -127,6 +127,6 @@ Guidelines:
 
 ## See also
 
-- [GitHub App installation](/cli/features/install-github-app) - Full setup guide for `/install-gh-app`
+- [GitHub App installation](/cli/features/install-github-app) - Full setup guide for `/install-github-app`
 - [GitHub Actions examples](/guides/droid-exec/github-actions) - More automation workflows
 - [Droid Exec](/cli/commands/exec) - Running Droid in CI/CD environments

--- a/docs/guides/droid-exec/github-actions.mdx
+++ b/docs/guides/droid-exec/github-actions.mdx
@@ -13,7 +13,7 @@ keywords: ['github actions', 'ci/cd', 'workflow', 'automation', 'pr review', 'dr
 Automatically reviews PRs, fixes issues, and posts detailed feedback.
 
 <Info>
-For a simpler setup, use the [`/install-gh-app`](/cli/features/install-github-app) command which configures the Factory GitHub App with guided steps.
+For a simpler setup, use the [`/install-github-app`](/cli/features/install-github-app) command which configures the Factory GitHub App with guided steps.
 </Info>
 
 ```yaml

--- a/docs/integrations/github-app.mdx
+++ b/docs/integrations/github-app.mdx
@@ -1,14 +1,14 @@
 ---
 title: GitHub App
-description: Use the /install-gh-app command to set up Droid integration with your GitHub repositories
-keywords: ['github', 'github app', 'install', '/install-gh-app', 'slash command', 'github actions', 'workflow', 'droid action', '@droid', 'automated review', 'CI/CD', 'pull request']
+description: Use the /install-github-app command to set up Droid integration with your GitHub repositories
+keywords: ['github', 'github app', 'install', '/install-github-app', 'slash command', 'github actions', 'workflow', 'droid action', '@droid', 'automated review', 'CI/CD', 'pull request']
 ---
 
 ## Overview
 
-The `/install-gh-app` command provides a guided workflow for installing the Factory GitHub App and configuring GitHub Actions workflows. This enables Droid to respond to @droid mentions in issues and PR comments, and optionally provide automated code reviews on new pull requests.
+The `/install-github-app` command provides a guided workflow for installing the Factory GitHub App and configuring GitHub Actions workflows. This enables Droid to respond to @droid mentions in issues and PR comments, and optionally provide automated code reviews on new pull requests.
 
-When you run `/install-gh-app`, droid guides you through verifying prerequisites, selecting a repository, installing the GitHub App, and creating workflow files via a pull request.
+When you run `/install-github-app`, droid guides you through verifying prerequisites, selecting a repository, installing the GitHub App, and creating workflow files via a pull request.
 
 ## Quick start
 
@@ -16,7 +16,7 @@ When you run `/install-gh-app`, droid guides you through verifying prerequisites
   <Step title="Start the installation flow">
     In an interactive droid session, type:
     ```bash
-    /install-gh-app
+    /install-github-app
     ```
   </Step>
 
@@ -50,7 +50,7 @@ When you run `/install-gh-app`, droid guides you through verifying prerequisites
 
 ## Prerequisites
 
-Before running `/install-gh-app`, ensure you have the GitHub CLI installed and authenticated.
+Before running `/install-github-app`, ensure you have the GitHub CLI installed and authenticated.
 
 ### Install GitHub CLI
 
@@ -135,7 +135,7 @@ Provides automated code review on new pull requests.
 
 ## Setup steps after installation
 
-After the `/install-gh-app` workflow completes, you need to:
+After the `/install-github-app` workflow completes, you need to:
 
 <Steps>
   <Step title="Review the pull request">
@@ -203,7 +203,7 @@ The Factory Droid GitHub App requires these permissions:
   </Accordion>
 
   <Accordion title="Multiple repositories">
-    Run `/install-gh-app` separately for each repository you want to configure. The flow automatically detects the current repository from your git remote.
+    Run `/install-github-app` separately for each repository you want to configure. The flow automatically detects the current repository from your git remote.
   </Accordion>
 </AccordionGroup>
 
@@ -213,7 +213,7 @@ The Factory Droid GitHub App requires these permissions:
 cd my-project
 droid
 
-> /install-gh-app
+> /install-github-app
 ```
 
 After completing the guided flow, Droid creates a PR with workflow files. Here's what the generated Droid Review workflow looks like:


### PR DESCRIPTION
Fixes the documentation to use the correct command name `/install-github-app` instead of `/install-gh-app`.

Updated files:
- `docs/integrations/github-app.mdx`
- `docs/guides/droid-exec/code-review.mdx`
- `docs/guides/droid-exec/github-actions.mdx`

Reported by user via support request.