### PR TITLE
docs: add GLM-5 and Gemini 3.1 Pro to model documentation

### DIFF
--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -27,7 +27,7 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 
 | Setting | Options | Default | Description |
 | ------- | ------- | ------- | ----------- |
-| `model` | `opus`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3-pro`, `droid-core`, `kimi-k2.5`, `minimax-m2.5`, `custom-model` | `opus` | The default AI model used by droid |
+| `model` | `opus`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3-pro`, `gemini-3.1-pro`, `droid-core`, `glm-5`, `kimi-k2.5`, `minimax-m2.5`, `custom-model` | `opus` | The default AI model used by droid |
 | `reasoningEffort` | `off`, `none`, `low`, `medium`, `high` (availability depends on the model) | Model-dependent default | Controls how much structured thinking the model performs. |
 | `autonomyLevel` | `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high` | `normal` | Sets the default autonomy mode when starting droid. |
 | `cloudSessionSync` | `true`, `false` | `true` | Mirror CLI sessions to Factory web. |
@@ -66,7 +66,9 @@ Choose the default AI model that powers your droid:
 - **`gpt-5.3-codex`** - GPT-5.3-Codex, latest OpenAI coding model with Extra High reasoning and verbosity support
 - **`haiku`** - Claude Haiku 4.5, fast and cost-effective
 - **`gemini-3-pro`** - Gemini 3 Pro
+- **`gemini-3.1-pro`** - Gemini 3.1 Pro
 - **`droid-core`** - GLM-4.7 open-source model
+- **`glm-5`** - GLM-5 open-source model
 - **`kimi-k2.5`** - Kimi K2.5 open-source model with image support
 - **`minimax-m2.5`** - MiniMax M2.5 open-source model with reasoning support (0.12× multiplier)
 - **`custom-model`** - Your own configured model via BYOK

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -82,8 +82,10 @@ Supported models (examples):
 - gpt-5.2-codex
 - gpt-5.3-codex
 - gemini-3-pro-preview
+- gemini-3.1-pro-preview
 - gemini-3-flash-preview
 - glm-4.7
+- glm-5
 - kimi-k2.5
 - minimax-m2.5
 

--- a/docs/cli/user-guides/choosing-your-model.mdx
+++ b/docs/cli/user-guides/choosing-your-model.mdx
@@ -4,7 +4,7 @@ description: Balance accuracy, speed, and cost by picking the right model and re
 keywords: ['model', 'models', 'llm', 'claude', 'sonnet', 'opus', 'haiku', 'gpt', 'openai', 'anthropic', 'choose model', 'switch model']
 ---
 
-Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shifts. Use this guide as a snapshot of how the major options compare today, and expect to revisit it as we publish updates. This guide was last updated on Friday, February 14th 2026.
+Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shifts. Use this guide as a snapshot of how the major options compare today, and expect to revisit it as we publish updates. This guide was last updated on Wednesday, February 25th 2026.
 
 ---
 
@@ -23,11 +23,13 @@ Model quality evolves quickly, and we tune the CLI defaults as the ecosystem shi
 | 9    | **GPT-5.1**                   | Good generalist, especially when you want OpenAI ergonomics with flexible reasoning effort.                                                     |
 | 10   | **GPT-5.2**                   | Advanced OpenAI model with verbosity support and reasoning up to **Extra High**.                                                                |
 | 11   | **Claude Haiku 4.5**          | Fast, cost-efficient for routine tasks and high-volume automation.                                                                              |
