### PR TITLE
docs: remove Managed Computers research preview banner

### DIFF
--- a/docs/cli/features/droid-computers.mdx
+++ b/docs/cli/features/droid-computers.mdx
@@ -42,10 +42,6 @@ You can register any machine you own — VPS, cloud VM, on-prem server, etc. —
 
 ## Managed Computers
 
-<Note>
-**Research Preview** — Managed Computers are currently available only to select organizations.
-</Note>
-
 The fastest way to get started is to create a computer directly from the Factory web app.
 
 1. Navigate to **Settings → Droid Computers**.


### PR DESCRIPTION
Managed Computers are now generally available, so this removes the "Research Preview — available only to select organizations" note from the Droid Computers overview page.

<img width="1440" height="900" alt="droid-computers-managed" src="https://github.com/user-attachments/assets/5538a31f-aaf8-46e8-a4ab-c15650aa8039" />


Verified locally by running `npx mintlify dev` against `docs/` and loading `/cli/features/droid-computers` — the banner at the top of the **Managed Computers** section is gone. Screenshot attached in a follow-up comment.