### PR TITLE
docs: add CLI changelog entry for v0.72.0

### DIFF
--- a/docs/changelog/cli-updates.mdx
+++ b/docs/changelog/cli-updates.mdx
@@ -4,6 +4,33 @@ description: "Recent features and improvements to Factory CLI"
 rss: true
 ---
 
+<Update label="March 10" rss={{ title: "CLI Updates", description: "GPT-5.4 Fast model, /fast command, chat UI refresh, and MCP OAuth for remote sessions" }}>
+  `v0.72.0`
+
+## New features
+
+- **GPT-5.4 Fast model** - New GPT-5.4 Fast model available with a `/fast` slash command for quick model switching
+- **MCP OAuth in remote sessions** - MCP servers requiring OAuth authentication now work in remote droid computer sessions
+- **Chat UI refresh** - Refreshed chat interface with improved tool display, user message styling, and interrupt indicators
+- **Mission subagent streaming** - Real-time streaming updates from subagents in mission control
+
+## Improvements
+
+- **Incremental rendering** - Enabled incremental rendering for smoother and more responsive CLI output
+- **Faster computer sessions** - Optimistic preconnection reduces wait time when starting computer sessions (app)
+- **Working directory validation** - Computer sessions now validate working directory configuration before starting (app)
+
+## Bug fixes
+
+- **Grep tool overflow** - Fixed Grep tool crashing on very large search results by returning partial results with an increased buffer
+- **Thinking indicator spacing** - Fixed spacing below the thinking indicator display
+- **Timeout warnings** - Fixed spurious timeout warnings appearing during normal operation
+- **Sentry integration reliability** - Improved reliability of the Sentry integration connection
+- **Slack integration reliability** - Improved error handling for Slack integration connections
+- **Mission reasoning** - Fixed reasoning issues in mission mode
+
+</Update>
+
 <Update label="March 9" rss={{ title: "CLI Updates", description: "Autofix PR button, worktree naming, and Create tool syntax highlighting" }}>
   `v0.71.0`
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Adds changelog entry for the March 10 release (v0.72.0).

## Highlights
- GPT-5.4 Fast model and `/fast` slash command
- MCP OAuth support in remote droid computer sessions
- Chat UI refresh with improved tool display and styling
- Mission subagent streaming
- Incremental rendering for smoother CLI output
- Bug fixes for Grep tool overflow, timeout warnings, and integration reliability