### PR TITLE
docs: add CLI changelog entry for v0.70.0

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,6 +4,32 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="March 6" rss={{ title: "CLI Updates", description: "Git worktree support, native PDF reading, and runtime settings overlay" }}>
+  `v0.70.0`
+
+  ## New features
+
+  * **Git worktree support** - New `--worktree` flag enables native git worktree support for working across multiple branches simultaneously
+  * **Native PDF support** - The Read tool now natively supports reading PDF files across all model providers
+  * **Runtime settings overlay** - New `--settings` flag allows applying settings at runtime with organization-precedence merge
+  * **Skills UI for remote sessions** - Skills UI is now available in droid computer sessions (app)
+
+  ## Improvements
+
+  * **Mission Control redesign** - Refreshed Mission Control interface with a cleaner layout
+
+  ## Bug fixes
+
+  * **Option+Arrow word jumping** - Restored Option+Arrow word jumping in ESC-prefix terminals
+  * **Background process isolation** - Background process tracking is now isolated per CLI instance to prevent cross-instance interference
+  * **@ search indexing** - Fixed file indexing in @ search suggestions
+  * **Shell environment in daemon** - Daemon now correctly inherits shell environment variables
+  * **Terminal compatibility** - Fixed Kitty keyboard protocol detection that could cause issues in certain terminals
+  * **Streaming cancellation** - Improved reliability when cancelling streaming responses
+  * **Daemon auto-updates** - Fixed an issue where daemon auto-updates could be incorrectly skipped
+
+</Update>
+
 <Update label="March 5" rss={{ title: "CLI Updates", description: "CJK internationalization, GPT-5.4 model updates, and --mission flag for droid exec" }}>
   `v0.69.0`
 


### PR DESCRIPTION
Add changelog entry for CLI v0.70.0 (Release 2026-03-06).

Highlights:
- Git worktree support via `--worktree` flag
- Native PDF support in Read tool
- Runtime `--settings` overlay with org-precedence merge
- Skills UI for droid computer sessions
- Mission Control redesign
- Multiple bug fixes (keyboard navigation, background process isolation, @ search, daemon environment, streaming cancellation)