### PR TITLE
fix(docs): remove stale _hiddenTabs key to restore search indexing

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -561,7 +561,6 @@
       }
     ]
   },
-  "_hiddenTabs": {},
   "logo": {
     "light": "/logo/light.png",
     "dark": "/logo/dark.svg"


### PR DESCRIPTION
The _hiddenTabs: {} field was introduced during the Japanese language migration and is not a valid Mintlify docs.json property. It likely prevents Mintlify's search indexer from correctly parsing the config, causing the search box to return no results.