### PR TITLE
docs: align CLI/integration references with current behavior

### DIFF
--- a/docs/cli/byok/overview.mdx
+++ b/docs/cli/byok/overview.mdx
@@ -54,7 +54,7 @@ Add custom models to `~/.factory/settings.json` under the `customModels` array:
 | `apiKey` | `string` | ✓ | Your API key for the provider. Can't be empty. Supports `${VAR_NAME}` in `settings.json`/`settings.local.json` (e.g., `${PROVIDER_API_KEY}` uses the `PROVIDER_API_KEY` environment variable). |
 | `provider` | `string` | ✓ | One of: `anthropic`, `openai`, or `generic-chat-completion-api` |
 | `maxOutputTokens` | `number` | | Maximum output tokens for model responses |
-| `supportsImages` | `boolean` | | Whether the model supports image inputs |
+| `noImageSupport` | `boolean` | | Set to `true` to disable image inputs for this model |
 | `extraArgs` | `object` | | Additional provider-specific arguments to include in API requests |
 | `extraHeaders` | `object` | | Additional HTTP headers to send with requests |
 

--- a/docs/cli/configuration/hooks-guide.mdx
+++ b/docs/cli/configuration/hooks-guide.mdx
@@ -79,9 +79,9 @@ Droid feedback on what to do differently.
 
 ### Step 2: Add a matcher
 
-Select `+ Add new matcher…` to run your hook only on Bash tool calls.
+Select `+ Add new matcher…` to run your hook only on Execute tool calls.
 
-Type `Bash` for the matcher.
+Type `Execute` for the matcher.
 
 <Note>You can use `*` to match all tools.</Note>
 
