### PR TITLE
docs(enterprise): add org-managed settings schema to hierarchical settings page

### DIFF
--- a/docs/enterprise/hierarchical-settings-and-org-control.mdx
+++ b/docs/enterprise/hierarchical-settings-and-org-control.mdx
@@ -208,7 +208,7 @@ Below is the full schema for org-managed settings. These are configured by org a
 </ResponseField>
 
 <ResponseField name="strictKnownMarketplaces" type="object[]">
-  Marketplace sources that are strictly enforced. Same source shape as `extraKnownMarketplaces` entries.
+  Marketplace sources that are strictly enforced. Each entry is a source object directly (e.g. `{ "source": "github", "repo": "owner/repo" }`), not wrapped in a `source` key like `extraKnownMarketplaces` values.
 </ResponseField>
 
 ### Supported model IDs


### PR DESCRIPTION
## Summary

Add a comprehensive, interactive schema reference for org-managed settings to the [Hierarchical Settings & Org Control](https://docs.factory.ai/enterprise/hierarchical-settings-and-org-control) docs page.

## Changes

- **Schema reference section** using Mintlify `<ResponseField>` / `<Expandable>` components documenting all `ManagedSettingsBaseSchema` properties:
  - `sessionDefaultSettings`, `maxAutonomyLevel`, `cloudSessionSync`, `includeCoAuthoredByDroid`, `enableDroidShield`, `ideAutoConnect`
  - `commandAllowlist` / `commandDenylist`
  - `customModels` (with `custom:` prefix requirement for `id`, env var syntax for `apiKey`)
  - `modelPolicy`, `userModelPolicies`
  - `enabledPlugins` (`plugin@marketplace` format, auto-install behavior)
  - `extraKnownMarketplaces` (auto-clone on startup), `strictKnownMarketplaces`
- **Supported model IDs table** aligned with current CLI model selector
- **Full JSON example** with all fields populated
- **Fixes**: `sessionDefaults` → `sessionDefaultSettings` typo, added `skills/` to folder contents list

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/factory/factory/editor/arman%2Fdocs-managed-settings-schema?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->