### PR TITLE
docs: sync model references with factory-mono registry and add changelog features

### DIFF
--- a/.factory/skills/update-model-docs/SKILL.md
+++ b/.factory/skills/update-model-docs/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: update-model-docs
+description: |
+  Update Factory documentation to match the latest model registry in factory-mono.
+  Use when new models are added, existing models are removed, reasoning levels change,
+  or pricing multipliers are updated. Triggered by model launches, model deprecations,
+  or registry changes.
+---
+
+# Update Model Docs
+
+Sync Factory documentation with the model registry source of truth in factory-mono.
+
+## Prerequisites
+
+- The `factory` docs repo is checked out locally
+- The `factory-mono` repo is checked out locally at `../factory-mono` (relative to docs repo)
+- Both repos are on their latest `main` branch (pull before starting)
+
+## Source of Truth
+
+All model data comes from one file:
+
+```
+factory-mono/packages/utils/src/llm/model-registry.ts
+```
+
+Read these sections to extract what you need:
+
+| Registry field | What it tells you |
+|---|---|
+| `ModelID` enum (in `packages/common/src/llm/enums.ts`) | The model ID strings (e.g. `claude-opus-4-6`) |
+| `name` / `shortName` | Display names for tables |
+| `reasoningEffort.supported` | Available reasoning levels (Off, None, Low, Medium, High, ExtraHigh, Max) |
+| `reasoningEffort.default` | Default reasoning level |
+| `cost.tokenMultiplier` | Pricing multiplier (e.g. 2.0 = 2x) |
+| `cost.promoLabel` | Promo pricing label if any |
+| `availableInCLI` | If explicitly `false`, model is NOT available in CLI docs |
+| `featureFlag` | Model may be gated behind a feature flag -- ask user before including |
+| `CLI_MODEL_ORDER` | Display order in the CLI model selector |
+
+## Workflow
+
+### Step 1: Read the registry and build a diff
+
+1. Pull latest `main` on both repos
+2. Read `factory-mono/packages/utils/src/llm/model-registry.ts` and `packages/common/src/llm/enums.ts`
+3. Build a table of all CLI-available models with: model ID, display name, reasoning levels, default reasoning, multiplier, promo label
+4. Read the current `docs/pricing.mdx` pricing table
+5. Compare registry vs docs and produce a diff:
+   - **New models**: in registry but not in docs
+   - **Removed models**: in docs but not in registry (or `availableInCLI: false`)
+   - **Changed models**: reasoning levels, multiplier, or name changed
+
+### Step 2: Confirm scope with user
+
+Present the diff and ask:
+- Which new models to add (some may be feature-flagged or not ready for docs)
+- Which removed models to actually remove
+- Any models to explicitly exclude
+
+Do NOT proceed until the user confirms the list.
+
+### Step 3: Edit files by tier
+
+#### Tier 1 -- Always update (model tables)
+
+**`docs/pricing.mdx`** -- Pricing Table
+- Add/remove/update model rows
+- Sort order: **multiplier ascending, then model name alphabetical** within same multiplier
+- Columns: Model name | Model ID (in backtick code) | Multiplier (with x symbol)
+- Include promo labels like "(Promo)" if `cost.promoLabel` exists
+
+**`docs/reference/cli-reference.mdx`** -- Available Models table (under `## Available models`)
+- Add/remove/update model rows
+- Sort order: **capability descending** (most powerful first, Droid Core last)
+- Columns: Model ID | Name | Reasoning support (list levels) | Default reasoning
+- Also update the `-m` flag example in the `droid exec` flags table if the default/recommended model changed
+
+**`docs/cli/user-guides/choosing-your-model.mdx`** -- Multiple sections:
+- **Stack rank table** (section 1): Update ranks, add/remove models. This is an opinionated ranking -- ask user for rank placement of new models
+- **Match the model to the job** (section 2): Update task recommendations if new models are better for certain tasks
+- **Reasoning effort settings** (section 4): Update reasoning levels list to match registry exactly
+- **Open-source models** (section 5): Update if open-source models changed
+- Update the "last updated" date in the intro paragraph
+
+#### Tier 2 -- Usually update (model lists)
+
+**`docs/cli/droid-exec/overview.mdx`** -- Supported models bullet list
+- Add/remove model IDs from the list under "Supported models (examples)"
+- Sort order: **capability descending** (same as cli-reference)
+
+**`docs/cli/configuration/settings.mdx`** -- Two locations:
+- Settings table: update the `model` row's Options column with all model aliases
+- Model list section (under `### Model`): add/remove bullet items with descriptions
+
+**`docs/cli/configuration/mixed-models.mdx`** -- Provider compatibility sections
+- Update if new models from a provider are added (e.g. new Anthropic model -> update Anthropic Models section)
+
+#### Tier 3 -- Update if model names/IDs changed
+
+**`docs/guides/power-user/token-efficiency.mdx`** -- Two locations:
+- Cost Multipliers table: sorted by **multiplier ascending, then name**
+- Task-Based Model Selection code block: update model recommendations
+- This is a simplified table -- not every model needs a row, but groups (like "GPT-5.1 / GPT-5.1-Codex") are fine
+
+**`docs/guides/power-user/prompt-crafting.mdx`** -- Model recommendation table
+- Update if the recommended model for a task type changed
+
+**`docs/cli/configuration/byok.mdx`** -- BYOK example configs
+- Only update if a model ID string itself changed (e.g. `zai-org/GLM-4.6` -> `zai-org/GLM-4.7`)
+
+**`docs/cli/byok/deepinfra.mdx`** -- DeepInfra config example
+- Same as above, only if model ID changed
+
+**`docs/guides/building/droid-vps-setup.mdx`** -- droid exec shell examples
+- Update `--model` flag values if model IDs changed
+
+**`docs/guides/building/droid-exec-tutorial.mdx`** -- Code snippets
+- Update model ID defaults in TypeScript code, `.env` examples, and comments
+
+### Step 4: Sweep for stale references
+
+After all edits, grep the entire `docs/` folder for old model IDs/names that should have been replaced:
+
+```bash
+# For each removed/renamed model, search for stale references
+rg "old-model-id" docs/ --glob '!changelog/**'
+rg "Old Model Name" docs/ --glob '!changelog/**'
+```
+
+Changelog files (`docs/changelog/`) are historical records -- never edit them.
+
+### Step 5: Validate
+
+1. Run `npx mintlify validate` inside the `docs/` directory (requires node <=24, not node 25+)
+2. Start dev server: `npx mintlify dev --no-open` inside `docs/`
+3. Verify each changed page loads without errors
+4. Spot-check tables render correctly using browser automation or manual review
+
+### Step 6: Commit, push, and create PR
+
+1. Create a feature branch (e.g. `update-models-<date>` or `add-<model-name>`)
+2. Stage only docs files (`git add docs/`)
+3. Commit with message format: `docs: update model references for <summary>`
+4. Push and create PR with a summary listing: new models added, models removed, other changes
+5. Review PR comments from auto-reviewer and address feedback
+
+## Rules
+
+- **Never edit changelog files.** Files under `docs/changelog/` are historical.
+- **Never make quality claims you can't back up.** Avoid "same quality" or "identical performance" -- use softer language like "tuned for" or "optimized for".
+- **Reasoning labels must match the registry exactly.** `Off` and `None` are different values in the codebase. Do not normalize them.
+- **Sort orders are per-file conventions.** Pricing = multiplier asc. CLI reference = capability desc. Do not mix them up.
+- **Ask before including feature-flagged models.** If `featureFlag` is set, the model may not be generally available yet.
+- **Keep Tier 3 files in scope.** The most common mistake is updating the main tables but forgetting the guides, tutorials, and BYOK examples.
+
+## Common Mistakes From Past Sessions
+
+1. **Missing files in sweep**: settings.mdx model list, token-efficiency cost table, and prompt-crafting recommendation table are easy to forget
+2. **Wrong sort order**: Pricing table rows must be sorted by multiplier, not by when they were added
+3. **Stale pre-existing entries**: Always audit surrounding rows in tables you edit -- there may be old mistakes from previous updates
+4. **Broken rank numbering**: When inserting rows into the choosing-your-model stack rank table, re-check all rank numbers are sequential
+5. **Mintlify dev server node version**: Requires node <=24 LTS. Node 25+ will error. Use `brew install node@22` if needed

