### PR TITLE
docs: add CLI changelog entry for v0.68.0

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -25,6 +25,7 @@ rss: true
   * **MCP tool compatibility** - Improved MCP tool schema sanitization for better compatibility across model providers
   * **Custom model streaming** - Fixed streaming issues with custom models
   * **Reasoning level display** - Fixed reasoning level not displaying correctly after using /model in spec mode
+  * **Authentication reliability** - Reliability improvements to authentication mechanisms
 
 </Update>
 


### PR DESCRIPTION
Adds changelog entry for the March 4, 2026 release (CLI v0.68.0).

## Highlights
- Subagent inactivity timer
- Token rate limits in-session settings (app)
- Multiple bug fixes: streaming stability, VS Code auto-installation, session resume, BYOK error handling, context management, MCP tool compatibility, and more