### PR TITLE
docs(droid-control): note configurable transitions + code annotations

### DIFF
--- a/docs/cli/features/droid-control.mdx
+++ b/docs/cli/features/droid-control.mdx
@@ -208,7 +208,7 @@ Droid Control supports three automation backends. The right one is selected auto
 
 ## Video rendering
 
-Demo and showcase videos are rendered with [Remotion](https://www.remotion.dev/), a React-based video engine. The plugin includes 22 visual components and 6 presets.
+Demo and showcase videos are rendered with [Remotion](https://www.remotion.dev/), a React-based video engine. The plugin includes 23 visual components and 6 presets.
 
 <AccordionGroup>
   <Accordion title="Visual presets">
@@ -223,7 +223,7 @@ Demo and showcase videos are rendered with [Remotion](https://www.remotion.dev/)
   </Accordion>
   <Accordion title="Automatic layers (always present)">
     - Warm radial backgrounds, floating particles, film grain overlay, color grading
-    - Motion blur title-to-content transition
+    - Configurable title-to-content transition (motion blur, flash, whip-pan, light leak, glitch-lite)
     - Animated window chrome with traffic lights and glassmorphic borders
     - Auto-scaled title/subtitle text
   </Accordion>
@@ -232,6 +232,7 @@ Demo and showcase videos are rendered with [Remotion](https://www.remotion.dev/)
     - Directed zoom for small text or details
     - Keystroke pills showing user actions
     - Section headers and transition sweeps
+    - Syntax-highlighted code annotations for source-change overlays
   </Accordion>
 </AccordionGroup>
 

--- a/docs/cli/features/droid-control.mdx
+++ b/docs/cli/features/droid-control.mdx
@@ -223,7 +223,7 @@ Demo and showcase videos are rendered with [Remotion](https://www.remotion.dev/)
   </Accordion>
   <Accordion title="Automatic layers (always present)">
     - Warm radial backgrounds, floating particles, film grain overlay, color grading
-    - Configurable title-to-content transition (motion blur, flash, whip-pan, light leak, glitch-lite)
+    - Configurable title-to-content transition (`motion-blur`, `flash`, `whip-pan`, `light-leak`, `glitch-lite`)
     - Animated window chrome with traffic lights and glassmorphic borders
     - Auto-scaled title/subtitle text
   </Accordion>


### PR DESCRIPTION
## Description

Three-line update to the droid-control docs page reflecting the post-processing additions shipped in [Factory-AI/factory-plugins#23](https://github.com/Factory-AI/factory-plugins/pull/23): configurable title-to-content transitions (`motion-blur`, `flash`, `whip-pan`, `light-leak`, `glitch-lite`) and the new `codeAnnotations` source-change overlay layer. Component count bumped from 22 to 23 (net +1: two new components added, one orphan removed).

## Related Issue

Tracks [Factory-AI/factory-plugins#23](https://github.com/Factory-AI/factory-plugins/pull/23). No Linear ticket.

## Potential Risk & Impact

Docs-only, three lines, single file. No API or CLI surface change. The previous "Motion blur title-to-content transition" wording is still accurate (it's the default), but reading it as the only option is no longer correct, hence the swap. If factory-plugins#23 is reverted before release this PR can be reverted independently.

## How Has This Been Tested?

- Verified the file renders structurally unchanged: only edits two existing lines and adds one bullet inside the existing `<Accordion title="Effect layers (selected at compose time)">` block.
- Cross-checked the component count against the post-merge state of `plugins/droid-control/remotion/src/components/` (23 `.tsx` files).
- Cross-checked the transition list against `plugins/droid-control/remotion/src/components/ShowcaseTransition.tsx` (5 presentations registered in `presentationMap`).