--- a/.factory/skills/update-model-docs/checklist.md
+++ b/.factory/skills/update-model-docs/checklist.md
@@ -1,0 +1,88 @@
+# Model Docs Update Checklist
+
+Use this checklist after making edits. For each file, verify the specific items listed.
+
+## Pre-flight
+
+- [ ] Pulled latest `main` on both `factory` and `factory-mono` repos
+- [ ] Read `factory-mono/packages/utils/src/llm/model-registry.ts` for current model data
+- [ ] Read `factory-mono/packages/common/src/llm/enums.ts` for ModelID string values
+- [ ] Built diff of registry vs current docs and confirmed scope with user
+
+## Tier 1 Files
+
+### `docs/pricing.mdx`
+- [ ] All CLI-available models present in pricing table
+- [ ] No removed/unavailable models still listed
+- [ ] Multipliers match `cost.tokenMultiplier` from registry
+- [ ] Promo labels match `cost.promoLabel` from registry
+- [ ] Sort order: multiplier ascending, model name alphabetical as tiebreaker
+- [ ] Model IDs in backtick code format
+
+### `docs/reference/cli-reference.mdx`
+- [ ] Available models table has all CLI models
+- [ ] Reasoning support column matches `reasoningEffort.supported` exactly (Off vs None matters)
+- [ ] Default reasoning column matches `reasoningEffort.default`
+- [ ] Sort order: capability descending (most powerful first)
+- [ ] `-m` flag example uses a current model ID
+
+### `docs/cli/user-guides/choosing-your-model.mdx`
+- [ ] Stack rank table has correct models with sequential numbering (1, 2, 3... no gaps or duplicates)
+- [ ] "Last updated" date in intro paragraph is current
+- [ ] Section heading date matches (e.g. "Current stack rank (February 2026)")
+- [ ] Task recommendation table mentions new top-tier models where appropriate
+- [ ] Reasoning effort settings list matches registry for every model
+- [ ] Open-source models section is up to date
+- [ ] Tip callout mentions current top model
+- [ ] No overly strong quality claims (avoid "same quality", "identical")
+
+## Tier 2 Files
+
+### `docs/cli/droid-exec/overview.mdx`
+- [ ] Supported models list includes all CLI-available models
+- [ ] Sort order: capability descending
+
+### `docs/cli/configuration/settings.mdx`
+- [ ] Settings table `model` row has all model aliases in Options column
+- [ ] Model list (under `### Model`) has bullet for each model with description
+- [ ] `droid-core` description references correct model name/version
+
+### `docs/cli/configuration/mixed-models.mdx`
+- [ ] Provider sections reference current top models
+- [ ] No stale model names in examples
+
+## Tier 3 Files
+
+### `docs/guides/power-user/token-efficiency.mdx`
+- [ ] Cost multipliers table has correct multipliers
+- [ ] Sort order: multiplier ascending, then name
+- [ ] Task-based model selection code block uses current model names
+- [ ] No stale model entries (check ALL rows, not just ones you're editing)
+
+### `docs/guides/power-user/prompt-crafting.mdx`
+- [ ] Model recommendation table uses current model names
+- [ ] Reasoning level suggestions match available levels
+
+### `docs/cli/configuration/byok.mdx`
+- [ ] BYOK example configs use current model IDs (if model IDs changed)
+
+### `docs/cli/byok/deepinfra.mdx`
+- [ ] DeepInfra example uses current model ID and display name
+
+### `docs/guides/building/droid-vps-setup.mdx`
+- [ ] `--model` flag values in shell examples are current
+
+### `docs/guides/building/droid-exec-tutorial.mdx`
+- [ ] TypeScript code uses current default model ID
+- [ ] `.env` example comments reference current model
+- [ ] Code comments reference current model names
+- [ ] Model list in documentation section is current
+
+## Post-edit Verification
+
+- [ ] Grep for all old/removed model IDs across `docs/` (excluding `docs/changelog/`)
+- [ ] Grep for all old/removed model names across `docs/` (excluding `docs/changelog/`)
+- [ ] No changelog files were modified
+- [ ] `npx mintlify validate` passes (run inside `docs/`, requires node <=24)
+- [ ] Dev server starts and pages render without 500 errors
+- [ ] PR created with descriptive summary of changes

--- a/docs/cli/byok/deepinfra.mdx
+++ b/docs/cli/byok/deepinfra.mdx
@@ -14,8 +14,8 @@ Add to `~/.factory/settings.json`:
 {
   "customModels": [
     {
-      "model": "zai-org/GLM-4.6",
-      "displayName": "GLM-4.6 [DeepInfra]",
+      "model": "zai-org/GLM-4.7",
+      "displayName": "GLM-4.7 [DeepInfra]",
       "baseUrl": "https://api.deepinfra.com/v1/openai",
       "apiKey": "YOUR_DEEPINFRA_TOKEN",
       "provider": "generic-chat-completion-api",

--- a/docs/cli/configuration/byok.mdx
+++ b/docs/cli/configuration/byok.mdx
@@ -203,8 +203,8 @@ Access cost-effective inference for a wide variety of open-source models:
 {
   "customModels": [
     {
-      "model": "zai-org/GLM-4.6",
-      "displayName": "GLM 4.6 [DeepInfra]",
+      "model": "zai-org/GLM-4.7",
+      "displayName": "GLM 4.7 [DeepInfra]",
       "baseUrl": "https://api.deepinfra.com/v1/openai",
       "apiKey": "YOUR_DEEPINFRA_TOKEN",
       "provider": "generic-chat-completion-api",

--- a/docs/cli/configuration/mixed-models.mdx
+++ b/docs/cli/configuration/mixed-models.mdx
@@ -131,8 +131,8 @@ Here are some effective model combinations for different scenarios:
 **Best for:** Most development workflows, flexible reasoning control
 
 - **Default model:** Haiku 4.5 or Sonnet 4.5 (select reasoning of your choice if supported)
-- **Spec mode model:** Sonnet 4.5 (reasoning: high)
-- **Benefits:** Fast implementation with deep planning analysis
+- **Spec mode model:** Opus 4.6 (reasoning: high) or Sonnet 4.5 (reasoning: high)
+- **Benefits:** Fast implementation with deep planning analysis. Opus 4.6 offers **Max** reasoning for the most thorough planning.
 
 ### OpenAI Models
 

--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -27,7 +27,7 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 
 | Setting | Options | Default | Description |
 | ------- | ------- | ------- | ----------- |
-| `model` | `sonnet`, `opus`, `GPT-5`, `gpt-5-codex`, `gpt-5-codex-max`, `haiku`, `droid-core`, `custom-model` | `opus` | The default AI model used by droid |
+| `model` | `opus`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.2-codex`, `haiku`, `gemini-3-pro`, `droid-core`, `kimi-k2.5`, `custom-model` | `opus` | The default AI model used by droid |
 | `reasoningEffort` | `off`, `none`, `low`, `medium`, `high` (availability depends on the model) | Model-dependent default | Controls how much structured thinking the model performs. |
 | `autonomyLevel` | `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high` | `normal` | Sets the default autonomy mode when starting droid. |
 | `cloudSessionSync` | `true`, `false` | `true` | Mirror CLI sessions to Factory web. |
@@ -55,14 +55,18 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 Choose the default AI model that powers your droid:
 
 - **`opus`** - Claude Opus 4.5 (current default)
+- **`opus-4-6`** - Claude Opus 4.6, latest flagship with Max reasoning
+- **`opus-4-6-fast`** - Claude Opus 4.6 Fast, tuned for faster responses
 - **`sonnet`** - Claude Sonnet 4.5, balanced cost and quality
 - **`gpt-5.1`** - OpenAI GPT-5.1
 - **`gpt-5.1-codex`** - Advanced coding-focused model
 - **`gpt-5.1-codex-max`** - GPT-5.1-Codex-Max, supports Extra High reasoning
 - **`gpt-5.2`** - OpenAI GPT-5.2
+- **`gpt-5.2-codex`** - GPT-5.2-Codex, latest OpenAI coding model with Extra High reasoning
 - **`haiku`** - Claude Haiku 4.5, fast and cost-effective
 - **`gemini-3-pro`** - Gemini 3 Pro
-- **`droid-core`** - GLM-4.6 open-source model
+- **`droid-core`** - GLM-4.7 open-source model
+- **`kimi-k2.5`** - Kimi K2.5 open-source model with image support
 - **`custom-model`** - Your own configured model via BYOK
 
 [You can also add custom models and BYOK.](/cli/configuration/byok)

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -66,6 +66,7 @@ Skills are discovered from a small set of well-known locations:
 | ------------- | ----------------------------------- | ----------------------------------------------------------------------- |
 | **Workspace** | `<repo>/.factory/skills/`           | Project skills shared with teammates; checked into git.                 |
 | **Personal**  | `~/.factory/skills/`                | Private skills that follow you across projects on your machine.         |
+| **Compatibility** | `<repo>/.agent/skills/`         | Discovered for compatibility with `.agent` folder conventions.          |
 
 Each **skill** lives in its own directory under one of these roots:
 

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -70,13 +70,20 @@ Options:
 
 Supported models (examples):
 
-- claude-opus-4-5-20251101 (default)
+- claude-opus-4-6
+- claude-opus-4-6-fast
+- claude-opus-4-5-20251101
 - claude-sonnet-4-5-20250929
 - claude-haiku-4-5-20251001
 - gpt-5.1-codex
+- gpt-5.1-codex-max
 - gpt-5.1
+- gpt-5.2
+- gpt-5.2-codex
 - gemini-3-pro-preview
-- glm-4.6
+- gemini-3-flash-preview
+- glm-4.7
+- kimi-k2.5
 
 <Note>
 See the [model table](/pricing#pricing-table) for the full list of available models and their costs.

--- a/docs/cli/getting-started/overview.mdx
+++ b/docs/cli/getting-started/overview.mdx
@@ -16,6 +16,10 @@ curl -fsSL https://app.factory.ai/cli | sh
 irm https://app.factory.ai/cli/windows | iex
 ```
 
+```bash npm
+npm install -g droid
+```
+
 </CodeGroup>
 
 Then navigate to your project and start the droid CLI.

--- a/docs/cli/getting-started/quickstart.mdx
+++ b/docs/cli/getting-started/quickstart.mdx
@@ -29,6 +29,10 @@ brew install --cask droid
 irm https://app.factory.ai/cli/windows | iex
 ```
 
+```bash npm
+npm install -g droid
+```
+
 </CodeGroup>
 
 <Note>

--- a/docs/cli/user-guides/choosing-your-model.mdx
+++ b/docs/cli/user-guides/choosing-your-model.mdx
@@ -4,23 +4,28 @@ description: Balance accuracy, speed, and cost by picking the right model and re
 keywords: ['model', 'models', 'llm', 'claude', 'sonnet', 'opus', 'haiku', 'gpt', 'openai', 'anthropic', 'choose model', 'switch model']
 ---
 
-Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shifts. Use this guide as a snapshot of how the major options compare today, and expect to revisit it as we publish updates. This guide was last updated on Thursday, December 4th 2025.
+Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shifts. Use this guide as a snapshot of how the major options compare today, and expect to revisit it as we publish updates. This guide was last updated on Thursday, February 12th 2026.
 
 ---
 
-## 1 · Current stack rank (December 2025)
+## 1 · Current stack rank (February 2026)
 
 | Rank | Model                         | Why we reach for it                                                                                                                               |
 | ---- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1    | **Claude Opus 4.5 (default)** | Highest quality-and-safety balance; current CLI default for both TUI and exec.                                                                   |
-| 2    | **GPT-5.1-Codex-Max**         | Fast coding loops with support up to **Extra High** reasoning; great for heavy implementation and debugging.                                    |
-| 3    | **Claude Sonnet 4.5**         | Strong daily driver with balanced cost/quality; great general-purpose choice when you don’t need Opus-level depth.                              |
-| 4    | **GPT-5.1-Codex**             | Quick iteration with solid code quality at lower cost; bump reasoning when you need more depth.                                                 |
-| 5    | **GPT-5.1**                   | Good generalist, especially when you want OpenAI ergonomics with flexible reasoning effort.                                                     |
-| 6    | **Claude Haiku 4.5**          | Fast, cost-efficient for routine tasks and high-volume automation.                                                                              |
-| 7    | **Gemini 3 Pro**              | Strong at mixed reasoning with Low/High settings; helpful for researchy flows with structured outputs.                                         |
-| 8    | **Gemini 3 Flash**            | Fast, cheap (0.2× multiplier) with full reasoning support; great for high-volume tasks where speed matters.                                    |
-| 9    | **Droid Core (GLM-4.6)**      | Open-source, 0.25× multiplier, great for bulk automation or air-gapped environments; note: no image support.                                   |
+| 1    | **Claude Opus 4.6**           | Latest Anthropic flagship with **Max** reasoning; best depth and safety for complex work.                                                        |
+| 2    | **Claude Opus 4.6 Fast**      | Opus 4.6 tuned for faster response times; 6× promo multiplier.                                                                          |
+| 3    | **Claude Opus 4.5**           | Proven quality-and-safety balance; strong default for TUI and exec.                                                                              |
+| 4    | **GPT-5.1-Codex-Max**         | Fast coding loops with support up to **Extra High** reasoning; great for heavy implementation and debugging.                                    |
+| 5    | **Claude Sonnet 4.5**         | Strong daily driver with balanced cost/quality; great general-purpose choice when you don’t need Opus-level depth.                              |
+| 6    | **GPT-5.2-Codex**             | Latest OpenAI coding model with **Extra High** reasoning; strong for implementation-heavy tasks.                                                |
+| 7    | **GPT-5.1-Codex**             | Quick iteration with solid code quality at lower cost; bump reasoning when you need more depth.                                                 |
+| 8    | **GPT-5.1**                   | Good generalist, especially when you want OpenAI ergonomics with flexible reasoning effort.                                                     |
+| 9    | **GPT-5.2**                   | Advanced OpenAI model with verbosity support and reasoning up to **Extra High**.                                                                |
+| 10   | **Claude Haiku 4.5**          | Fast, cost-efficient for routine tasks and high-volume automation.                                                                              |
+| 11   | **Gemini 3 Pro**              | Strong at mixed reasoning with Low/High settings; helpful for researchy flows with structured outputs.                                         |
+| 12   | **Gemini 3 Flash**            | Fast, cheap (0.2× multiplier) with full reasoning support; great for high-volume tasks where speed matters.                                    |
+| 13   | **Droid Core (GLM-4.7)**      | Open-source, 0.25× multiplier, great for bulk automation or air-gapped environments; note: no image support.                                   |
+| 14   | **Droid Core (Kimi K2.5)**    | Open-source, 0.25× multiplier with image support; good for cost-sensitive work.                                                                 |
 
 <Note>
   We ship model updates regularly. When a new release overtakes the list above,
@@ -33,14 +38,14 @@ Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shi
 
 | Scenario                                                         | Recommended model                                                                                                                          |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Deep planning, architecture reviews, ambiguous product specs** | Start with **Opus 4.5 (default)** for depth and safety. Use **Sonnet 4.5** when you want balanced cost/quality, or **Codex/Codex-Max** for faster iteration with reasoning. |
-| **Full-feature development, large refactors**                    | **Opus 4.5** for default depth and safety. **GPT-5.1-Codex-Max** when you need speed plus **Extra High** reasoning; **Sonnet 4.5** for balanced loops. |
+| **Deep planning, architecture reviews, ambiguous product specs** | Start with **Opus 4.6** for best depth and safety, or **Opus 4.6 Fast** for faster turnaround. Use **Sonnet 4.5** when you want balanced cost/quality, or **Codex/Codex-Max** for faster iteration with reasoning. |
+| **Full-feature development, large refactors**                    | **Opus 4.6** or **Opus 4.5** for depth and safety. **GPT-5.2-Codex** or **GPT-5.1-Codex-Max** when you need speed plus **Extra High** reasoning; **Sonnet 4.5** for balanced loops. |
 | **Repeatable edits, summarization, boilerplate generation**      | **Haiku 4.5** or **Droid Core** for speed and cost. **GPT-5.1 / GPT-5.1-Codex** when you need higher quality or structured outputs. |
 | **CI/CD or automation loops**                                    | Favor **Haiku 4.5** or **Droid Core** for predictable, low-cost throughput. Use **Codex** or **Codex-Max** when automation needs stronger reasoning. |
 | **High-volume automation, frequent quick turns**                 | **Haiku 4.5** for speedy feedback. **Droid Core** when cost is critical or you need air-gapped deployment. |
 
 <Tip>
-  **Claude Opus 4.5** is the top-tier option for extremely complex architecture decisions or critical work where you need maximum reasoning capability. Most tasks don't require Opus-level power—start with Sonnet 4.5 and escalate only if needed.
+  **Claude Opus 4.6** is the top-tier option for extremely complex architecture decisions or critical work where you need maximum reasoning capability. **Opus 4.6 Fast** is tuned for faster responses at a higher cost. Most tasks don't require Opus-level power—start with Sonnet 4.5 and escalate only if needed.
 </Tip>
 
 Tip: you can swap models mid-session with `/model` or by toggling in the settings panel (`Shift+Tab` → **Settings**).
@@ -58,16 +63,19 @@ Tip: you can swap models mid-session with `/model` or by toggling in the setting
 
 ## 4 · Reasoning effort settings
 
-- **Opus / Sonnet / Haiku**: Off / Low / Medium / High (default: Off)
+- **Opus 4.6 / Opus 4.6 Fast**: Off / Low / Medium / High / **Max** (default: High)
+- **Opus 4.5 / Sonnet 4.5 / Haiku 4.5**: Off / Low / Medium / High (default: Off)
 - **GPT-5.1**: None / Low / Medium / High (default: None)
 - **GPT-5.1-Codex**: Low / Medium / High (default: Medium)
 - **GPT-5.1-Codex-Max**: Low / Medium / High / **Extra High** (default: Medium)
-- **GPT-5.2**: Low / Medium / High (default: Low)
-- **Gemini 3 Pro**: Low / High (default: High)
+- **GPT-5.2**: Off / Low / Medium / High / **Extra High** (default: Low)
+- **GPT-5.2-Codex**: None / Low / Medium / High / **Extra High** (default: Medium)
+- **Gemini 3 Pro**: None / Low / Medium / High (default: High)
 - **Gemini 3 Flash**: Minimal / Low / Medium / High (default: High)
-- **Droid Core (GLM-4.6)**: None only (default: None; no image support)
+- **Droid Core (GLM-4.7)**: None only (default: None; no image support)
+- **Droid Core (Kimi K2.5)**: None only (default: None)
 
-Reasoning effort increases latency and cost—start low for simple work and escalate as needed. **Extra High** is only available on GPT-5.1-Codex-Max.
+Reasoning effort increases latency and cost—start low for simple work and escalate as needed. **Max** is available on Claude Opus 4.6. **Extra High** is available on GPT-5.1-Codex-Max, GPT-5.2, and GPT-5.2-Codex.
 
 <Tip>
   Change reasoning effort from `/model` → **Reasoning effort**, or via the
@@ -82,14 +90,14 @@ Factory ships with managed Anthropic and OpenAI access. If you prefer to run aga
 
 ### Open-source models
 
-**Droid Core (GLM-4.6)** is an open-source alternative available in the CLI. It's useful for:
+**Droid Core (GLM-4.7)** and **Droid Core (Kimi K2.5)** are open-source alternatives available in the CLI. They're useful for:
 
 - **Air-gapped environments** where external API calls aren't allowed
 - **Cost-sensitive projects** needing unlimited local inference
 - **Privacy requirements** where code cannot leave your infrastructure
 - **Experimentation** with open-source model capabilities
 
-**Note:** GLM-4.6 does not support image attachments. For image-based workflows, use Claude or GPT models.
+**Note:** GLM-4.7 does not support image attachments. Kimi K2.5 does support images. For image-based workflows, use Claude, GPT, or Kimi models.
 
 To use open-source models, you'll need to configure them via BYOK with a local inference server (like Ollama) or a hosted provider. See [BYOK documentation](/cli/configuration/byok) for setup instructions.
 

--- a/docs/guides/building/droid-exec-tutorial.mdx
+++ b/docs/guides/building/droid-exec-tutorial.mdx
@@ -78,8 +78,8 @@ The Factory example uses a simple pattern: spawn `droid exec` with `--output-for
 function runDroidExec(prompt: string, repoPath: string) {
   const args = ["exec", "--output-format", "debug"];
   
-  // Optional: configure model (defaults to glm-4.6)
-  const model = process.env.DROID_MODEL_ID ?? "glm-4.6";
+  // Optional: configure model (defaults to glm-4.7)
+  const model = process.env.DROID_MODEL_ID ?? "glm-4.7";
   args.push("-m", model);
   
   // Optional: reasoning level (off|low|medium|high)
@@ -105,7 +105,7 @@ function runDroidExec(prompt: string, repoPath: string) {
 - Alternative: `--output-format json` for final output only
 
 **`-m` (model)**: Choose your AI model
-- `glm-4.6` - Fast, cheap (default)
+- `glm-4.7` - Fast, cheap (default)
 - `gpt-5-codex` - Most powerful for complex code
 - `claude-sonnet-4-5-20250929` - Best balance of speed and capability
 
@@ -311,7 +311,7 @@ The example supports environment variables:
 
 ```bash
 # .env
-DROID_MODEL_ID=gpt-5-codex  # Default: glm-4.6
+DROID_MODEL_ID=gpt-5-codex  # Default: glm-4.7
 DROID_REASONING=low         # Default: low (off|low|medium|high)
 PORT=4000                   # Default: 4000
 HOST=localhost              # Default: localhost
@@ -376,7 +376,7 @@ fs.writeFileSync('./repos/site-content/page.md', markdown);
 function runWithModel(prompt: string, model: string) {
   return Bun.spawn([
     "droid", "exec",
-    "-m", model,  // glm-4.6, gpt-5-codex, etc.
+    "-m", model,  // glm-4.7, gpt-5-codex, etc.
     "--output-format", "debug",
     prompt
   ], { cwd: repoPath });

--- a/docs/guides/building/droid-vps-setup.mdx
+++ b/docs/guides/building/droid-vps-setup.mdx
@@ -182,15 +182,15 @@ The real power of running droid on a VPS is `droid exec` - a headless mode that 
 ### Basic droid exec usage
 
 ```bash
-# Simple query with a fast model (GLM 4.6)
-droid exec --model glm-4.6 "Tell me a joke"
+# Simple query with a fast model (GLM 4.7)
+droid exec --model glm-4.7 "Tell me a joke"
 ```
 
 ### Advanced: System exploration
 
 ```bash
 # Ask droid to explore your system and find specific information
-droid exec --model glm-4.6 "Explore my system and tell me where the file is that I'm serving with Nginx"
+droid exec --model glm-4.7 "Explore my system and tell me where the file is that I'm serving with Nginx"
 ```
 
 Droid will:

--- a/docs/guides/power-user/prompt-crafting.mdx
+++ b/docs/guides/power-user/prompt-crafting.mdx
@@ -372,11 +372,11 @@ Match the model to the task:
 
 | Task Type | Recommended Model | Reasoning Level |
 |-----------|-------------------|-----------------|
-| **Complex architecture** | Opus 4.5 | Medium-High |
+| **Complex architecture** | Opus 4.6 or Opus 4.5 | High-Max |
 | **Feature implementation** | Sonnet 4.5 or GPT-5.1-Codex | Medium |
 | **Quick edits, formatting** | Haiku 4.5 | Off/Low |
 | **Code review** | GPT-5.1-Codex-Max | High |
-| **Bulk automation** | GLM-4.6 (Droid Core) | None |
+| **Bulk automation** | GLM-4.7 (Droid Core) | None |
 | **Research/analysis** | Gemini 3 Pro | High |
 
 ---

--- a/docs/guides/power-user/token-efficiency.mdx
+++ b/docs/guides/power-user/token-efficiency.mdx
@@ -134,13 +134,16 @@ Different models have different cost multipliers and capabilities. Match the mod
 
 | Model | Multiplier | Best For |
 |-------|------------|----------|
-| GLM-4.6 (Droid Core) | 0.25× | Bulk automation, simple tasks |
+| Gemini 3 Flash | 0.2× | Fast, cheap for high-volume tasks |
+| Droid Core (GLM-4.7) | 0.25× | Bulk automation, simple tasks |
+| Droid Core (Kimi K2.5) | 0.25× | Cost-sensitive work, supports images |
 | Claude Haiku 4.5 | 0.4× | Quick edits, routine work |
 | GPT-5.1 / GPT-5.1-Codex | 0.5× | Implementation, debugging |
 | Gemini 3 Pro | 0.8× | Research, analysis |
 | Claude Sonnet 4.5 | 1.2× | Balanced quality/cost |
 | Claude Opus 4.5 | 2× | Complex reasoning, architecture |
-| Claude Opus 4.1 | 6× | Maximum capability (use sparingly) |
+| Claude Opus 4.6 | 2× | Latest flagship, Max reasoning |
+| Claude Opus 4.6 Fast | 6× (Promo) | Opus 4.6 tuned for faster responses |
 
 ### Task-Based Model Selection
 
@@ -148,7 +151,7 @@ Different models have different cost multipliers and capabilities. Match the mod
 Simple edit, formatting      → Haiku 4.5 (0.4×)
 Implement feature from spec  → GPT-5.1-Codex (0.5×)
 Debug complex issue          → Sonnet 4.5 (1.2×)
-Architecture planning        → Opus 4.5 (2×)
+Architecture planning        → Opus 4.6 (2×) or Opus 4.5 (2×)
 Bulk file processing         → Droid Core (0.25×)
 ```
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -24,16 +24,20 @@ Different models have different multipliers applied to calculate Standard Token 
 
 | Model                    | Model ID                     | Multiplier |
 | ------------------------ | ---------------------------- | ---------- |
-| Droid Core               | `glm-4.6`                    | 0.25×      |
+| Gemini 3 Flash           | `gemini-3-flash-preview`     | 0.2×       |
+| Droid Core (GLM-4.7)     | `glm-4.7`                    | 0.25×      |
+| Droid Core (Kimi K2.5)   | `kimi-k2.5`                  | 0.25×      |
 | Claude Haiku 4.5         | `claude-haiku-4-5-20251001`  | 0.4×       |
 | GPT-5.1                  | `gpt-5.1`                    | 0.5×       |
 | GPT-5.1-Codex            | `gpt-5.1-codex`              | 0.5×       |
 | GPT-5.1-Codex-Max        | `gpt-5.1-codex-max`          | 0.5×       |
 | GPT-5.2                  | `gpt-5.2`                    | 0.7×       |
+| GPT-5.2-Codex            | `gpt-5.2-codex`              | 0.7×       |
 | Gemini 3 Pro             | `gemini-3-pro-preview`       | 0.8×       |
-| Gemini 3 Flash           | `gemini-3-flash-preview`     | 0.2×       |
 | Claude Sonnet 4.5        | `claude-sonnet-4-5-20250929` | 1.2×       |
 | Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 2×         |
+| Claude Opus 4.6          | `claude-opus-4-6`            | 2×         |
+| Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       | 6× (Promo) |
 
 ## Thinking About Tokens
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -33,6 +33,7 @@ The CLI operates in two modes:
 | `cat file \| droid exec`         | Process piped content                       | `git diff \| droid exec "draft release notes"` |
 | `droid exec -s <id> "query"`     | Resume existing session in exec mode        | `droid exec -s session-123 "continue"`          |
 | `droid exec --list-tools`        | List available tools, then exit             | `droid exec --list-tools`                       |
+| `droid update`                   | Manually update the CLI to latest version   | `droid update`                                  |
 
 ## CLI flags
 
@@ -41,7 +42,7 @@ Customize droid's behavior with command-line flags:
 | Flag                                 | Description                                                                                                  | Example                                                    |
 | :----------------------------------- | :----------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------- |
 | `-f, --file <path>`                  | Read prompt from a file                                                                                      | `droid exec -f plan.md`                                    |
-| `-m, --model <id>`                   | Select a specific model (see [model IDs](#available-models))                                                 | `droid exec -m claude-opus-4-5-20251101`                   |
+| `-m, --model <id>`                   | Select a specific model (see [model IDs](#available-models))                                                 | `droid exec -m claude-opus-4-6`                            |
 | `-s, --session-id <id>`              | Continue an existing session                                                                                 | `droid exec -s session-abc123`                             |
 | `--auto <level>`                     | Set [autonomy level](#autonomy-levels) (`low`, `medium`, `high`)                                             | `droid exec --auto medium "run tests"`                     |
 | `--enabled-tools <ids>`              | Force-enable specific tools (comma or space separated)                                                       | `droid exec --enabled-tools ApplyPatch,Bash`               |
@@ -97,18 +98,22 @@ droid exec --auto high "Run tests, commit, and push changes"
 
 ## Available models
 
-| Model ID                      | Name                         | Reasoning support                 | Default reasoning |
-| :---------------------------- | :--------------------------- | :-------------------------------- | :---------------- |
-| `claude-opus-4-5-20251101`    | Claude Opus 4.5 (default)    | Yes (Off/Low/Medium/High)         | off               |
-| `gpt-5.1-codex-max`           | GPT-5.1-Codex-Max            | Yes (Low/Medium/High/Extra High)  | medium            |
-| `gpt-5.1-codex`               | GPT-5.1-Codex                | Yes (Low/Medium/High)             | medium            |
-| `gpt-5.1`                     | GPT-5.1                      | Yes (None/Low/Medium/High)        | none              |
-| `gpt-5.2`                     | GPT-5.2                      | Yes (Low/Medium/High)             | low               |
-| `claude-sonnet-4-5-20250929`  | Claude Sonnet 4.5            | Yes (Off/Low/Medium/High)         | off               |
-| `claude-haiku-4-5-20251001`   | Claude Haiku 4.5             | Yes (Off/Low/Medium/High)         | off               |
-| `gemini-3-pro-preview`        | Gemini 3 Pro                 | Yes (Low/High)                    | high              |
-| `gemini-3-flash-preview`      | Gemini 3 Flash               | Yes (Minimal/Low/Medium/High)     | high              |
-| `glm-4.6`                     | Droid Core (GLM-4.6)         | None only                         | none              |
+| Model ID                      | Name                         | Reasoning support                        | Default reasoning |
+| :---------------------------- | :--------------------------- | :--------------------------------------- | :---------------- |
+| `claude-opus-4-6`             | Claude Opus 4.6              | Yes (Off/Low/Medium/High/Max)            | high              |
+| `claude-opus-4-6-fast`        | Claude Opus 4.6 Fast         | Yes (Off/Low/Medium/High/Max)            | high              |
+| `claude-opus-4-5-20251101`    | Claude Opus 4.5              | Yes (Off/Low/Medium/High)                | off               |
+| `gpt-5.1-codex-max`           | GPT-5.1-Codex-Max            | Yes (Low/Medium/High/Extra High)         | medium            |
+| `gpt-5.1-codex`               | GPT-5.1-Codex                | Yes (Low/Medium/High)                    | medium            |
+| `gpt-5.1`                     | GPT-5.1                      | Yes (None/Low/Medium/High)               | none              |
+| `gpt-5.2`                     | GPT-5.2                      | Yes (Off/Low/Medium/High/Extra High)     | low               |
+| `gpt-5.2-codex`               | GPT-5.2-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
+| `claude-sonnet-4-5-20250929`  | Claude Sonnet 4.5            | Yes (Off/Low/Medium/High)                | off               |
+| `claude-haiku-4-5-20251001`   | Claude Haiku 4.5             | Yes (Off/Low/Medium/High)                | off               |
+| `gemini-3-pro-preview`        | Gemini 3 Pro                 | Yes (None/Low/Medium/High)               | high              |
+| `gemini-3-flash-preview`      | Gemini 3 Flash               | Yes (Minimal/Low/Medium/High)            | high              |
+| `glm-4.7`                     | Droid Core (GLM-4.7)         | None only                                | none              |
+| `kimi-k2.5`                   | Droid Core (Kimi K2.5)       | None only                                | none              |
 
 Custom models configured via [BYOK](/cli/configuration/byok) use the format: `custom:<alias>`
 
@@ -141,6 +146,7 @@ Available when running `droid` in interactive mode. Type the command at the prom
 | `/cost`                  | Show token usage statistics                           |
 | `/droids`                | Manage custom droids                                  |
 | `/favorite`              | Mark current session as a favorite                    |
+| `/fork`                  | Duplicate current session with all messages into a new session |
 | `/help`                  | Show available slash commands                         |
 | `/hooks`                 | Manage lifecycle hooks                                |
 | `/ide`                   | Configure IDE integrations                            |

--- a/docs/reference/hooks-reference.mdx
+++ b/docs/reference/hooks-reference.mdx
@@ -230,6 +230,7 @@ statistics, or saving session state.
 The `reason` field in the hook input will be one of:
 
 * `clear` - Session cleared with /clear command
+* `new` - Session ended with /new command
 * `logout` - User logged out
 * `prompt_input_exit` - User exited while prompt input was visible
 * `other` - Other exit reasons


### PR DESCRIPTION
## Summary

Update documentation across 18 files to reflect the current model registry and recently shipped CLI features.

### Model updates (16 files)
- Add **Opus 4.6**, **Opus 4.6 Fast**, **GPT-5.2-Codex**, and **Kimi K2.5**
- Replace all GLM-4.6 references with **GLM-4.7** (preserving changelogs)
- Update GPT-5.2 reasoning levels (now includes Off/Extra High)
- Update Opus 4.6 reasoning (supports Max)
- Fix pricing table sort order (multiplier ascending, alpha tiebreaker)
- Fix stack rank numbering in choosing-your-model

### Changelog-driven additions (5 files)
- Add `/fork` to slash commands table
- Add `droid update` to CLI commands table
- Add `npm install -g droid` as install option in quickstart and overview
- Add `.agent/skills/` compatibility path to skills discovery table
- Add `new` as SessionEnd hook reason

### Skill
- Add `.factory/skills/update-model-docs/` for repeatable registry syncs

### Verification
- Mintlify validate passes
- All changes verified in local dev server via Playwright