### PR TITLE
docs: add MiniMax M2.7 to model list

### DIFF
--- a/docs/jp/pricing.mdx
+++ b/docs/jp/pricing.mdx
@@ -37,6 +37,7 @@ Enterpriseの料金については[営業チームにお問い合わせ](https:/
 | モデル                    | モデルID                     |
 | ------------------------ | ---------------------------- |
 | Droid Core (MiniMax M2.5)| `minimax-m2.5`               |
+| Droid Core (MiniMax M2.7)| `minimax-m2.7`               |
 | Gemini 3 Flash           | `gemini-3-flash-preview`     |
 | Droid Core (Kimi K2.5)   | `kimi-k2.5`                  |
 | GPT-5.4 Mini             | `gpt-5.4-mini`               |

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -37,6 +37,7 @@ Everything in Max, plus:
 | Model                    | Model ID                     |
 | ------------------------ | ---------------------------- |
 | Droid Core (MiniMax M2.5)| `minimax-m2.5`               |
+| Droid Core (MiniMax M2.7)| `minimax-m2.7`               |
 | Gemini 3 Flash           | `gemini-3-flash-preview`     |
 | Droid Core (Kimi K2.5)   | `kimi-k2.5`                  |
 | GPT-5.4 Mini             | `gpt-5.4-mini`               |


### PR DESCRIPTION
## Summary
- add MiniMax M2.7 to the English and Japanese available-model lists
- keep the public docs aligned with the GA MiniMax rollout