-| 12   | **Gemini 3 Pro**              | Strong at mixed reasoning with Low/High settings; helpful for researchy flows with structured outputs.                                         |
-| 13   | **Gemini 3 Flash**            | Fast, cheap (0.2× multiplier) with full reasoning support; great for high-volume tasks where speed matters.                                    |
-| 14   | **Droid Core (MiniMax M2.5)** | Open-source, 0.12× multiplier with reasoning support (Low/Medium/High); cheapest model available. No image support.                            |
-| 15   | **Droid Core (GLM-4.7)**      | Open-source, 0.25× multiplier, great for bulk automation or air-gapped environments; note: no image support.                                   |
-| 16   | **Droid Core (Kimi K2.5)**    | Open-source, 0.25× multiplier with image support; good for cost-sensitive work.                                                                 |
+| 12   | **Gemini 3.1 Pro**            | Newer Gemini Pro generation with strong structured outputs and mixed reasoning controls for research-heavy tasks.                                |
+| 13   | **Gemini 3 Pro**              | Strong at mixed reasoning with Low/High settings; helpful for researchy flows with structured outputs.                                           |
+| 14   | **Gemini 3 Flash**            | Fast, cheap (0.2× multiplier) with full reasoning support; great for high-volume tasks where speed matters.                                     |
+| 15   | **Droid Core (MiniMax M2.5)** | Open-source, 0.12× multiplier with reasoning support (Low/Medium/High); cheapest model available. No image support.                             |
+| 16   | **Droid Core (GLM-5)**        | Open-source, 0.4× multiplier with updated GLM capabilities for bulk automation and air-gapped environments; no image support.                   |
+| 17   | **Droid Core (GLM-4.7)**      | Open-source, 0.25× multiplier, stable choice for bulk automation or air-gapped environments; note: no image support.                            |
+| 18   | **Droid Core (Kimi K2.5)**    | Open-source, 0.25× multiplier with image support; good for cost-sensitive work.                                                                  |
 
 <Note>
   We ship model updates regularly. When a new release overtakes the list above,
@@ -73,8 +75,10 @@ Tip: you can swap models mid-session with `/model` or by toggling in the setting
 - **GPT-5.2**: Off / Low / Medium / High / **Extra High** (default: Low)
 - **GPT-5.2-Codex**: None / Low / Medium / High / **Extra High** (default: Medium)
 - **GPT-5.3-Codex**: None / Low / Medium / High / **Extra High** (default: Medium)
+- **Gemini 3.1 Pro**: Low / Medium / High (default: High)
 - **Gemini 3 Pro**: None / Low / Medium / High (default: High)
 - **Gemini 3 Flash**: Minimal / Low / Medium / High (default: High)
+- **Droid Core (GLM-5)**: None only (default: None; no image support)
 - **Droid Core (GLM-4.7)**: None only (default: None; no image support)
 - **Droid Core (Kimi K2.5)**: None only (default: None)
 - **Droid Core (MiniMax M2.5)**: Low / Medium / High (default: High)
@@ -94,14 +98,14 @@ Factory ships with managed Anthropic and OpenAI access. If you prefer to run aga
 
 ### Open-source models
 
-**Droid Core (GLM-4.7)**, **Droid Core (Kimi K2.5)**, and **Droid Core (MiniMax M2.5)** are open-source alternatives available in the CLI. They're useful for:
+**Droid Core (GLM-5)**, **Droid Core (GLM-4.7)**, **Droid Core (Kimi K2.5)**, and **Droid Core (MiniMax M2.5)** are open-source alternatives available in the CLI. They're useful for:
 
 - **Air-gapped environments** where external API calls aren't allowed
 - **Cost-sensitive projects** needing unlimited local inference
 - **Privacy requirements** where code cannot leave your infrastructure
 - **Experimentation** with open-source model capabilities
 
-**Note:** GLM-4.7 and MiniMax M2.5 do not support image attachments. Kimi K2.5 does support images. MiniMax M2.5 is the cheapest model available (0.12× multiplier) and uniquely supports reasoning (Low/Medium/High) among Droid Core models. For image-based workflows, use Claude, GPT, or Kimi models.
+**Note:** GLM-5, GLM-4.7, and MiniMax M2.5 do not support image attachments. Kimi K2.5 does support images. MiniMax M2.5 is the cheapest model available (0.12× multiplier) and uniquely supports reasoning (Low/Medium/High) among Droid Core models. For image-based workflows, use Claude, GPT, or Kimi models.
 
 To use open-source models, you'll need to configure them via BYOK with a local inference server (like Ollama) or a hosted provider. See [BYOK documentation](/cli/configuration/byok) for setup instructions.
 

--- a/docs/guides/power-user/token-efficiency.mdx
+++ b/docs/guides/power-user/token-efficiency.mdx
@@ -139,9 +139,11 @@ Different models have different cost multipliers and capabilities. Match the mod
 | Droid Core (GLM-4.7) | 0.25× | Bulk automation, simple tasks |
 | Droid Core (Kimi K2.5) | 0.25× | Cost-sensitive work, supports images |
 | Claude Haiku 4.5 | 0.4× | Quick edits, routine work |
