### PR TITLE
docs: add recently shipped CLI features from changelog

### DIFF
--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -66,6 +66,7 @@ Skills are discovered from a small set of well-known locations:
 | ------------- | ----------------------------------- | ----------------------------------------------------------------------- |
 | **Workspace** | `<repo>/.factory/skills/`           | Project skills shared with teammates; checked into git.                 |
 | **Personal**  | `~/.factory/skills/`                | Private skills that follow you across projects on your machine.         |
+| **Compatibility** | `<repo>/.agent/skills/`         | Discovered for compatibility with `.agent` folder conventions.          |
 
 Each **skill** lives in its own directory under one of these roots:
 

--- a/docs/cli/getting-started/overview.mdx
+++ b/docs/cli/getting-started/overview.mdx
@@ -16,6 +16,10 @@ curl -fsSL https://app.factory.ai/cli | sh
 irm https://app.factory.ai/cli/windows | iex
 ```
 
+```bash npm
+npm install -g droid
+```
+
 </CodeGroup>
 
 Then navigate to your project and start the droid CLI.

--- a/docs/cli/getting-started/quickstart.mdx
+++ b/docs/cli/getting-started/quickstart.mdx
@@ -29,6 +29,10 @@ brew install --cask droid
 irm https://app.factory.ai/cli/windows | iex
 ```
 
+```bash npm
+npm install -g droid
+```
+
 </CodeGroup>
 
 <Note>

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -33,6 +33,7 @@ The CLI operates in two modes:
 | `cat file \| droid exec`         | Process piped content                       | `git diff \| droid exec "draft release notes"` |
 | `droid exec -s <id> "query"`     | Resume existing session in exec mode        | `droid exec -s session-123 "continue"`          |
 | `droid exec --list-tools`        | List available tools, then exit             | `droid exec --list-tools`                       |
+| `droid update`                   | Manually update the CLI to latest version   | `droid update`                                  |
 
 ## CLI flags
 
@@ -145,6 +146,7 @@ Available when running `droid` in interactive mode. Type the command at the prom
 | `/cost`                  | Show token usage statistics                           |
 | `/droids`                | Manage custom droids                                  |
 | `/favorite`              | Mark current session as a favorite                    |
+| `/fork`                  | Duplicate current session with all messages into a new session |
 | `/help`                  | Show available slash commands                         |
 | `/hooks`                 | Manage lifecycle hooks                                |
 | `/ide`                   | Configure IDE integrations                            |

--- a/docs/reference/hooks-reference.mdx
+++ b/docs/reference/hooks-reference.mdx
@@ -230,6 +230,7 @@ statistics, or saving session state.
 The `reason` field in the hook input will be one of:
 
 * `clear` - Session cleared with /clear command
+* `new` - Session ended with /new command
 * `logout` - User logged out
 * `prompt_input_exit` - User exited while prompt input was visible
 * `other` - Other exit reasons


### PR DESCRIPTION
## Summary

Document 5 recently shipped CLI features (v0.56-v0.57) that were missing from the docs.

### Changes (5 files)
- **`/fork`** -- added to slash commands table in cli-reference
- **`droid update`** -- added to CLI commands table in cli-reference
- **`npm install -g droid`** -- added as install option in quickstart and overview
- **`.agent/skills/`** -- added as compatibility path in skills discovery table
- **`new` SessionEnd reason** -- added to hooks-reference

### Verification
- Mintlify validate passes
- All additions verified in local dev server