### PR TITLE
docs: add GPT-5.3-Codex and MiniMax M2.5 to model documentation

### DIFF
--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -27,7 +27,7 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 
 | Setting | Options | Default | Description |
 | ------- | ------- | ------- | ----------- |
-| `model` | `opus`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.2-codex`, `haiku`, `gemini-3-pro`, `droid-core`, `kimi-k2.5`, `custom-model` | `opus` | The default AI model used by droid |
+| `model` | `opus`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3-pro`, `droid-core`, `kimi-k2.5`, `minimax-m2.5`, `custom-model` | `opus` | The default AI model used by droid |
 | `reasoningEffort` | `off`, `none`, `low`, `medium`, `high` (availability depends on the model) | Model-dependent default | Controls how much structured thinking the model performs. |
 | `autonomyLevel` | `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high` | `normal` | Sets the default autonomy mode when starting droid. |
 | `cloudSessionSync` | `true`, `false` | `true` | Mirror CLI sessions to Factory web. |
@@ -62,11 +62,13 @@ Choose the default AI model that powers your droid:
 - **`gpt-5.1-codex`** - Advanced coding-focused model
 - **`gpt-5.1-codex-max`** - GPT-5.1-Codex-Max, supports Extra High reasoning
 - **`gpt-5.2`** - OpenAI GPT-5.2
-- **`gpt-5.2-codex`** - GPT-5.2-Codex, latest OpenAI coding model with Extra High reasoning
+- **`gpt-5.2-codex`** - GPT-5.2-Codex, OpenAI coding model with Extra High reasoning
+- **`gpt-5.3-codex`** - GPT-5.3-Codex, latest OpenAI coding model with Extra High reasoning and verbosity support
 - **`haiku`** - Claude Haiku 4.5, fast and cost-effective
 - **`gemini-3-pro`** - Gemini 3 Pro
 - **`droid-core`** - GLM-4.7 open-source model
 - **`kimi-k2.5`** - Kimi K2.5 open-source model with image support
+- **`minimax-m2.5`** - MiniMax M2.5 open-source model with reasoning support (0.12× multiplier)
 - **`custom-model`** - Your own configured model via BYOK
 
 [You can also add custom models and BYOK.](/cli/configuration/byok)

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -80,10 +80,12 @@ Supported models (examples):
 - gpt-5.1
 - gpt-5.2
 - gpt-5.2-codex
+- gpt-5.3-codex
 - gemini-3-pro-preview
 - gemini-3-flash-preview
 - glm-4.7
 - kimi-k2.5
