### PR TITLE
docs: add Windows to BYOM prerequisites for Droid Computers

### DIFF
--- a/docs/cli/features/droid-computers.mdx
+++ b/docs/cli/features/droid-computers.mdx
@@ -43,7 +43,7 @@ You can register any machine — VPS, cloud VM, on-prem server, etc. — as a Dr
 
 ### Prerequisites
 
-- A machine running **Linux** or **macOS**
+- A machine running **Linux**, **macOS**, or **Windows**
 - Droid CLI installed on the machine
 - Authenticated with Factory (`/login` in an interactive session)
 - Network access to Factory APIs, specifically relay.factory.ai (no inbound ports need to be opened)


### PR DESCRIPTION
The BYOM prerequisites in the Droid Computers docs incorrectly stated only Linux and macOS are supported. The CLI and daemon fully support Windows (with `.exe` handling, PowerShell integration, and dedicated Windows e2e tests in `factory-mono`).

This PR adds Windows to the list of supported platforms in the prerequisites section.