@@ -110,7 +110,7 @@ Run `/hooks` again or check `~/.factory/settings.json` to see your configuration
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Execute",
         "hooks": [
           {
             "type": "command",
@@ -152,7 +152,7 @@ Automatically format TypeScript files after editing:
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Create",
         "hooks": [
           {
             "type": "command",
@@ -174,7 +174,7 @@ Automatically fix missing language tags and formatting issues in markdown files:
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Create",
         "hooks": [
           {
             "type": "command",
@@ -319,7 +319,7 @@ Block edits to sensitive files:
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Create",
         "hooks": [
           {
             "type": "command",

--- a/docs/cli/configuration/mcp.mdx
+++ b/docs/cli/configuration/mcp.mdx
@@ -260,8 +260,11 @@ To clear authentication for a server, use the `/mcp` interactive manager and sel
 
 Each server entry includes:
 
-- **type**: Server type (`stdio` or `http`)
-- **disabled**: Boolean flag to temporarily disable the server (default: `false`)
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `type` | `"stdio" \| "http"` | Server type |
+| `disabled` | `boolean` | Temporarily disable the server (default: `false`) |
+| `disabledTools` | `string[]` | List of tool names to disable for this MCP server |
 
 For **stdio** servers:
 - **command**: Executable to run

--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -23,13 +23,22 @@ Changes take effect immediately and are saved to your settings file.
 
 If the file doesn't exist, it's created with defaults the first time you run **droid**.
 
+### Local overrides
+
+You can create a `settings.local.json` alongside `settings.json` in any `.factory/` folder:
+
+- `~/.factory/settings.local.json` (user-level)
+- `<project>/.factory/settings.local.json` (project-level)
+
+Local overrides merge on top of the corresponding `settings.json` at the same level and follow the same hierarchy precedence. Add `settings.local.json` to `.gitignore` if you want to keep machine-specific preferences out of version control.
+
 ## Available settings
 
 | Setting | Options | Default | Description |
 | ------- | ------- | ------- | ----------- |
 | `model` | `opus`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `gpt-5.1`, `gpt-5.1-codex`, `gpt-5.1-codex-max`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3-pro`, `gemini-3.1-pro`, `droid-core`, `glm-5`, `kimi-k2.5`, `minimax-m2.5`, `custom-model` | `opus` | The default AI model used by droid |
 | `reasoningEffort` | `off`, `none`, `low`, `medium`, `high` (availability depends on the model) | Model-dependent default | Controls how much structured thinking the model performs. |
-| `autonomyLevel` | `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high` | `normal` | Sets the default autonomy mode when starting droid. |
+| `autonomyMode` | `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high` | `normal` | Sets the default autonomy mode when starting droid. |
 | `cloudSessionSync` | `true`, `false` | `true` | Mirror CLI sessions to Factory web. |
 | `diffMode` | `github`, `unified` | `github` | Choose between split GitHub-style diffs and a single-column view. |
 | `completionSound` | `off`, `bell`, `fx-ok01`, `fx-ack01`, or custom file path | `fx-ok01` | Audio cue when a response finishes. |
@@ -42,12 +51,7 @@ If the file doesn't exist, it's created with defaults the first time you run **d
 | `hooksDisabled` | `true`, `false` | `false` | Globally disable all hooks execution. |
 | `ideAutoConnect` | `true`, `false` | `false` | Auto-connect to IDE from external terminals. |
 | `todoDisplayMode` | `inline`, `pinned` | `pinned` | How the todo list is displayed in the UI. |
-| `specSaveEnabled` | `true`, `false` | `false` | Persist spec outputs to disk. |
-| `specSaveDir` | File path | `.factory/docs` | Directory used when `specSaveEnabled` is `true`. |
-| `enableCustomDroids` | `true`, `false` | `true` | Toggle the Custom Droids feature. |
 | `showThinkingInMainView` | `true`, `false` | `false` | Display AI thinking/reasoning blocks in the main chat view. |
-| `allowBackgroundProcesses` | `true`, `false` | `false` | Allow droid to spawn background processes (experimental). |
-| `enableReadinessReport` | `true`, `false` | `false` | Enable the `/readiness-report` slash command (experimental). |
 | `customModels` | Array of model configs | `[]` | Custom model configurations for BYOK. See [BYOK docs](/cli/configuration/byok). |
 
 ### Model
@@ -86,7 +90,7 @@ Anthropic models default to `off`, while GPT-5 starts on `medium`.
 
 ### Autonomy level
 
-`autonomyLevel` controls how proactively droid executes commands when sessions begin. Start at `normal`, or select an `auto-*` preset to pre-authorize additional actions.
+`autonomyMode` controls how proactively droid executes commands when sessions begin. Start at `normal`, or select an `auto-*` preset to pre-authorize additional actions.
 
 ### Diff mode
 

--- a/docs/cli/configuration/skills.mdx
+++ b/docs/cli/configuration/skills.mdx
@@ -6,7 +6,7 @@ keywords: ['skills', 'capabilities', 'tools', 'workflows', 'expertise', 'reusabl
 Skills are **reusable capabilities** that extend what your Droid can do. Create a `SKILL.md` file with instructions, and the Droid adds it to its toolkit. The Droid uses skills when relevant, or you can invoke one directly with `/skill-name`.
 
 <Tip>
-Explore the full [skills cookbooks](/guides/skills) for examples.
+Explore the [skills guides](/guides/skills/frontend-ui-integration) for examples.
 </Tip>
 
 <Note>

--- a/docs/cli/getting-started/overview.mdx
+++ b/docs/cli/getting-started/overview.mdx
@@ -110,14 +110,14 @@ You're now connected to Factory's development agent from your terminal. [Try the
       <Card
         title="CI/CD Integration"
         icon="diagram-project"
-        href="/cli/configuration/ci-cd"
+        href="/cli/droid-exec/overview"
       >
         Use droid in your continuous integration pipelines
       </Card>
       <Card
         title="Pricing & Usage"
         icon="credit-card"
-        href="/cli/account/tokens-and-pricing"
+        href="/pricing"
       >
         Understand usage tracking and billing
       </Card>

--- a/docs/enterprise/hierarchical-settings-and-org-control.mdx
+++ b/docs/enterprise/hierarchical-settings-and-org-control.mdx
@@ -15,8 +15,8 @@ Settings are defined in `.factory/` folders with a consistent structure at four 
 
 ```text
 Org         → Central `.factory/` bundle (or config endpoint)
-Project     → <git-root>/.factory/
 Folder      → <git-root>/.../subfolder/.factory/
+Project     → <git-root>/.factory/
 User        → ~/.factory/
 ```
 
@@ -49,8 +49,8 @@ Below is the full schema for org-managed settings. These are configured by org a
     <ResponseField name="interactionMode" type="string">
       Droid interaction mode. One of `auto`, `spec`, `agi`.
     </ResponseField>
-    <ResponseField name="autonomyLevel" type="string">
-      Autonomy level for the session. One of `off`, `low`, `medium`, `high`.
+    <ResponseField name="autonomyMode" type="string">
+      Autonomy mode for the session. One of `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high`.
     </ResponseField>
     <ResponseField name="specModeModel" type="string">
       Model to use when spec mode is active.
@@ -245,7 +245,7 @@ For simple scalar values (strings, numbers, booleans):
 Examples:
 
 - `sessionDefaultSettings.model`
-- `sessionDefaultSettings.autonomyLevel`
+- `sessionDefaultSettings.autonomyMode`
 - `maxAutonomyLevel`
 
 This guarantees that org decisions (such as which models or autonomy levels are allowed) remain authoritative.
@@ -375,7 +375,7 @@ Again, users cannot override these rules; they can only choose safer personal de
     "model": "claude-opus-4-6",
     "reasoningEffort": "high",
     "interactionMode": "auto",
-    "autonomyLevel": "medium",
+    "autonomyMode": "auto-medium",
     "specModeModel": "claude-sonnet-4-6",
     "specModeReasoningEffort": "medium"
   },

--- a/docs/guides/droid-exec/code-review.mdx
+++ b/docs/guides/droid-exec/code-review.mdx
@@ -129,4 +129,4 @@ Guidelines:
 
 - [GitHub App installation](/cli/features/install-github-app) - Full setup guide for `/install-github-app`
 - [GitHub Actions examples](/guides/droid-exec/github-actions) - More automation workflows
-- [Droid Exec](/cli/commands/exec) - Running Droid in CI/CD environments
+- [Droid Exec](/cli/droid-exec/overview) - Running Droid in CI/CD environments

--- a/docs/guides/power-user/rules-conventions.mdx
+++ b/docs/guides/power-user/rules-conventions.mdx
@@ -605,7 +605,7 @@ Add a PostToolUse hook to run your linter after every file edit:
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Create",
         "hooks": [
           {
             "type": "command",
@@ -627,7 +627,7 @@ Run Prettier or your formatter automatically:
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Create",
         "hooks": [
           {
             "type": "command",

--- a/docs/guides/power-user/setup-checklist.mdx
+++ b/docs/guides/power-user/setup-checklist.mdx
@@ -279,7 +279,7 @@ Add reusable skills and automation hooks.
       "hooks": {
         "PostToolUse": [
           {
-            "matcher": "Edit|Write",
+            "matcher": "Edit|Create",
             "hooks": [
               {
                 "type": "command",

--- a/docs/integrations/github-app.mdx
+++ b/docs/integrations/github-app.mdx
@@ -24,7 +24,7 @@ When you run `/install-github-app`, droid guides you through verifying prerequis
     Droid verifies that you have:
     - GitHub CLI (`gh`) installed
     - Authenticated with GitHub (`gh auth login`)
-    - Required OAuth scopes (`repo`, `read:org`)
+    - Required OAuth scopes (`repo`, `read:org`, `workflow`)
   </Step>
 
   <Step title="Select a repository">
@@ -93,10 +93,10 @@ gh auth login
 
 ### Verify required scopes
 
-The CLI needs `repo` and `read:org` scopes. If missing, refresh your authentication:
+The CLI needs `repo`, `read:org`, and `workflow` scopes. If missing, refresh your authentication:
 
 ```bash
-gh auth refresh -s repo,read:org
+gh auth refresh -s repo,read:org,workflow
 ```
 
 ## Available workflows
@@ -190,7 +190,7 @@ The Factory Droid GitHub App requires these permissions:
     |-------|----------|
     | GitHub CLI not installed | Install `gh` using the commands above |
     | Not logged in | Run `gh auth login` |
-    | Missing permissions | Run `gh auth refresh -s repo,read:org` |
+    | Missing permissions | Run `gh auth refresh -s repo,read:org,workflow` |
     | API access error | Check your internet connection and run `gh auth status` |
   </Accordion>
 
@@ -220,50 +220,38 @@ After completing the guided flow, Droid creates a PR with workflow files. Here's
 
 <Accordion title="Generated Droid Review Workflow">
 ```yaml
-name: Droid Code Review
+name: Droid Auto Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, ready_for_review, reopened]
 
 concurrency:
-  group: droid-review-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  pull-requests: write
-  contents: read
-  issues: write
-
 jobs:
-  code-review:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+  droid-review:
     if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
 
-      - name: Install Droid CLI
-        run: |
-          curl -fsSL https://app.factory.ai/cli | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Configure git identity
-        run: |
-          git config user.name "Droid Agent"
-          git config user.email "droidagent@factory.ai"
-
-      - name: Perform automated code review
-        env:
-          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          droid exec --auto high --model claude-sonnet-4-5-20250929 -f prompt.txt
+      - name: Run Droid Auto Review
+        uses: Factory-AI/droid-action@v3
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
 ```
 </Accordion>
 

--- a/docs/integrations/ide-integrations.mdx
+++ b/docs/integrations/ide-integrations.mdx
@@ -21,7 +21,7 @@ keywords:
 
 Droid works great with any Integrated Development Environment (IDE) that has a terminal. Just run `droid`, and you're ready to go.
 
-In addition, Droid provides dedicated plugins for both Visual Studio Code (including popular forks like Cursor, Windsurf, and VSCodium) and JetBrains IDEs. For JetBrains IDEs such as IntelliJ IDEA, PyCharm, Android Studio, WebStorm, PhpStorm, and GoLand, you can either install the official Factory Droid plugin for enhanced integration or simply run `droid` in the integrated terminal.
+Droid also provides dedicated plugins for Visual Studio Code (including Cursor and Windsurf) and JetBrains IDEs. For JetBrains IDEs such as IntelliJ IDEA, PyCharm, Android Studio, WebStorm, PhpStorm, and GoLand, you can install the official Factory Droid plugin for enhanced integration, or just run `droid` in the integrated terminal.
 
 ## Features
 
@@ -35,7 +35,7 @@ In addition, Droid provides dedicated plugins for both Visual Studio Code (inclu
 
 ### VS Code
 
-To install Droid on VS Code and popular forks like Cursor, Windsurf, and VSCodium:
+To install Droid on VS Code and supported forks (Cursor, Windsurf):
 
 1. Open VS Code
 2. Open the integrated terminal
@@ -52,7 +52,7 @@ To install Droid on VS Code and popular forks like Cursor, Windsurf, and VSCodiu
   <Card
     title="JetBrains IDEs"
     icon="sparkles"
-    href="/integrations/jetbrains-ide"
+    href="/integrations/jetbrains"
   >
     Step-by-step setup and usage for IntelliJ IDEA, PyCharm, WebStorm, and other
     JetBrains IDEs.
@@ -92,7 +92,6 @@ This command will:
   - For VS Code: `code` command should be available
   - For Cursor: `cursor` command should be available
   - For Windsurf: `windsurf` command should be available
-  - For VSCodium: `codium` command should be available
   - If not installed, use `Cmd+Shift+P` (Mac) or `Ctrl+Shift+P` (Windows/Linux) and search for "Shell Command: Install 'code' command in PATH" (or the equivalent for your IDE)
 - Check that VS Code has permission to install extensions
 

--- a/docs/integrations/slack.mdx
+++ b/docs/integrations/slack.mdx
@@ -50,14 +50,11 @@ Before using the tools below, make sure that the Factory app is invited
 to the channels you'd like to interact with by sending <code>/invite&nbsp;@Factory</code> in those channels.
 </Warning>
 
-Factory provides four native tools to interact with Slack:
+Factory currently provides one native Slack tool:
 
 | Tool | What it does |
 | ---- | ------------ |
-| **Get Slack Channels** | Lists all channels the bot can access |
-| **Post Slack Message** | Sends a message to a channel or replies to an existing thread |
-| **Read Thread Messages** | Reads the messages from a Slack thread |
-| **Get Channel History** | Retrieves recent messages from a channel |
+| **Post Message** | Sends a message to a channel or replies in an existing thread |
 
 ## Additional Features
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -11,8 +11,8 @@ Factory measures usage through Standard Tokens. Cached tokens are billed at one-
 | Plan     | Standard Tokens / Month                       | Price / Month |
 | -------- | --------------------------------------------- | ------------- |
 | **Free** | BYOK                                          | $0            | 
-| **Pro**  | 10 million (+10 million bonus tokens)         | $20           |
-| **Max**  | 100 million (+100 million bonus tokens)       | $200          | 
+| **Pro**  | 20 million                                    | $20           |
+| **Max**  | 200 million                                   | $200          | 
 
 Overage is billed at $2.70 per million Factory Standard Tokens.
 
@@ -39,6 +39,7 @@ Different models have different multipliers applied to calculate Standard Token 
 | Gemini 3 Pro             | `gemini-3-pro-preview`       | 0.8×       |
 | Gemini 3.1 Pro           | `gemini-3.1-pro-preview`     | 0.8×       |
 | Claude Sonnet 4.5        | `claude-sonnet-4-5-20250929` | 1.2×       |
+| Claude Sonnet 4.6        | `claude-sonnet-4-6`          | 1.2×       |
 | Claude Opus 4.5          | `claude-opus-4-5-20251101`   | 2×         |
 | Claude Opus 4.6          | `claude-opus-4-6`            | 2×         |
 | Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       | 12×        |

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -56,7 +56,8 @@ Customize droid's behavior with command-line flags:
 | `--use-spec`                         | Start in specification mode (plan before executing)                                                          | `droid exec --use-spec "add user profiles"`                |
 | `--skip-permissions-unsafe`          | Skip all permission prompts (⚠️ use with extreme caution)                                                    | `droid exec --skip-permissions-unsafe`                     |
 | `--cwd <path>`                       | Execute from a specific working directory                                                                    | `droid exec --cwd ../service "run tests"`                  |
-| `--delegation-url <url>`             | URL for delegated sessions (Slack thread or Linear issue)                                                    | `droid exec --delegation-url <slack-or-linear-url>`        |
+| `--tag <spec>`                       | Session tag (name or JSON, repeatable)                                                                       | `droid exec --tag code-review`                             |
+| `--log-group-id <id>`                | Log group ID for filtering logs                                                                              | `droid exec --log-group-id grp-123`                        |
 | `-v, --version`                      | Display CLI version                                                                                          | `droid -v`                                                 |
 | `-h, --help`                         | Show help information                                                                                        | `droid --help`                                             |
 
@@ -110,6 +111,7 @@ droid exec --auto high "Run tests, commit, and push changes"
 | `gpt-5.2-codex`               | GPT-5.2-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `gpt-5.3-codex`               | GPT-5.3-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `claude-sonnet-4-5-20250929`  | Claude Sonnet 4.5            | Yes (Off/Low/Medium/High)                | off               |
+| `claude-sonnet-4-6`           | Claude Sonnet 4.6            | Yes (Off/Low/Medium/High/Max)            | high              |
 | `claude-haiku-4-5-20251001`   | Claude Haiku 4.5             | Yes (Off/Low/Medium/High)                | off               |
 | `gemini-3.1-pro-preview`      | Gemini 3.1 Pro               | Yes (Low/Medium/High)                    | high              |
 | `gemini-3-pro-preview`        | Gemini 3 Pro                 | Yes (None/Low/Medium/High)               | high              |
@@ -143,31 +145,43 @@ Available when running `droid` in interactive mode. Type the command at the prom
 | :----------------------- | :---------------------------------------------------- |
 | `/account`               | Open Factory account settings in browser              |
 | `/billing`               | View and manage billing settings                      |
+| `/bg-process`            | Manage background processes                           |
 | `/bug [title]`           | Create a bug report with session data and logs        |
 | `/clear`                 | Start a new session (alias for `/new`)                |
 | `/commands`              | Manage custom slash commands                          |
 | `/compress [prompt]`     | Compress session and move to new one with summary     |
 | `/cost`                  | Show token usage statistics                           |
+| `/create-skill`          | Create a reusable skill from current session          |
 | `/droids`                | Manage custom droids                                  |
+| `/enter-mission`         | Enter Mission mode                                    |
 | `/favorite`              | Mark current session as a favorite                    |
 | `/fork`                  | Duplicate current session with all messages into a new session |
+| `/generate_blog`         | Generate semantic diff blog post                      |
 | `/help`                  | Show available slash commands                         |
 | `/hooks`                 | Manage lifecycle hooks                                |
 | `/ide`                   | Configure IDE integrations                            |
+| `/install-github-app`    | Install Factory GitHub App                            |
 | `/login`                 | Sign in to Factory                                    |
 | `/logout`                | Sign out of Factory                                   |
 | `/mcp`                   | Manage Model Context Protocol servers                 |
+| `/mission`               | Open Mission Control                                  |
+| `/missions`              | List and select missions to resume                    |
 | `/model`                 | Switch AI model mid-session                           |
 | `/new`                   | Start a new session                                   |
+| `/plugins`               | Manage plugins and marketplaces                       |
 | `/quit`                  | Exit droid (alias: `exit`, or press Ctrl+C)           |
 | `/readiness-report`      | Generate readiness report                             |
+| `/rename`                | Rename current session                                |
 | `/review`                | Start AI-powered code review workflow                 |
 | `/rewind-conversation`   | Undo recent changes in the session                    |
 | `/sessions`              | List and select previous sessions                     |
 | `/settings`              | Configure application settings                        |
+| `/share`                 | Share session with organization                       |
 | `/skills`                | Manage and invoke skills                              |
 | `/status`                | Show current droid status and configuration           |
+| `/statusline`            | Configure custom status line                          |
 | `/terminal-setup`        | Configure terminal keybindings for Shift+Enter        |
+| `/wrapped`               | Show Droid usage statistics                           |
 
 For detailed information on slash commands, see the [interactive mode documentation](/cli/getting-started/quickstart#useful-slash-commands).
 

--- a/docs/reference/hooks-reference.mdx
+++ b/docs/reference/hooks-reference.mdx
@@ -40,8 +40,8 @@ Hooks are organized by matchers, where each matcher can have multiple hooks:
 
 * **matcher**: Pattern to match tool names, case-sensitive (only applicable for
   `PreToolUse` and `PostToolUse`)
-  * Simple strings match exactly: `Write` matches only the Write tool
-  * Supports regex: `Edit|Write` or `Notebook.*`
+  * Simple strings match exactly: `Create` matches only the Create tool
+  * Supports regex: `Edit|Create` or `Notebook.*`
   * Use `*` to match all tools. You can also use empty string (`""`) or leave
     `matcher` blank.
 * **hooks**: Array of commands to execute when the pattern matches
@@ -89,7 +89,7 @@ ensuring they work regardless of Droid's current directory:
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Create|Edit",
         "hooks": [
           {
             "type": "command",
@@ -121,7 +121,7 @@ Plugins can provide hooks that integrate seamlessly with your user and project h
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Create|Edit",
         "hooks": [
           {
             "type": "command",
@@ -160,13 +160,13 @@ Runs after Droid creates tool parameters and before processing the tool call.
 **Common matchers:**
 
 * `Task` - Sub-droid tasks (see [subagents documentation](/cli/user-guides/specification-mode))
-* `Bash` - Shell commands
+* `Execute` - Shell commands
 * `Glob` - File pattern matching
 * `Grep` - Content search
 * `Read` - File reading
 * `Edit` - File editing
-* `Write` - File writing
-* `WebFetch`, `WebSearch` - Web operations
+* `Create` - File creation
+* `FetchUrl`, `WebSearch` - Web operations
 
 ### PostToolUse
 
@@ -179,7 +179,7 @@ Recognizes the same matcher values as PreToolUse.
 Runs when Droid sends notifications. Notifications are sent when:
 
 1. Droid needs your permission to use a tool. Example: "Droid needs your
-   permission to use Bash"
+   permission to use Execute"
 2. The prompt input has been idle for at least 60 seconds. "Droid is waiting
    for your input"
 
@@ -229,8 +229,7 @@ statistics, or saving session state.
 
 The `reason` field in the hook input will be one of:
 
-* `clear` - Session cleared with /clear command
-* `new` - Session ended with /new command
+* `clear` - Session cleared with /clear or /new command
 * `logout` - User logged out
 * `prompt_input_exit` - User exited while prompt input was visible
 * `other` - Other exit reasons
@@ -246,7 +245,7 @@ event-specific data:
   session_id: string
   transcript_path: string  // Path to conversation JSON
   cwd: string              // The current working directory when the hook is invoked
-  permission_mode: string  // Current permission mode: "default", "plan", "acceptEdits", or "bypassPermissions"
+  permission_mode: string  // Current permission mode: "off", "spec", "auto-low", "auto-medium", or "auto-high"
 
   // Event-specific fields
   hook_event_name: string
@@ -263,9 +262,9 @@ The exact schema for `tool_input` depends on the tool.
   "session_id": "abc123",
   "transcript_path": "/Users/.../.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "PreToolUse",
-  "tool_name": "Write",
+  "tool_name": "Create",
   "tool_input": {
     "file_path": "/path/to/file.txt",
     "content": "file content"
@@ -282,9 +281,9 @@ The exact schema for `tool_input` and `tool_response` depends on the tool.
   "session_id": "abc123",
   "transcript_path": "/Users/.../.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "PostToolUse",
-  "tool_name": "Write",
+  "tool_name": "Create",
   "tool_input": {
     "file_path": "/path/to/file.txt",
     "content": "file content"
@@ -303,7 +302,7 @@ The exact schema for `tool_input` and `tool_response` depends on the tool.
   "session_id": "abc123",
   "transcript_path": "/Users/.../.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "Notification",
   "message": "Task completed successfully"
 }
@@ -316,7 +315,7 @@ The exact schema for `tool_input` and `tool_response` depends on the tool.
   "session_id": "abc123",
   "transcript_path": "/Users/.../.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "UserPromptSubmit",
   "prompt": "Write a function to calculate the factorial of a number"
 }
@@ -333,7 +332,7 @@ from running indefinitely.
   "session_id": "abc123",
   "transcript_path": "~/.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "Stop",
   "stop_hook_active": true
 }
@@ -349,7 +348,7 @@ For `manual`, `custom_instructions` comes from what the user passes into
   "session_id": "abc123",
   "transcript_path": "~/.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "PreCompact",
   "trigger": "manual",
   "custom_instructions": ""
@@ -363,7 +362,7 @@ For `manual`, `custom_instructions` comes from what the user passes into
   "session_id": "abc123",
   "transcript_path": "~/.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "SessionStart",
   "source": "startup"
 }
@@ -376,9 +375,9 @@ For `manual`, `custom_instructions` comes from what the user passes into
   "session_id": "abc123",
   "transcript_path": "~/.factory/projects/.../00893aaf-19fa-41d2-8238-13269b9b3ca0.jsonl",
   "cwd": "/Users/...",
-  "permission_mode": "default",
+  "permission_mode": "off",
   "hook_event_name": "SessionEnd",
-  "reason": "exit"
+  "reason": "other"
 }
 ```
 
@@ -564,7 +563,7 @@ Additionally, hooks can modify tool inputs before execution using `updatedInput`
 `SessionEnd` hooks run when a session ends. They cannot block session termination
 but can perform cleanup tasks.
 
-#### Exit Code Example: Bash Command Validation
+#### Exit Code Example: Execute Command Validation
 
 ```python
 #!/usr/bin/env python3
@@ -603,7 +602,7 @@ tool_name = input_data.get("tool_name", "")
 tool_input = input_data.get("tool_input", {})
 command = tool_input.get("command", "")
 
-if tool_name != "Bash" or not command:
+if tool_name != "Execute" or not command:
     sys.exit(1)
 
 # Validate the command
@@ -849,10 +848,10 @@ For complex hook issues:
 Use `droid --debug` to see hook execution details:
 
 ```
-[DEBUG] Executing hooks for PostToolUse:Write
-[DEBUG] Getting matching hook commands for PostToolUse with query: Write
+[DEBUG] Executing hooks for PostToolUse:Create
+[DEBUG] Getting matching hook commands for PostToolUse with query: Create
 [DEBUG] Found 1 hook matchers in settings
-[DEBUG] Matched 1 hooks for query "Write"
+[DEBUG] Matched 1 hooks for query "Create"
 [DEBUG] Found 1 hook commands to execute
 [DEBUG] Executing hook command: <Your command> with timeout 60000ms
 [DEBUG] Hook command completed with status 0: <Your stdout>

--- a/docs/web/machine-connection/cloud-templates/installation-and-usage.mdx
+++ b/docs/web/machine-connection/cloud-templates/installation-and-usage.mdx
@@ -12,7 +12,7 @@ A **cloud template** is a fully-configured, on-demand development environment th
 ## System Requirements
 
 - A repository enabled in Factory
-- Manager role or higher to create cloud templates
+- User role or higher to create cloud templates
 
 <Steps>
 

--- a/docs/web/machine-connection/cloud-templates/setup-script.mdx
+++ b/docs/web/machine-connection/cloud-templates/setup-script.mdx
@@ -8,7 +8,7 @@ The setup script is a shell script that Factory runs during template creation, a
 ## 1. How to define a setup script
 
 1. In the modal for template creation, in the "Setup Script (Optional)" section, add your initialization script. You can write a multi-line bash script with all the commands you need.
-2. Submit. The script runs in the repo root with bash strict mode (consider using `set -euo pipefail` at the start of your script). Script failures will stop the build.
+2. Submit. The script runs in the repo root exactly as provided. Add `set -euo pipefail` at the top of your script if you want strict error handling. Script failures will stop the build.
 3. Keep your script non‑interactive and idempotent. Write commands that can be safely re-run.
 4. Review build logs if anything fails to see detailed output from your script execution.
 


### PR DESCRIPTION
## Summary
This PR applies a docs-only cleanup from the audit pass to align public documentation with current product behavior and terminology.

## What changed
- Updated tool naming in hooks docs (`Write`/`Bash`/`WebFetch` -> `Create`/`Execute`/`FetchUrl`)
- Corrected permission mode values and SessionEnd reason examples
- Fixed settings/enterprise field naming and hierarchy details (`autonomyMode`, precedence order)
- Updated CLI reference with missing slash commands and current flags
- Updated integration docs (GitHub scopes/workflow example, Slack tool coverage, IDE links/support)
- Corrected BYOK field semantics (`noImageSupport`)
- Fixed pricing model entries/presentation and added missing Sonnet 4.6 rows
- Fixed broken internal links and stale wording in cloud template docs
- Removed stale `Edit|Write` matcher examples in power-user guides

## Scope/cleanliness
- Docs-only: **18 MDX files under `docs/`**
- No `.factory/` or mission artifact files included
- No code/runtime behavior changes

## Validation
- Verified branch diff contains only `docs/**/*.mdx` paths
- Previewed changed pages locally with Mintlify and checked route responses (HTTP 200)
