### PR TITLE
docs: add CLI changelog entries v0.56.1 through v0.57.10

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,6 +4,138 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="February 9" rss={{ title: "CLI Updates", description: "Skills UX overhaul, terminal tab titles, desktop notifications, and mobile experience" }}>
+  `v0.57.10`
+
+  ## New features
+
+  * **`/skills` UX overhaul** - Tabbed layout with pagination and a dedicated detail view for browsing and importing skills
+  * **Terminal tab titles** - Terminal tab now displays the session name so you can identify Droid sessions across multiple tabs
+  * **`droid update` command** - New command to manually update the CLI, plus ability to disable autoupdate via `/settings`
+  * **Session end hooks** - Hooks now fire when running `/clear` or `/new`, enabling custom cleanup workflows
+  * **Desktop notifications** - Native macOS and Windows notifications when sessions complete, with configurable preferences (app)
+  * **Desktop native view redesign** - Refreshed sidebar layout with smooth animations, new terminal editor icons, and keyboard shortcut formatting (app)
+  * **Mobile experience** - Overhauled mobile and responsive layout with touch-friendly settings and onboarding flows (app)
+
+  ## Bug fixes
+
+  * **`/bug` command memory** - Optimized log loading with streaming I/O to prevent out-of-memory on large log files
+  * **Session persistence** - Thinking and reasoning fields now preserved correctly when saving sessions
+  * **MCP settings UI** - Filled toggle style, clickable tool rows, and capitalized server names (app)
+  * **Git timeout** - Increased git timeout to 60 seconds to prevent failures on slow connections or large repos
+
+</Update>
+
+<Update label="February 7" rss={{ title: "CLI Updates", description: "Opus 4.6 Fast Mode and pricing update" }}>
+  `v0.57.9`
+
+  ## Improvements
+
+  * **Opus 4.6 Fast Mode** - Renamed from "Opus 4.6 Fast" to "Opus 4.6 Fast Mode" for clarity
+  * **Opus 4.6 Fast Mode promo pricing** - Updated token multiplier from 12x to 6x promotional rate
+
+</Update>
+
+<Update label="February 6" rss={{ title: "CLI Updates", description: "Opus 4.6 Fast, /fork command, session archiving, and org-managed settings" }}>
+  `v0.57.7`
+
+  ## New features
+
+  * **Claude Opus 4.6 Fast** - Added Opus 4.6 Fast as a new model option in the model selector
+  * **`/fork` command** - Duplicate your current session with all messages preserved into a new session
+  * **Org-managed settings** - Local settings that are set by your organization are now locked from editing
+  * **Session archiving** - Archive sessions from the web app to keep your sidebar clean (app)
+
+  ## Bug fixes
+
+  * **Shell environment loading** - Shell environment now loads consistently across desktop, sandbox, and computer platforms
+  * **Orphaned browser processes** - Agent-browser daemon processes are now cleaned up properly
+  * **Task tool output** - Progress updates from Task tool are now truncated to prevent UI overflow
+
+</Update>
+
+<Update label="February 5" rss={{ title: "CLI Updates", description: "Opus 4.6, semantic diffs, npm package, plugin hooks, and startup optimizations" }}>
+  `v0.57.5`
+
+  ## New features
+
+  * **Claude Opus 4.6** - Added Claude Opus 4.6 model support
+  * **Semantic structured diffs** - Code change diffs now use semantic structure-aware rendering for better readability
+  * **Plugin hooks** - Added support for plugin hooks with Claude hooks format compatibility
+  * **npm package** - CLI is now installable via npm: `npm install -g droid`
+  * **User-invocable skills as slash commands** - Custom skills marked as user-invocable are now registered as slash commands
+  * **`FACTORY_LOG_FILE` and `FACTORY_DISABLE_KEYRING` env vars** - New environment variables for log file output and keyring control
+  * **Enterprise Controls** - New settings page for managing agent behavior, command policy, model access, and security (app)
+  * **Skills UI** - Skills button and modal added to the chat input for easy skill access (app)
+  * **Ask User tool** - Ask User tool now available in the web and desktop apps (app)
+
+  ## Improvements
+
+  * **Startup latency** - Optimized CLI startup with sub-metric tracking for faster launch times
+
+  ## Bug fixes
+
+  * **Unicode crash** - Fixed CLI crash when sessions contain certain unicode characters
+  * **Marketplace auto-update** - Auto-update now only runs in interactive mode, not during `droid exec`
+
+</Update>
+
+<Update label="February 3" rss={{ title: "CLI Updates", description: "Task tool streaming, image pasting, and skills improvements" }}>
+  `v0.57.3`
+
+  ## New features
+
+  * **Task tool live streaming** - Real-time subagent tool progress display and Execute tool output streaming in web and desktop apps (app)
+  * **Image pasting** - Paste images directly into the chat composer (app)
+  * **`.agent` skills folders** - Skills can now be loaded from `.agent` folders in your project for custom skill support
+
+  ## Improvements
+
+  * **Skills filtering** - Skills are now filtered by model invocability so only relevant skills appear in the Skill tool
+
+  ## Bug fixes
+
+  * **File suggestion UX** - Trailing space now added after file suggestion selection for smoother typing
+
+</Update>
+
+<Update label="January 30" rss={{ title: "CLI Updates", description: "Full text search, MiniMax M2.1, and AskUser improvements" }}>
+  `v0.57.2`
+
+  ## New features
+
+  * **Full text search** - Search across your session history and codebase directly in the CLI
+  * **MiniMax M2.1** - Added MiniMax M2.1 model support
+
+  ## Bug fixes
+
+  * **AskUser tool** - Improved questionnaire parsing and interaction reliability
+
+</Update>
+
+<Update label="January 29" rss={{ title: "CLI Updates", description: "Plugin hooks and ASCII mermaid diagrams" }}>
+  `v0.57.0`
+
+  ## New features
+
+  * **ASCII mermaid diagrams** - Mermaid diagrams now render as ASCII art directly in the terminal
+
+</Update>
+
+<Update label="January 28" rss={{ title: "CLI Updates", description: "MCP tool management and Read tool fixes" }}>
+  `v0.56.1`
+
+  ## Improvements
+
+  * **MCP tool management** - Improved MCP tool status tracking to prevent cross-contamination between servers
+
+  ## Bug fixes
+
+  * **Read tool images** - Fixed image support in the Read tool, along with rate limit retry and reasoning fixes
+  * **Cache block limits** - Ensured no more than 3 cache blocks are sent to the LLM to prevent context issues
+
+</Update>
+
 <Update label="January 27" rss={{ title: "CLI Updates", description: "ACP daemon mode, lazy session loading, and model updates" }}>
   `v0.56.0`
 


### PR DESCRIPTION
Adds changelog entries for 8 releases from January 28 through February 9, covering:

- **Feb 9** (v0.57.10): Skills UX overhaul, terminal tab titles, droid update command, desktop notifications, mobile experience
- **Feb 7** (v0.57.9): Opus 4.6 Fast Mode rename and promo pricing
- **Feb 6** (v0.57.7): Opus 4.6 Fast, /fork command, org-managed settings, session archiving
- **Feb 5** (v0.57.5): Opus 4.6, semantic diffs, plugin hooks, npm package, Enterprise Controls, startup optimizations
- **Feb 3** (v0.57.3): Task tool live streaming, image pasting, .agent skills folders
- **Jan 30** (v0.57.2): Full text search, MiniMax M2.1
- **Jan 29** (v0.57.0): ASCII mermaid diagrams
- **Jan 28** (v0.56.1): MCP tool management, Read tool fixes