### PR TITLE
docs: update Opus 4.6 Fast multiplier from 6x promo to 12x

### DIFF
--- a/docs/cli/user-guides/choosing-your-model.mdx
+++ b/docs/cli/user-guides/choosing-your-model.mdx
@@ -13,7 +13,7 @@ Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shi
 | Rank | Model                         | Why we reach for it                                                                                                                               |
 | ---- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 1    | **Claude Opus 4.6**           | Latest Anthropic flagship with **Max** reasoning; best depth and safety for complex work.                                                        |
-| 2    | **Claude Opus 4.6 Fast**      | Opus 4.6 tuned for faster response times; 6× promo multiplier.                                                                          |
+| 2    | **Claude Opus 4.6 Fast**      | Opus 4.6 tuned for faster response times; 12× multiplier.                                                                          |
 | 3    | **Claude Opus 4.5**           | Proven quality-and-safety balance; strong default for TUI and exec.                                                                              |
 | 4    | **GPT-5.1-Codex-Max**         | Fast coding loops with support up to **Extra High** reasoning; great for heavy implementation and debugging.                                    |
 | 5    | **Claude Sonnet 4.5**         | Strong daily driver with balanced cost/quality; great general-purpose choice when you don’t need Opus-level depth.                              |

--- a/docs/guides/power-user/token-efficiency.mdx
+++ b/docs/guides/power-user/token-efficiency.mdx
@@ -145,7 +145,7 @@ Different models have different cost multipliers and capabilities. Match the mod
 | Claude Sonnet 4.5 | 1.2× | Balanced quality/cost |
 | Claude Opus 4.5 | 2× | Complex reasoning, architecture |
 | Claude Opus 4.6 | 2× | Latest flagship, Max reasoning |
-| Claude Opus 4.6 Fast | 6× (Promo) | Opus 4.6 tuned for faster responses |
+| Claude Opus 4.6 Fast | 12× | Opus 4.6 tuned for faster responses |
 
 ### Task-Based Model Selection
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -39,7 +39,7 @@ Different models have different multipliers applied to calculate Standard Token 
 | Claude Sonnet 4.5        | `claude-sonnet-4-5-20250929` | 1.2×       |
 | Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 2×         |
 | Claude Opus 4.6          | `claude-opus-4-6`            | 2×         |
-| Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       | 6× (Promo) |
+| Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       | 12×        |
 
 ## Thinking About Tokens
 


### PR DESCRIPTION
## Summary

Promo period for Opus 4.6 Fast has ended. Updates the multiplier from `6× (Promo)` to `12×` and removes all promo labels.

### Files updated
- `docs/pricing.mdx` — pricing table
- `docs/cli/user-guides/choosing-your-model.mdx` — stack rank description
- `docs/guides/power-user/token-efficiency.mdx` — cost multipliers table

### Not edited
- `docs/changelog/` — historical record, not modified per policy