### PR TITLE
docs: add CLI changelog entry for v0.69.0

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,6 +4,40 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="March 5" rss={{ title: "CLI Updates", description: "CJK internationalization, GPT-5.4 model updates, and --mission flag for droid exec" }}>
+  `v0.69.0`
+
+  ## New features
+
+  * **CJK internationalization** - Full internationalization support for Japanese, Chinese, and Korean languages in the CLI
+  * **GPT-5.4 model updates** - GPT-5.4 is now a default model option with expanded context limits
+  * **`--mission` flag for droid exec** - New `--mission` flag enables non-interactive mission orchestration via `droid exec`
+  * **Personal analytics page** - View your personal usage analytics directly in the app (app)
+  * **Settings audit trail** - Track changes to settings values with a full audit trail (app)
+  * **Version history for Enterprise Controls** - View configuration change history in Enterprise Controls (app)
+  * **Combined billing summary** - Billing summary now available in both personal and organization settings views (app)
+
+  ## Improvements
+
+  * **Git config updates** - Git configuration can now be updated when you explicitly request it
+  * **BYOK Anthropic thinking** - Improved adaptive thinking support for custom Anthropic models
+  * **Smarter retry handling** - Improved retry delays for provider capacity errors
+  * **LLM timeout errors** - Clearer user-facing error messages when model requests time out
+  * **MCP tool rendering** - Improved MCP tool result display in the web app (app)
+
+  ## Bug fixes
+
+  * **VSCode keyboard shortcuts** - Fixed support for Cmd + key combinations in VSCode terminal
+  * **Anthropic streaming stability** - Improved streaming reliability for Anthropic models
+  * **Empty model responses** - Empty model responses are now handled gracefully instead of causing errors
+  * **Thinking recovery** - Auto-recovery from thinking signature validation errors during reasoning
+  * **Spec mode navigation** - Fixed back navigation from autonomy menu in spec mode
+  * **Mission session cleanup** - Fresh session now starts correctly when exiting a proposed mission
+  * **Gemini error handling** - Improved error handling for authentication and payment errors with Gemini models
+  * **Profile display** - Fixed user profile parsing for accounts with incomplete name fields
+
+</Update>
+
 <Update label="March 5" rss={{ title: "CLI Updates", description: "VSCode Kitty protocol support and authentication fixes" }}>
   `v0.68.1`
 


### PR DESCRIPTION
Adds changelog entry for CLI v0.69.0 (Release 2026-03-05).

Highlights:
- CJK internationalization for Japanese, Chinese, and Korean
- GPT-5.4 model updates with expanded context limits
- `--mission` flag for non-interactive mission orchestration
- Personal analytics page, settings audit trail, and billing summary improvements (app)
- Multiple bug fixes for streaming stability, VSCode shortcuts, and error handling