### PR TITLE
docs: add CLI changelog entry for v0.66.0

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,6 +4,33 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="March 2" rss={{ title: "CLI Updates", description: "/copy command, marketplace management, and mission worker improvements" }}>
+  `v0.66.0`
+
+  ## New features
+
+  * **`/copy` slash command** - Copy content to your clipboard directly from the CLI
+  * **Marketplace management** - New UI for managing marketplace plugins under the Plugins section in enterprise controls (app)
+  * **App version display** - Desktop app now shows the current version number (app)
+  * **Grouped exec sessions** - Droid exec sessions are now grouped under a dedicated tab for cleaner organization (app)
+
+  ## Improvements
+
+  * **Mission worker reliability** - Hardened mission worker lifecycle with improved pause and resume handling
+
+  ## Bug fixes
+
+  * **Subagent model and permissions** - Fixed subagent model inheritance and permissions level
+  * **BYOK compaction errors** - Upstream error details are now surfaced in BYOK compaction failures
+  * **Cross-provider messages** - Fixed message conversion for OpenAI Responses API across providers
+  * **Spec model display** - Corrected spec model display in `/model` selector and prevented global fallback on clear
+  * **Session archiving** - Fixed session archive confirmation flow in the app
+  * **Chat scrolling** - Fixed scroll-to-last-message behavior in session chat (app)
+  * **User limits modal** - Fixed scroll bug in the Individual User Limits modal (app)
+  * **Diff generation** - Fixed potential crash with non-string inputs in diff generation
+
+</Update>
+
 <Update label="February 27" rss={{ title: "CLI Updates", description: "Diagnostics command, GitHub comments in diff viewer, and mission mode fixes" }}>
   `v0.65.0`
 


### PR DESCRIPTION
Adds changelog entry for the March 2 release (v0.66.0).

## Highlights
- New `/copy` slash command
- Marketplace management UI in enterprise controls
- App version display in desktop
- Grouped droid exec sessions
- Mission worker reliability improvements
- Multiple bug fixes for subagent model inheritance, BYOK errors, cross-provider messages, and more