### PR TITLE
docs: clarify cached read tokens billing on pricing page

### DIFF
--- a/docs/jp/pricing.mdx
+++ b/docs/jp/pricing.mdx
@@ -6,7 +6,7 @@ keywords: ['pricing', 'models', 'model id', 'model pricing', 'tokens', 'standard
 
 ## 料金プラン
 
-Factoryは、Standard Tokenを通じて使用量を測定しています。キャッシュされたトークンは、Standard Tokenの10分の1の料金で請求されます（キャッシュトークン10個 = Standard Token 1個）。2つのサブスクリプションプランを提供しています：
+Factoryは、Standard Tokenを通じて使用量を測定しています。キャッシュされた読み取りトークンは、Standard Tokenの10分の1の料金で請求されます（キャッシュトークン10個 = Standard Token 1個）。2つのサブスクリプションプランを提供しています：
 
 | プラン     | Standard Tokens / 月                          | 月額料金      |
 | -------- | --------------------------------------------- | ------------- |

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -6,7 +6,7 @@ keywords: ['pricing', 'models', 'model id', 'model pricing', 'tokens', 'standard
 
 ## Pricing Tiers
 
-Factory measures usage through Standard Tokens. Cached tokens are billed at one-tenth of a Standard Token (10 cached tokens = 1 Standard Token). We offer two subscription plans:
+Factory measures usage through Standard Tokens. Cached read tokens are billed at one-tenth of a Standard Token (10 cached tokens = 1 Standard Token). We offer two subscription plans:
 
 | Plan     | Standard Tokens / Month                       | Price / Month |
 | -------- | --------------------------------------------- | ------------- |


### PR DESCRIPTION
Updates the pricing page (EN and JP) to specify **cached read tokens** instead of just **cached tokens** for clarity.

Single-line change: `Cached tokens are billed at...` -> `Cached read tokens are billed at...`