### PR TITLE
Add placeholder comment to droid computers docs

### DIFF
--- a/docs/cli/features/droid-computers.mdx
+++ b/docs/cli/features/droid-computers.mdx
@@ -3,6 +3,8 @@ title: Droid Computers (Research Preview)
 description: Persistent, long-lived compute environments for Droid
 ---
 
+<!-- Updated by Jerry -->
+
 <Note>
 **Research Preview** — Droid Computers is currently available only to select organizations. There is a limit of **one computer per user**.
 </Note>

--- a/docs/cli/features/droid-computers.mdx
+++ b/docs/cli/features/droid-computers.mdx
@@ -3,7 +3,7 @@ title: Droid Computers (Research Preview)
 description: Persistent, long-lived compute environments for Droid
 ---
 
-<!-- Updated by Jerry -->
+<!-- Last updated: April 6, 2026 -->
 
 <Note>
 **Research Preview** — Droid Computers is currently available only to select organizations. There is a limit of **one computer per user**.


### PR DESCRIPTION
Adds a placeholder comment at the top of the droid computers documentation.