+| Droid Core (GLM-5) | 0.4× | Newer open-source GLM model when you want stronger quality in Droid Core |
 | GPT-5.1 / GPT-5.1-Codex | 0.5× | Implementation, debugging |
 | GPT-5.2-Codex / GPT-5.3-Codex | 0.7× | Advanced coding with Extra High reasoning |
 | Gemini 3 Pro | 0.8× | Research, analysis |
+| Gemini 3.1 Pro | 0.8× | Research, analysis with newer Gemini generation |
 | Claude Sonnet 4.5 | 1.2× | Balanced quality/cost |
 | Claude Opus 4.5 | 2× | Complex reasoning, architecture |
 | Claude Opus 4.6 | 2× | Latest flagship, Max reasoning |
@@ -154,7 +156,7 @@ Simple edit, formatting      → Haiku 4.5 (0.4×)
 Implement feature from spec  → GPT-5.1-Codex (0.5×)
 Debug complex issue          → Sonnet 4.5 (1.2×)
 Architecture planning        → Opus 4.6 (2×) or Opus 4.5 (2×)
-Bulk file processing         → Droid Core (0.25×)
+Bulk file processing         → Droid Core (GLM-4.7 at 0.25× or GLM-5 at 0.4×)
 ```
 
 ### Reasoning Effort Impact

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -29,6 +29,7 @@ Different models have different multipliers applied to calculate Standard Token 
 | Droid Core (GLM-4.7)     | `glm-4.7`                    | 0.25×      |
 | Droid Core (Kimi K2.5)   | `kimi-k2.5`                  | 0.25×      |
 | Claude Haiku 4.5         | `claude-haiku-4-5-20251001`  | 0.4×       |
+| Droid Core (GLM-5)       | `glm-5`                      | 0.4×       |
 | GPT-5.1                  | `gpt-5.1`                    | 0.5×       |
 | GPT-5.1-Codex            | `gpt-5.1-codex`              | 0.5×       |
 | GPT-5.1-Codex-Max        | `gpt-5.1-codex-max`          | 0.5×       |
@@ -36,6 +37,7 @@ Different models have different multipliers applied to calculate Standard Token 
 | GPT-5.2-Codex            | `gpt-5.2-codex`              | 0.7×       |
 | GPT-5.3-Codex            | `gpt-5.3-codex`              | 0.7×       |
 | Gemini 3 Pro             | `gemini-3-pro-preview`       | 0.8×       |
+| Gemini 3.1 Pro           | `gemini-3.1-pro-preview`     | 0.8×       |
 | Claude Sonnet 4.5        | `claude-sonnet-4-5-20250929` | 1.2×       |
 | Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 2×         |
 | Claude Opus 4.6          | `claude-opus-4-6`            | 2×         |

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -111,9 +111,11 @@ droid exec --auto high "Run tests, commit, and push changes"
 | `gpt-5.3-codex`               | GPT-5.3-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `claude-sonnet-4-5-20250929`  | Claude Sonnet 4.5            | Yes (Off/Low/Medium/High)                | off               |
 | `claude-haiku-4-5-20251001`   | Claude Haiku 4.5             | Yes (Off/Low/Medium/High)                | off               |
+| `gemini-3.1-pro-preview`      | Gemini 3.1 Pro               | Yes (Low/Medium/High)                    | high              |
 | `gemini-3-pro-preview`        | Gemini 3 Pro                 | Yes (None/Low/Medium/High)               | high              |
 | `gemini-3-flash-preview`      | Gemini 3 Flash               | Yes (Minimal/Low/Medium/High)            | high              |
 | `glm-4.7`                     | Droid Core (GLM-4.7)         | None only                                | none              |
+| `glm-5`                       | Droid Core (GLM-5)           | None only                                | none              |
 | `kimi-k2.5`                   | Droid Core (Kimi K2.5)       | None only                                | none              |
 | `minimax-m2.5`                | Droid Core (MiniMax M2.5)    | Yes (Low/Medium/High)                    | high              |
 


### PR DESCRIPTION
## Summary
- add GLM-5 and Gemini 3.1 Pro to core model documentation pages
- sync pricing multipliers and reasoning support with model-registry entries
- update model references in docs tables and guides

## Validation
- cd "/Users/sagar/code/work/factory/docs" && npx --yes mintlify validate