### PR TITLE
docs: add CLI changelog entry for v0.67.0

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -11,7 +11,6 @@ rss: true
 
   * **CLI banners** - Display customizable banners in the CLI for quick access to important information
   * **`/stats` command** - The `/wrapped` command has been renamed to `/stats` with date range filtering support
-  * **`/git-ai` command** - New slash command for setting up Git AI integration
   * **Skills search bar** - Added search bar to the skills menu for quickly finding skills
   * **Configurable image compression** - New `image_quality` parameter in the Read tool for controlling image compression quality
   * **Electron app automation** - The agent-browser skill now supports automating Electron desktop applications

--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,6 +4,36 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="March 3" rss={{ title: "CLI Updates", description: "CLI banners, /stats command, skills search, and configurable image compression" }}>
+  `v0.67.0`
+
+  ## New features
+
+  * **CLI banners** - Display customizable banners in the CLI for quick access to important information
+  * **`/stats` command** - The `/wrapped` command has been renamed to `/stats` with date range filtering support
+  * **`/git-ai` command** - New slash command for setting up Git AI integration
+  * **Skills search bar** - Added search bar to the skills menu for quickly finding skills
+  * **Configurable image compression** - New `image_quality` parameter in the Read tool for controlling image compression quality
+  * **Electron app automation** - The agent-browser skill now supports automating Electron desktop applications
+
+  ## Improvements
+
+  * **Automation detail view** - Redesigned automation detail view to align with session UI patterns (app)
+  * **Windows ARM64 and Zed extension** - CLI distribution now includes Windows ARM64 builds and Zed editor extension
+
+  ## Bug fixes
+
+  * **Certificate loading order** - Fixed system certificate loading that could cause authentication failures on startup
+  * **Gemini schema compatibility** - Fixed schema compatibility issues with Gemini models
+  * **Payment redirect on desktop** - Fixed payment page redirect handling in the desktop app (app)
+  * **Character encoding** - Fixed display of malformed UTF characters in messages
+  * **Mission list formatting** - Fixed formatting of feature and worker list descriptions in missions
+  * **BYOK error handling** - Improved error messages for custom model (BYOK) configurations
+  * **MCP server reconnection** - Fixed potential deadlock when MCP servers fail to reload during disconnection
+  * **Execute tool file actions** - Fixed file operations not being applied correctly during command execution
+
+</Update>
+
 <Update label="February 27" rss={{ title: "CLI Updates", description: "Diagnostics command, GitHub comments in diff viewer, and mission mode fixes" }}>
   `v0.65.0`
 


### PR DESCRIPTION
Adds changelog entry for CLI v0.67.0 (Release 2026-03-03).

## Highlights
- CLI banners
- `/stats` command (renamed from `/wrapped` with date range filtering)
- `/git-ai` command
- Skills search bar
- Configurable image compression
- Electron app automation in agent-browser skill
- Multiple bug fixes including certificate loading, Gemini compatibility, MCP reconnection, and BYOK error handling