### PR TITLE
docs: add deep/shallow review depth and security review to code review docs

### DIFF
--- a/docs/cli/features/code-review.mdx
+++ b/docs/cli/features/code-review.mdx
@@ -255,8 +255,8 @@ For automated PR reviews, use the [Automated Code Review](/guides/droid-exec/cod
 
 - **Review depth** (`deep` or `shallow`) to control thoroughness and cost
 - **Security review** with STRIDE-based vulnerability scanning, configurable severity thresholds, and PR blocking on critical findings
-- **On-demand security scans** via `@droid security` comments on PRs
-- **Scheduled full-repo scans** via `@droid security --full`
+- **On-demand security scans** via `@droid security` comments on PRs, or `@droid security --full` for a full-repo scan
+- **Scheduled full-repo scans** via cron-based workflow triggers
 
 Set up with:
 

--- a/docs/cli/features/code-review.mdx
+++ b/docs/cli/features/code-review.mdx
@@ -249,9 +249,27 @@ Plus an **overall assessment**:
 # Choose the recent commit to understand changes
 ```
 
+## Automated reviews in CI
+
+For automated PR reviews, use the [Automated Code Review](/guides/droid-exec/code-review) workflow. It supports:
+
+- **Review depth** (`deep` or `shallow`) to control thoroughness and cost
+- **Security review** with STRIDE-based vulnerability scanning, configurable severity thresholds, and PR blocking on critical findings
+- **On-demand security scans** via `@droid security` comments on PRs
+- **Scheduled full-repo scans** via `@droid security --full`
+
+Set up with:
+
+```bash
+droid
+> /install-code-review
+```
+
+See the [Automated Code Review guide](/guides/droid-exec/code-review) for full configuration options.
+
 ## See also
 
 - [CLI Reference](/reference/cli-reference) - Complete command reference including `/review`
-- [Code Review automation guide](/guides/droid-exec/code-review) - Automate reviews with `droid exec`
+- [Automated Code Review guide](/guides/droid-exec/code-review) - Set up automated PR reviews with deep/shallow modes and security scanning
 - [Common use cases](/cli/getting-started/common-use-cases) - Other workflows and patterns
 - [How to talk to a droid](/cli/getting-started/how-to-talk-to-a-droid) - Getting better results from AI reviews

--- a/docs/guides/droid-exec/code-review.mdx
+++ b/docs/guides/droid-exec/code-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: Automated Code Review
 description: Set up automated pull request reviews using the Factory GitHub App
-keywords: ['code review', 'pr review', 'pull request', 'github actions', 'automation', 'droid exec', 'github app']
+keywords: ['code review', 'pr review', 'pull request', 'github actions', 'automation', 'droid exec', 'github app', 'security review', 'deep review', 'shallow review']
 ---
 
 Set up automated code review for your repository using the Factory GitHub App. Droid will analyze pull requests, identify issues, and post feedback as inline comments.
@@ -17,20 +17,20 @@ Set up automated code review for your repository using the Factory GitHub App. D
 
 ## Setup
 
-Use the `/install-github-app` command to install the Factory GitHub App and configure the code review workflow:
+Use the `/install-code-review` command to set up automated code review for GitHub or GitLab:
 
 ```bash
 droid
-> /install-github-app
+> /install-code-review
 ```
 
 The guided flow will:
-1. Verify GitHub CLI prerequisites
-2. Install the Factory GitHub App on your repository
-3. Let you select the **Droid Review** workflow
-4. Create a PR with the workflow files
+1. Detect your SCM platform (GitHub or GitLab)
+2. Verify prerequisites (CLI tools, permissions)
+3. Walk you through review configuration (depth, security, triggers)
+4. Create a PR/MR with the workflow files
 
-For detailed setup instructions, see the [GitHub App installation guide](/cli/features/install-github-app).
+You can also use `/install-github-app` for GitHub-only setup. For detailed setup instructions, see the [GitHub App installation guide](/cli/features/install-github-app).
 
 ## How it works
 
@@ -39,9 +39,81 @@ Once enabled, the Droid Review workflow:
 1. Triggers on pull request events (opened, synchronized, reopened, ready for review)
 2. Skips draft PRs to avoid noise during development
 3. Fetches the PR diff and existing comments
-4. Analyzes code changes for issues
+4. Runs a two-pass review: candidates pass identifies potential issues, validator pass filters false positives
 5. Posts inline comments on problematic lines
 6. Submits an approval when no issues are found
+
+## Review depth
+
+The `review_depth` input controls the thoroughness and cost of each review. You choose the depth during `/install-code-review` setup, or set it directly in your workflow.
+
+- **`deep`** (default) — Thorough analysis with higher reasoning effort. Catches more subtle bugs but costs more per review. Best for production code and security-sensitive repos.
+- **`shallow`** — Faster, more cost-effective reviews that cover surface-level issues. Good for high-volume repos, draft PRs, or teams watching spend.
+
+```yaml
+with:
+  automatic_review: true
+  review_depth: deep  # or shallow
+```
+
+You can also override the model or reasoning effort directly with `review_model` and `reasoning_effort`, which take precedence over the depth preset.
+
+## Security review
+
+Security review runs a STRIDE-based analysis alongside (or instead of) the standard code review. It uses a dedicated security-reviewer subagent that scans for spoofing, tampering, repudiation, information disclosure, denial of service, and elevation of privilege vulnerabilities.
+
+### Enabling automatic security review
+
+Add `automatic_security_review: true` to your workflow. When both `automatic_review` and `automatic_security_review` are enabled, the security reviewer runs as a parallel subagent during the code review pass:
+
+```yaml
+with:
+  automatic_review: true
+  automatic_security_review: true
+```
+
+The security review findings are included in the same PR comment, appended as a **Security Review Summary** section with its own severity ratings.
+
+### On-demand security review
+
+You can also trigger a security review manually by commenting on any PR:
+
+```
+@droid security
+```
+
+For a full repository security scan that creates a dedicated report:
+
+```
+@droid security --full
+```
+
+The `--full` scan creates a new branch (`droid/security-report-{date}`), generates a report at `.factory/security/reports/security-report-{date}.md`, and opens a PR with the findings.
+
+### Security configuration
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `automatic_security_review` | `false` | Run security review automatically on every PR |
+| `security_model` | (inherits from `review_model`) | Model for security analysis |
+| `security_severity_threshold` | `medium` | Minimum severity to report: `critical`, `high`, `medium`, `low` |
+| `security_block_on_critical` | `true` | Submit `REQUEST_CHANGES` on critical findings |
+| `security_block_on_high` | `false` | Submit `REQUEST_CHANGES` on high findings |
+| `security_notify_team` | (empty) | GitHub team to @mention on critical findings (e.g., `@org/security-team`) |
+
+### Scheduled security scans
+
+Run periodic full-repository scans on a schedule:
+
+```yaml
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Every Monday at 6am
+
+with:
+  security_scan_schedule: true
+  security_scan_days: 7  # Scan commits from the last 7 days
+```
 
 ## What Droid reviews
 
@@ -91,16 +163,6 @@ Additional checks for this codebase:
 
 These guidelines are automatically picked up and injected into every review run. No workflow changes needed.
 
-### Change the model
-
-Use a different model for reviews:
-
-```yaml
-droid exec --auto high --model claude-sonnet-4-5-20250929 -f prompt.txt
-# Or use a faster model for quicker feedback:
-droid exec --auto high --model claude-haiku-4-5-20251001 -f prompt.txt
-```
-
 ### Skip certain PRs
 
 Add conditions to skip reviews for specific cases:
@@ -124,8 +186,27 @@ Guidelines:
 - Submit at most 5 comments total, prioritizing the most critical issues
 ```
 
+## All workflow inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `automatic_review` | `false` | Automatically review PRs without `@droid review` |
+| `review_depth` | `deep` | Review preset: `deep` (thorough) or `shallow` (fast) |
+| `review_model` | (from depth) | Override model for code review |
+| `reasoning_effort` | (from depth) | Override reasoning effort |
+| `include_suggestions` | `true` | Include code suggestion blocks in comments |
+| `automatic_security_review` | `false` | Run security review on every PR |
+| `security_model` | (from `review_model`) | Override model for security review |
+| `security_severity_threshold` | `medium` | Minimum severity to report |
+| `security_block_on_critical` | `true` | Block PRs on critical findings |
+| `security_block_on_high` | `false` | Block PRs on high findings |
+| `security_notify_team` | (empty) | Team to @mention on critical findings |
+| `security_scan_schedule` | `false` | Enable scheduled full-repo scans |
+| `security_scan_days` | `7` | Days of commits to scan |
+
 ## See also
 
 - [GitHub App installation](/cli/features/install-github-app) - Full setup guide for `/install-github-app`
+- [GitHub Integration Security](/enterprise/github-integration-security) - Security architecture for the GitHub App integration
 - [GitHub Actions examples](/guides/droid-exec/github-actions) - More automation workflows
 - [Droid Exec](/cli/droid-exec/overview) - Running Droid in CI/CD environments

--- a/docs/guides/droid-exec/code-review.mdx
+++ b/docs/guides/droid-exec/code-review.mdx
@@ -36,10 +36,10 @@ You can also use `/install-github-app` for GitHub-only setup. For detailed setup
 
 Once enabled, the Droid Review workflow:
 
-1. Triggers on pull request events (opened, synchronized, reopened, ready for review)
+1. Triggers on pull request events (opened, synchronize, reopened, ready for review)
 2. Skips draft PRs to avoid noise during development
 3. Fetches the PR diff and existing comments
-4. Runs a two-pass review: candidates pass identifies potential issues, validator pass filters false positives
+4. Analyzes code changes for bugs, security issues, and correctness problems
 5. Posts inline comments on problematic lines
 6. Submits an approval when no issues are found
 
@@ -103,16 +103,22 @@ The `--full` scan creates a new branch (`droid/security-report-{date}`), generat
 
 ### Scheduled security scans
 
-Run periodic full-repository scans on a schedule:
+Run periodic full-repository scans on a schedule by adding a cron trigger to your workflow:
 
 ```yaml
+name: Security Scan
 on:
   schedule:
     - cron: '0 6 * * 1'  # Every Monday at 6am
 
-with:
-  security_scan_schedule: true
-  security_scan_days: 7  # Scan commits from the last 7 days
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Factory-AI/droid-action@v3
+        with:
+          security_scan_schedule: true
+          security_scan_days: 7  # Scan commits from the last 7 days
 ```
 
 ## What Droid reviews
@@ -162,6 +168,16 @@ Additional checks for this codebase:
 ```
 
 These guidelines are automatically picked up and injected into every review run. No workflow changes needed.
+
+### Change the model
+
+Use a different model for reviews:
+
+```yaml
+droid exec --auto high --model claude-sonnet-4-5-20250929 -f prompt.txt
+# Or use a faster model for quicker feedback:
+droid exec --auto high --model claude-haiku-4-5-20251001 -f prompt.txt
+```
 
 ### Skip certain PRs
 


### PR DESCRIPTION
Closes FAC-18721

## Changes

Adds documentation for two undocumented code review features:

### Review depth (deep/shallow)
- Documents the `review_depth` input (`deep` vs `shallow`)
- Explains cost vs thoroughness tradeoff

### Security review
- Documents `automatic_security_review` for STRIDE-based scanning on PRs
- Documents on-demand `@droid security` and `@droid security --full` commands
- Documents all security configuration inputs (severity threshold, blocking, team notifications)
- Documents scheduled full-repo security scans

### Files changed
- `docs/guides/droid-exec/code-review.mdx` - Main automated code review guide (added review depth, security review, all workflow inputs reference table)
- `docs/cli/features/code-review.mdx` - Interactive /review page (added CI section linking to automated guide)