+- minimax-m2.5
 
 <Note>
 See the [model table](/pricing#pricing-table) for the full list of available models and their costs.

--- a/docs/cli/user-guides/choosing-your-model.mdx
+++ b/docs/cli/user-guides/choosing-your-model.mdx
@@ -4,7 +4,7 @@ description: Balance accuracy, speed, and cost by picking the right model and re
 keywords: ['model', 'models', 'llm', 'claude', 'sonnet', 'opus', 'haiku', 'gpt', 'openai', 'anthropic', 'choose model', 'switch model']
 ---
 
-Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shifts. Use this guide as a snapshot of how the major options compare today, and expect to revisit it as we publish updates. This guide was last updated on Thursday, February 12th 2026.
+Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shifts. Use this guide as a snapshot of how the major options compare today, and expect to revisit it as we publish updates. This guide was last updated on Friday, February 14th 2026.
 
 ---
 
@@ -17,15 +17,17 @@ Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shi
 | 3    | **Claude Opus 4.5**           | Proven quality-and-safety balance; strong default for TUI and exec.                                                                              |
 | 4    | **GPT-5.1-Codex-Max**         | Fast coding loops with support up to **Extra High** reasoning; great for heavy implementation and debugging.                                    |
 | 5    | **Claude Sonnet 4.5**         | Strong daily driver with balanced cost/quality; great general-purpose choice when you don’t need Opus-level depth.                              |
-| 6    | **GPT-5.2-Codex**             | Latest OpenAI coding model with **Extra High** reasoning; strong for implementation-heavy tasks.                                                |
-| 7    | **GPT-5.1-Codex**             | Quick iteration with solid code quality at lower cost; bump reasoning when you need more depth.                                                 |
-| 8    | **GPT-5.1**                   | Good generalist, especially when you want OpenAI ergonomics with flexible reasoning effort.                                                     |
-| 9    | **GPT-5.2**                   | Advanced OpenAI model with verbosity support and reasoning up to **Extra High**.                                                                |
-| 10   | **Claude Haiku 4.5**          | Fast, cost-efficient for routine tasks and high-volume automation.                                                                              |
-| 11   | **Gemini 3 Pro**              | Strong at mixed reasoning with Low/High settings; helpful for researchy flows with structured outputs.                                         |
-| 12   | **Gemini 3 Flash**            | Fast, cheap (0.2× multiplier) with full reasoning support; great for high-volume tasks where speed matters.                                    |
-| 13   | **Droid Core (GLM-4.7)**      | Open-source, 0.25× multiplier, great for bulk automation or air-gapped environments; note: no image support.                                   |
-| 14   | **Droid Core (Kimi K2.5)**    | Open-source, 0.25× multiplier with image support; good for cost-sensitive work.                                                                 |
+| 6    | **GPT-5.3-Codex**             | Newest OpenAI coding model with **Extra High** reasoning and verbosity support; strong for implementation-heavy tasks.                          |
+| 7    | **GPT-5.2-Codex**             | Proven OpenAI coding model with **Extra High** reasoning; solid for implementation-heavy tasks.                                                 |
+| 8    | **GPT-5.1-Codex**             | Quick iteration with solid code quality at lower cost; bump reasoning when you need more depth.                                                 |
+| 9    | **GPT-5.1**                   | Good generalist, especially when you want OpenAI ergonomics with flexible reasoning effort.                                                     |
+| 10   | **GPT-5.2**                   | Advanced OpenAI model with verbosity support and reasoning up to **Extra High**.                                                                |
+| 11   | **Claude Haiku 4.5**          | Fast, cost-efficient for routine tasks and high-volume automation.                                                                              |
+| 12   | **Gemini 3 Pro**              | Strong at mixed reasoning with Low/High settings; helpful for researchy flows with structured outputs.                                         |
+| 13   | **Gemini 3 Flash**            | Fast, cheap (0.2× multiplier) with full reasoning support; great for high-volume tasks where speed matters.                                    |
+| 14   | **Droid Core (MiniMax M2.5)** | Open-source, 0.12× multiplier with reasoning support (Low/Medium/High); cheapest model available. No image support.                            |
+| 15   | **Droid Core (GLM-4.7)**      | Open-source, 0.25× multiplier, great for bulk automation or air-gapped environments; note: no image support.                                   |
+| 16   | **Droid Core (Kimi K2.5)**    | Open-source, 0.25× multiplier with image support; good for cost-sensitive work.                                                                 |
 
 <Note>
   We ship model updates regularly. When a new release overtakes the list above,
@@ -39,10 +41,10 @@ Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shi
 | Scenario                                                         | Recommended model                                                                                                                          |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Deep planning, architecture reviews, ambiguous product specs** | Start with **Opus 4.6** for best depth and safety, or **Opus 4.6 Fast** for faster turnaround. Use **Sonnet 4.5** when you want balanced cost/quality, or **Codex/Codex-Max** for faster iteration with reasoning. |
-| **Full-feature development, large refactors**                    | **Opus 4.6** or **Opus 4.5** for depth and safety. **GPT-5.2-Codex** or **GPT-5.1-Codex-Max** when you need speed plus **Extra High** reasoning; **Sonnet 4.5** for balanced loops. |
-| **Repeatable edits, summarization, boilerplate generation**      | **Haiku 4.5** or **Droid Core** for speed and cost. **GPT-5.1 / GPT-5.1-Codex** when you need higher quality or structured outputs. |
+| **Full-feature development, large refactors**                    | **Opus 4.6** or **Opus 4.5** for depth and safety. **GPT-5.3-Codex**, **GPT-5.2-Codex**, or **GPT-5.1-Codex-Max** when you need speed plus **Extra High** reasoning; **Sonnet 4.5** for balanced loops. |
+| **Repeatable edits, summarization, boilerplate generation**      | **Haiku 4.5** or **Droid Core** (including **MiniMax M2.5** at 0.12×) for speed and cost. **GPT-5.1 / GPT-5.1-Codex** when you need higher quality or structured outputs. |
 | **CI/CD or automation loops**                                    | Favor **Haiku 4.5** or **Droid Core** for predictable, low-cost throughput. Use **Codex** or **Codex-Max** when automation needs stronger reasoning. |
-| **High-volume automation, frequent quick turns**                 | **Haiku 4.5** for speedy feedback. **Droid Core** when cost is critical or you need air-gapped deployment. |
+| **High-volume automation, frequent quick turns**                 | **Haiku 4.5** for speedy feedback. **Droid Core** (especially **MiniMax M2.5** at 0.12× with reasoning) when cost is critical or you need air-gapped deployment. |
 
 <Tip>
   **Claude Opus 4.6** is the top-tier option for extremely complex architecture decisions or critical work where you need maximum reasoning capability. **Opus 4.6 Fast** is tuned for faster responses at a higher cost. Most tasks don't require Opus-level power—start with Sonnet 4.5 and escalate only if needed.
@@ -70,12 +72,14 @@ Tip: you can swap models mid-session with `/model` or by toggling in the setting
 - **GPT-5.1-Codex-Max**: Low / Medium / High / **Extra High** (default: Medium)
 - **GPT-5.2**: Off / Low / Medium / High / **Extra High** (default: Low)
 - **GPT-5.2-Codex**: None / Low / Medium / High / **Extra High** (default: Medium)
+- **GPT-5.3-Codex**: None / Low / Medium / High / **Extra High** (default: Medium)
 - **Gemini 3 Pro**: None / Low / Medium / High (default: High)
 - **Gemini 3 Flash**: Minimal / Low / Medium / High (default: High)
 - **Droid Core (GLM-4.7)**: None only (default: None; no image support)
 - **Droid Core (Kimi K2.5)**: None only (default: None)
+- **Droid Core (MiniMax M2.5)**: Low / Medium / High (default: High)
 
-Reasoning effort increases latency and cost—start low for simple work and escalate as needed. **Max** is available on Claude Opus 4.6. **Extra High** is available on GPT-5.1-Codex-Max, GPT-5.2, and GPT-5.2-Codex.
+Reasoning effort increases latency and cost—start low for simple work and escalate as needed. **Max** is available on Claude Opus 4.6. **Extra High** is available on GPT-5.1-Codex-Max, GPT-5.2, GPT-5.2-Codex, and GPT-5.3-Codex.
 
 <Tip>
   Change reasoning effort from `/model` → **Reasoning effort**, or via the
@@ -90,14 +94,14 @@ Factory ships with managed Anthropic and OpenAI access. If you prefer to run aga
 
 ### Open-source models
 
-**Droid Core (GLM-4.7)** and **Droid Core (Kimi K2.5)** are open-source alternatives available in the CLI. They're useful for:
+**Droid Core (GLM-4.7)**, **Droid Core (Kimi K2.5)**, and **Droid Core (MiniMax M2.5)** are open-source alternatives available in the CLI. They're useful for:
 
 - **Air-gapped environments** where external API calls aren't allowed
 - **Cost-sensitive projects** needing unlimited local inference
 - **Privacy requirements** where code cannot leave your infrastructure
 - **Experimentation** with open-source model capabilities
 
-**Note:** GLM-4.7 does not support image attachments. Kimi K2.5 does support images. For image-based workflows, use Claude, GPT, or Kimi models.
+**Note:** GLM-4.7 and MiniMax M2.5 do not support image attachments. Kimi K2.5 does support images. MiniMax M2.5 is the cheapest model available (0.12× multiplier) and uniquely supports reasoning (Low/Medium/High) among Droid Core models. For image-based workflows, use Claude, GPT, or Kimi models.
 
 To use open-source models, you'll need to configure them via BYOK with a local inference server (like Ollama) or a hosted provider. See [BYOK documentation](/cli/configuration/byok) for setup instructions.
 

--- a/docs/guides/power-user/token-efficiency.mdx
+++ b/docs/guides/power-user/token-efficiency.mdx
@@ -134,11 +134,13 @@ Different models have different cost multipliers and capabilities. Match the mod
 
 | Model | Multiplier | Best For |
 |-------|------------|----------|
+| Droid Core (MiniMax M2.5) | 0.12× | Cheapest option with reasoning support |
 | Gemini 3 Flash | 0.2× | Fast, cheap for high-volume tasks |
 | Droid Core (GLM-4.7) | 0.25× | Bulk automation, simple tasks |
 | Droid Core (Kimi K2.5) | 0.25× | Cost-sensitive work, supports images |
 | Claude Haiku 4.5 | 0.4× | Quick edits, routine work |
 | GPT-5.1 / GPT-5.1-Codex | 0.5× | Implementation, debugging |
+| GPT-5.2-Codex / GPT-5.3-Codex | 0.7× | Advanced coding with Extra High reasoning |
 | Gemini 3 Pro | 0.8× | Research, analysis |
 | Claude Sonnet 4.5 | 1.2× | Balanced quality/cost |
 | Claude Opus 4.5 | 2× | Complex reasoning, architecture |

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -24,6 +24,7 @@ Different models have different multipliers applied to calculate Standard Token 
 
 | Model                    | Model ID                     | Multiplier |
 | ------------------------ | ---------------------------- | ---------- |
+| Droid Core (MiniMax M2.5)| `minimax-m2.5`               | 0.12×      |
 | Gemini 3 Flash           | `gemini-3-flash-preview`     | 0.2×       |
 | Droid Core (GLM-4.7)     | `glm-4.7`                    | 0.25×      |
 | Droid Core (Kimi K2.5)   | `kimi-k2.5`                  | 0.25×      |
@@ -33,6 +34,7 @@ Different models have different multipliers applied to calculate Standard Token 
 | GPT-5.1-Codex-Max        | `gpt-5.1-codex-max`          | 0.5×       |
 | GPT-5.2                  | `gpt-5.2`                    | 0.7×       |
 | GPT-5.2-Codex            | `gpt-5.2-codex`              | 0.7×       |
+| GPT-5.3-Codex            | `gpt-5.3-codex`              | 0.7×       |
 | Gemini 3 Pro             | `gemini-3-pro-preview`       | 0.8×       |
 | Claude Sonnet 4.5        | `claude-sonnet-4-5-20250929` | 1.2×       |
 | Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 2×         |

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -108,12 +108,14 @@ droid exec --auto high "Run tests, commit, and push changes"
 | `gpt-5.1`                     | GPT-5.1                      | Yes (None/Low/Medium/High)               | none              |
 | `gpt-5.2`                     | GPT-5.2                      | Yes (Off/Low/Medium/High/Extra High)     | low               |
 | `gpt-5.2-codex`               | GPT-5.2-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
+| `gpt-5.3-codex`               | GPT-5.3-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `claude-sonnet-4-5-20250929`  | Claude Sonnet 4.5            | Yes (Off/Low/Medium/High)                | off               |
 | `claude-haiku-4-5-20251001`   | Claude Haiku 4.5             | Yes (Off/Low/Medium/High)                | off               |
 | `gemini-3-pro-preview`        | Gemini 3 Pro                 | Yes (None/Low/Medium/High)               | high              |
 | `gemini-3-flash-preview`      | Gemini 3 Flash               | Yes (Minimal/Low/Medium/High)            | high              |
 | `glm-4.7`                     | Droid Core (GLM-4.7)         | None only                                | none              |
 | `kimi-k2.5`                   | Droid Core (Kimi K2.5)       | None only                                | none              |
+| `minimax-m2.5`                | Droid Core (MiniMax M2.5)    | Yes (Low/Medium/High)                    | high              |
 
 Custom models configured via [BYOK](/cli/configuration/byok) use the format: `custom:<alias>`
 


### PR DESCRIPTION
## Summary

Add two newly released models to all documentation tiers:

### New Models

| Model | Model ID | Multiplier | Reasoning | Default |
|-------|----------|------------|-----------|---------|
| **GPT-5.3-Codex** | `gpt-5.3-codex` | 0.7× | None/Low/Medium/High/Extra High | Medium |
| **Droid Core (MiniMax M2.5)** | `minimax-m2.5` | 0.12× | Low/Medium/High | High |

### Files Updated

**Tier 1 (model tables):**
- `docs/pricing.mdx` — pricing table
- `docs/reference/cli-reference.mdx` — available models table
- `docs/cli/user-guides/choosing-your-model.mdx` — stack rank, job matching, reasoning settings, open-source section, date

**Tier 2 (model lists):**
- `docs/cli/configuration/settings.mdx` — model options and descriptions
- `docs/cli/droid-exec/overview.mdx` — supported models list

**Tier 3 (references):**
- `docs/guides/power-user/token-efficiency.mdx` — cost multipliers table

### Verification
- All ranks sequential (1-16), no gaps or duplicates
- Cross-file consistency confirmed (names, IDs, multipliers match everywhere)
- No changelog files modified
- Local mintlify dev build renders all pages correctly