### PR TITLE
fix(docs): add description to docs.json to trigger search re-index

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "willow",
   "name": "Factory Documentation",
+  "description": "Factory is an AI-native software development platform. Delegate complete tasks like refactors, incident response, and migrations to Droids without changing your tools, models, or workflow.",
   "colors": {
     "primary": "#020202",
     "light": "#f8f8f8",


### PR DESCRIPTION
## Problem
The Mintlify in-site search (Ctrl+K) returns completely irrelevant results. Searching for "quickstart" returns results about Plugins, Browser automation, Leaderboards, etc.

## Investigation
- The `_hiddenTabs` fix from d6f8b77 is still in place (not regressed)
- `jp` is a valid Mintlify language code per [their docs](https://mintlify.com/docs/guides/internationalization)
- JSON is valid, all 214 referenced pages exist, frontmatter is clean
- The search index appears corrupted/stale on Mintlify's side

## Fix
Add the recommended `description` field to `docs.json` to:
1. Force a Mintlify re-deploy and search re-index
2. Improve SEO and AI indexing (Mintlify recommends this field)

If search is still broken after merging, a manual re-deploy from the Mintlify dashboard may be needed.