### PR TITLE
docs: rename CLI Updates to Release notes

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CLI Updates"
+title: "Release notes"
 description: "Recent features and improvements to Factory CLI"
 rss: true
 ---

--- a/docs/jp/changelog/cli-updates.mdx
+++ b/docs/jp/changelog/cli-updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: "CLI Updates"
+title: "Release notes"
 description: Factory CLIの最新機能と改善点
 rss: true
 ---


### PR DESCRIPTION
Changes the changelog page title from "CLI Updates" to "Release notes" to better reflect that this page covers the entire Factory platform release notes.

## Changes
- Updated title in `docs/changelog/cli-updates.mdx`
- Updated title in `docs/jp/changelog/cli-updates.mdx` (Japanese)