### PR TITLE
Add allowed_bots parameter with Dependabot to droid-review workflow

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
+          allowed_bots: 'dependabot'


### PR DESCRIPTION
Follow-up to https://github.com/Factory-AI/factory/commit/af70e20c7eaa4efbe0c40e7b4b7a3578589cbba1 to resolve check error on Dependabot PRs e.g. https://github.com/Factory-AI/factory/actions/runs/22740790631/job/65953318427#step:3:134

> `Error: Prepare step failed with error: Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`

This PR adds the `allowed_bots` parameter with Dependabot to the workflow, reference https://github.com/Factory-AI/droid-action/blob/dev/action.yml#L19-L22