### PR TITLE
docs: Move JP sync to Droid Exec and rolling PRs

### DIFF
--- a/.github/prompts/sync-jp-docs.md
+++ b/.github/prompts/sync-jp-docs.md
@@ -1,0 +1,22 @@
+You are updating Japanese technical documentation files in this repository.
+
+Working style:
+
+- Treat the diff manifest below as the primary scope.
+- The manifest provides an English source snapshot path and a Japanese target path for each file.
+- Before editing any target file, read the full English source snapshot and the current Japanese target file for context.
+- Prefer the smallest correct edit. If only one section changed in English, update only the corresponding Japanese section.
+- If the Japanese target file does not exist yet, create it by translating the full English source file.
+- Optimize for token efficiency: do not read unrelated files, do not rewrite unaffected sections, and do not add explanatory output outside the docs.
+
+Requirements:
+
+- Edit only the Japanese target files listed in the manifest.
+- Prioritize accuracy, clarity, consistency, and non-redundancy. This is technical documentation, not prose.
+- Preserve frontmatter keys, MDX and Markdown structure, imports, JSX and MDX component tags, code fences, inline code, URLs, image paths, and file paths.
+- Translate prose, headings, list items, table cell text, link text, image alt text, and human-readable attribute values such as `title=""` and `description=""`.
+- Keep terminology consistent with existing Japanese docs when possible.
+- Keep these brands and common technical terms in English unless the surrounding Japanese convention clearly differs: Factory, Droid, GitHub, GitLab, Linear, Slack, Discord, Sentry, PagerDuty, Jira, Notion, API, CLI, SDK, MCP, SSO, SCIM, BYOK, IDE, JSON, YAML, MDX, PR, CI/CD, OAuth, OTEL, LLM.
+- For docs-internal links that point to English docs paths, rewrite them to the `/jp/` path when the Japanese equivalent exists.
+- Do not edit the English snapshot files.
+- Do not commit, push, open PRs, or edit workflow/configuration files.

--- a/.github/workflows/sync-jp-docs.yml
+++ b/.github/workflows/sync-jp-docs.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**/*.mdx'
-      - 'docs/**/*.md'
-      - '!docs/jp/**'
+      - "docs/**/*.mdx"
+      - "docs/**/*.md"
+      - "!docs/jp/**"
   workflow_dispatch:
+
+concurrency:
+  group: sync-jp-docs
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -17,6 +21,10 @@ permissions:
 jobs:
   sync-jp-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+      DROID_VERSION: "0.108.0"
 
     steps:
       - name: Checkout repository
@@ -24,84 +32,264 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
+      - name: Validate API key
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -n "${FACTORY_API_KEY:-}" ] || { echo "FACTORY_API_KEY is missing"; exit 1; }
 
-      - name: Install dependencies
-        run: pip install anthropic
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pinned Droid CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install -g "droid@${DROID_VERSION}"
+          NPM_GLOBAL_BIN="$(npm config get prefix)/bin"
+          echo "$NPM_GLOBAL_BIN" >> "$GITHUB_PATH"
+          "$NPM_GLOBAL_BIN/droid" --version
 
       - name: Sync and translate changed English docs to Japanese
         id: sync
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY_DOCS }}
+        shell: bash
         run: |
+          set -euo pipefail
+
+          BRANCH="docs/auto-sync-jp-docs"
+          TITLE="docs: sync and translate English doc changes to Japanese"
+
+          git fetch origin main
+          git fetch origin "$BRANCH" || true
+
           BEFORE="${{ github.event.before }}"
-          # Handle zero SHA on first push or force push
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
             BEFORE="$(git rev-parse HEAD~1 2>/dev/null || echo "")"
           fi
           if [ -z "$BEFORE" ]; then
             echo "Cannot determine base commit, skipping."
-            echo "synced=false" >> $GITHUB_OUTPUT
+            echo "synced=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          changed_files=$(git diff --name-only --diff-filter=ACM "$BEFORE" ${{ github.sha }} -- 'docs/**/*.mdx' 'docs/**/*.md' ':!docs/jp/**')
+
+          if [ "${{ github.actor }}" = "github-actions[bot]" ]; then
+            echo "Skipping JP sync for github-actions[bot] push."
+            echo "synced=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## JP sync"
+              echo "- Skipped: push actor was github-actions[bot]."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only --diff-filter=ACM "$BEFORE" "${{ github.sha }}" -- 'docs/**/*.mdx' 'docs/**/*.md' ':!docs/jp/**')"
 
           if [ -z "$changed_files" ]; then
             echo "No English doc changes detected."
-            echo "synced=false" >> $GITHUB_OUTPUT
+            echo "synced=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          synced=false
-          jp_files=""
-          while IFS= read -r file; do
-            jp_file="${file/docs\//docs/jp/}"
-            mkdir -p "$(dirname "$jp_file")"
-            cp "$file" "$jp_file"
-            jp_files="$jp_files $jp_file"
-            echo "Copied: $file -> $jp_file"
-            synced=true
-          done <<< "$changed_files"
-
-          # Translate the copied files if API key is available
-          if [ -n "$ANTHROPIC_API_KEY" ] && [ "$synced" = true ]; then
-            echo "Translating files to Japanese..."
-            python .github/scripts/translate-docs.py $jp_files
-          elif [ "$synced" = true ]; then
-            echo "Warning: ANTHROPIC_API_KEY not set, skipping translation. Files copied in English."
-          fi
-
-          if [ "$synced" = true ]; then
-            echo "synced=true" >> $GITHUB_OUTPUT
-          else
-            echo "synced=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create PR with synced docs
-        if: steps.sync.outputs.synced == 'true'
-        run: |
-          BRANCH="docs/auto-sync-jp-docs-$(date +%Y%m%d-%H%M%S)"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH" "origin/main"
+
+          if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+            mapfile -t existing_jp_files < <(git diff --name-only --diff-filter=ACMR origin/main...origin/"$BRANCH" -- docs/jp)
+            if [ "${#existing_jp_files[@]}" -gt 0 ]; then
+              git checkout "origin/$BRANCH" -- "${existing_jp_files[@]}"
+            fi
+          fi
+
+          changed_files_file="$(mktemp)"
+          manifest_file="$(mktemp)"
+          prompt_file="$(mktemp)"
+          snapshot_root="$(mktemp -d)"
+          cleanup() {
+            rm -f "$changed_files_file" "$manifest_file" "$prompt_file"
+            rm -rf "$snapshot_root"
+          }
+          trap cleanup EXIT
+
+          printf '%s\n' "$changed_files" > "$changed_files_file"
+
+          jp_targets=0
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            jp_file="${file/docs\//docs/jp/}"
+            snapshot_path="$snapshot_root/$file"
+            mkdir -p "$(dirname "$jp_file")"
+            mkdir -p "$(dirname "$snapshot_path")"
+            git show "${{ github.sha }}:$file" > "$snapshot_path"
+            jp_targets=$((jp_targets + 1))
+          done < "$changed_files_file"
+
+          if [ "$jp_targets" -eq 0 ]; then
+            echo "No Japanese docs targets were generated."
+            echo "synced=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BEFORE="$BEFORE" GITHUB_SHA="${{ github.sha }}" CHANGED_FILES_FILE="$changed_files_file" SNAPSHOT_ROOT="$snapshot_root" python3 - <<'PY' > "$manifest_file"
+          from pathlib import Path
+          import os
+          import subprocess
+
+          before = os.environ["BEFORE"]
+          sha = os.environ["GITHUB_SHA"]
+          changed_files_file = Path(os.environ["CHANGED_FILES_FILE"])
+          snapshot_root = Path(os.environ["SNAPSHOT_ROOT"])
+          changed_files = [line.strip() for line in changed_files_file.read_text().splitlines() if line.strip()]
+
+
+          def run(*args: str) -> str:
+              return subprocess.run(args, check=True, capture_output=True, text=True).stdout
+
+
+          print("## Translation manifest")
+          print()
+          print("Use the English diffs below to scope edits, but read the full English source file and current Japanese target file before you edit.")
+          print()
+
+          for index, source in enumerate(changed_files, start=1):
+              snapshot_path = snapshot_root / source
+              target = source.replace("docs/", "docs/jp/", 1)
+              target_exists = Path(target).exists()
+              diff = run("git", "diff", "--unified=2", before, sha, "--", source).rstrip()
+              if not diff:
+                  diff = "(No textual diff was produced; inspect the file pair directly before deciding no change is needed.)"
+
+              print(f"### {index}. `{source}`")
+              print(f"- English source snapshot: `{snapshot_path}`")
+              print(f"- Japanese target file: `{target}`")
+              print(f"- Existing Japanese target before this run: {'yes' if target_exists else 'no'}")
+              print("- Preferred edit scope: only the Japanese sections affected by the English diff below, unless the file is new or the diff forces a broader rewrite.")
+              print()
+              print("```diff")
+              print(diff)
+              print("```")
+              print()
+          PY
+
+          {
+            cat .github/prompts/sync-jp-docs.md
+            echo
+            cat "$manifest_file"
+          } > "$prompt_file"
+
+          "$HOME/.local/bin/droid" exec \
+            --auto medium \
+            --model gpt-5.4 \
+            --reasoning-effort high \
+            --disabled-tools execute-cli \
+            --file "$prompt_file"
+
           git add docs/jp/
-          git commit -m "docs: sync and translate English doc changes to Japanese"
-          git push origin "$BRANCH"
+          if git diff --cached --quiet; then
+            echo "No Japanese docs changes to commit."
+            echo "synced=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
+          {
+            echo "## JP sync"
+            echo "- English docs changed: $changed_count"
+            echo "- Japanese targets requested: $jp_targets"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "branch=$BRANCH"
+            echo "title=$TITLE"
+            echo "synced=true"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upsert PR with synced docs
+        id: pr
+        if: steps.sync.outputs.synced == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BRANCH="${{ steps.sync.outputs.branch }}"
+          TITLE="${{ steps.sync.outputs.title }}"
+          BODY="Auto-generated by the sync-jp-docs Droid Exec workflow. This PR is reused for cumulative JP sync updates, so please review each commit for translation accuracy."
+          REPO_OWNER="${{ github.repository_owner }}"
+
+          find_open_pr_number() {
+            gh pr list \
+              --base main \
+              --head "$BRANCH" \
+              --state open \
+              --json number,isCrossRepository,headRepositoryOwner \
+              --jq ".[] | select((.isCrossRepository | not) and .headRepositoryOwner.login == \"$REPO_OWNER\") | .number" \
+              | head -n 1
+          }
+
+          find_reopenable_pr_number() {
+            gh pr list \
+              --base main \
+              --head "$BRANCH" \
+              --state closed \
+              --json number,isCrossRepository,headRepositoryOwner,isMerged \
+              --jq ".[] | select((.isCrossRepository | not) and .headRepositoryOwner.login == \"$REPO_OWNER\" and (.isMerged | not)) | .number" \
+              | head -n 1
+          }
+
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
+
+          open_pr="$(find_open_pr_number)"
+          if [ -n "$open_pr" ] && [ "$open_pr" != "null" ]; then
+            gh pr edit "$open_pr" --title "$TITLE" --body "$BODY"
+            {
+              echo "pr_number=$open_pr"
+              echo "action=updated"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          closed_pr="$(find_reopenable_pr_number)"
+          if [ -n "$closed_pr" ] && [ "$closed_pr" != "null" ]; then
+            gh pr reopen "$closed_pr"
+            gh pr edit "$closed_pr" --title "$TITLE" --body "$BODY"
+            {
+              echo "pr_number=$closed_pr"
+              echo "action=reopened"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           gh pr create \
             --base main \
             --head "$BRANCH" \
-            --title "docs: sync and translate English doc changes to Japanese" \
-            --body "Auto-generated by the sync-jp-docs workflow. English documentation changes have been translated to Japanese and synced to the Japanese docs directory. Please review the translations for accuracy."
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            --title "$TITLE" \
+            --body "$BODY"
+
+          created_pr="$(find_open_pr_number)"
+          {
+            echo "pr_number=$created_pr"
+            echo "action=created"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Summary
+        shell: bash
         run: |
-          if [ "${{ steps.sync.outputs.synced }}" == "true" ]; then
-            echo "✅ Japanese docs sync and translation PR created"
-          else
+          if [ "${{ steps.sync.outputs.synced }}" != "true" ]; then
             echo "ℹ️ No English doc changes to sync"
+            echo "## JP sync" >> "$GITHUB_STEP_SUMMARY"
+            echo "- No English documentation changes required translation." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+
+          {
+            echo "- PR action: ${{ steps.pr.outputs.action }}"
+            echo "- PR number: #${{ steps.pr.outputs.pr_number }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "✅ Japanese docs sync PR ${{ steps.pr.outputs.action }} (#${{ steps.pr.outputs.pr_number }})"

--- a/.github/workflows/sync-jp-docs.yml
+++ b/.github/workflows/sync-jp-docs.yml
@@ -179,7 +179,7 @@ jobs:
             cat "$manifest_file"
           } > "$prompt_file"
 
-          "$HOME/.local/bin/droid" exec \
+          droid exec \
             --auto medium \
             --model gpt-5.4 \
             --reasoning-effort high \

--- a/.github/workflows/sync-jp-docs.yml
+++ b/.github/workflows/sync-jp-docs.yml
@@ -70,13 +70,19 @@ jobs:
           fi
           if [ -z "$BEFORE" ]; then
             echo "Cannot determine base commit, skipping."
-            echo "synced=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "synced=false"
+              echo "reason=no_base_commit"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "${{ github.actor }}" = "github-actions[bot]" ]; then
             echo "Skipping JP sync for github-actions[bot] push."
-            echo "synced=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "synced=false"
+              echo "reason=bot_push"
+            } >> "$GITHUB_OUTPUT"
             {
               echo "## JP sync"
               echo "- Skipped: push actor was github-actions[bot]."
@@ -88,7 +94,10 @@ jobs:
 
           if [ -z "$changed_files" ]; then
             echo "No English doc changes detected."
-            echo "synced=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "synced=false"
+              echo "reason=no_english_changes"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -128,7 +137,10 @@ jobs:
 
           if [ "$jp_targets" -eq 0 ]; then
             echo "No Japanese docs targets were generated."
-            echo "synced=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "synced=false"
+              echo "reason=no_jp_targets"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -189,7 +201,10 @@ jobs:
           git add docs/jp/
           if git diff --cached --quiet; then
             echo "No Japanese docs changes to commit."
-            echo "synced=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "synced=false"
+              echo "reason=no_jp_changes"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -204,6 +219,7 @@ jobs:
             echo "branch=$BRANCH"
             echo "title=$TITLE"
             echo "synced=true"
+            echo "reason=synced"
           } >> "$GITHUB_OUTPUT"
 
       - name: Upsert PR with synced docs
@@ -281,9 +297,30 @@ jobs:
         shell: bash
         run: |
           if [ "${{ steps.sync.outputs.synced }}" != "true" ]; then
-            echo "ℹ️ No English doc changes to sync"
+            reason="${{ steps.sync.outputs.reason }}"
             echo "## JP sync" >> "$GITHUB_STEP_SUMMARY"
-            echo "- No English documentation changes required translation." >> "$GITHUB_STEP_SUMMARY"
+            case "$reason" in
+              bot_push)
+                echo "ℹ️ Skipping JP sync for github-actions[bot] push"
+                echo "- Skipped: push actor was github-actions[bot]." >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              no_jp_changes)
+                echo "ℹ️ English docs changed, but no JP updates were needed"
+                echo "- English docs changed, but Droid produced no Japanese doc edits." >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              no_jp_targets)
+                echo "ℹ️ No JP targets were generated"
+                echo "- English docs changed, but no Japanese target files were derived." >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              no_base_commit)
+                echo "ℹ️ Could not determine base commit for JP sync"
+                echo "- Skipped: could not determine the base commit for diffing English docs." >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              *)
+                echo "ℹ️ No English doc changes to sync"
+                echo "- No English documentation changes required translation." >> "$GITHUB_STEP_SUMMARY"
+                ;;
+            esac
             exit 0
           fi
 

--- a/.github/workflows/sync-jp-docs.yml
+++ b/.github/workflows/sync-jp-docs.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
       DROID_VERSION: "0.108.0"
 
     steps:
@@ -33,6 +32,8 @@ jobs:
           fetch-depth: 0
 
       - name: Validate API key
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -54,6 +55,8 @@ jobs:
 
       - name: Sync and translate changed English docs to Japanese
         id: sync
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -90,9 +93,17 @@ jobs:
             exit 0
           fi
 
-          changed_files="$(git diff --name-only --diff-filter=ACM "$BEFORE" "${{ github.sha }}" -- 'docs/**/*.mdx' 'docs/**/*.md' ':!docs/jp/**')"
+          changed_entries_file="$(mktemp)"
+          git diff \
+            --name-status \
+            --find-renames \
+            --diff-filter=ACMR \
+            "$BEFORE" \
+            "${{ github.sha }}" \
+            -- 'docs/**/*.mdx' 'docs/**/*.md' ':!docs/jp/**' \
+            > "$changed_entries_file"
 
-          if [ -z "$changed_files" ]; then
+          if [ ! -s "$changed_entries_file" ]; then
             echo "No English doc changes detected."
             {
               echo "synced=false"
@@ -112,28 +123,44 @@ jobs:
             fi
           fi
 
-          changed_files_file="$(mktemp)"
           manifest_file="$(mktemp)"
           prompt_file="$(mktemp)"
           snapshot_root="$(mktemp -d)"
           cleanup() {
-            rm -f "$changed_files_file" "$manifest_file" "$prompt_file"
+            rm -f "$changed_entries_file" "$manifest_file" "$prompt_file"
             rm -rf "$snapshot_root"
           }
           trap cleanup EXIT
 
-          printf '%s\n' "$changed_files" > "$changed_files_file"
-
           jp_targets=0
-          while IFS= read -r file; do
-            [ -n "$file" ] || continue
-            jp_file="${file/docs\//docs/jp/}"
-            snapshot_path="$snapshot_root/$file"
-            mkdir -p "$(dirname "$jp_file")"
+          while IFS=$'\t' read -r status first second; do
+            [ -n "$status" ] || continue
+            source_path="$first"
+            old_source_path=""
+            if [[ "$status" == R* ]]; then
+              old_source_path="$first"
+              source_path="$second"
+            fi
+
+            jp_file="${source_path/docs\//docs/jp/}"
+            snapshot_path="$snapshot_root/$source_path"
             mkdir -p "$(dirname "$snapshot_path")"
-            git show "${{ github.sha }}:$file" > "$snapshot_path"
+            mkdir -p "$(dirname "$jp_file")"
+
+            if [ -n "$old_source_path" ]; then
+              old_jp_file="${old_source_path/docs\//docs/jp/}"
+              if [ -e "$old_jp_file" ] && [ "$old_jp_file" != "$jp_file" ]; then
+                if [ -e "$jp_file" ]; then
+                  rm -f "$old_jp_file"
+                else
+                  mv "$old_jp_file" "$jp_file"
+                fi
+              fi
+            fi
+
+            git show "${{ github.sha }}:$source_path" > "$snapshot_path"
             jp_targets=$((jp_targets + 1))
-          done < "$changed_files_file"
+          done < "$changed_entries_file"
 
           if [ "$jp_targets" -eq 0 ]; then
             echo "No Japanese docs targets were generated."
@@ -144,16 +171,20 @@ jobs:
             exit 0
           fi
 
-          BEFORE="$BEFORE" GITHUB_SHA="${{ github.sha }}" CHANGED_FILES_FILE="$changed_files_file" SNAPSHOT_ROOT="$snapshot_root" python3 - <<'PY' > "$manifest_file"
+          BEFORE="$BEFORE" GITHUB_SHA="${{ github.sha }}" CHANGED_ENTRIES_FILE="$changed_entries_file" SNAPSHOT_ROOT="$snapshot_root" python3 - <<'PY' > "$manifest_file"
           from pathlib import Path
           import os
           import subprocess
 
           before = os.environ["BEFORE"]
           sha = os.environ["GITHUB_SHA"]
-          changed_files_file = Path(os.environ["CHANGED_FILES_FILE"])
+          changed_entries_file = Path(os.environ["CHANGED_ENTRIES_FILE"])
           snapshot_root = Path(os.environ["SNAPSHOT_ROOT"])
-          changed_files = [line.strip() for line in changed_files_file.read_text().splitlines() if line.strip()]
+          changed_entries = [
+              line.strip().split("\t")
+              for line in changed_entries_file.read_text().splitlines()
+              if line.strip()
+          ]
 
 
           def run(*args: str) -> str:
@@ -165,15 +196,25 @@ jobs:
           print("Use the English diffs below to scope edits, but read the full English source file and current Japanese target file before you edit.")
           print()
 
-          for index, source in enumerate(changed_files, start=1):
+          for index, entry in enumerate(changed_entries, start=1):
+              status = entry[0]
+              old_source = None
+              if status.startswith("R"):
+                  old_source = entry[1]
+                  source = entry[2]
+              else:
+                  source = entry[1]
               snapshot_path = snapshot_root / source
               target = source.replace("docs/", "docs/jp/", 1)
               target_exists = Path(target).exists()
-              diff = run("git", "diff", "--unified=2", before, sha, "--", source).rstrip()
+              diff_paths = [source] if old_source is None else [old_source, source]
+              diff = run("git", "diff", "--find-renames", "--unified=2", before, sha, "--", *diff_paths).rstrip()
               if not diff:
                   diff = "(No textual diff was produced; inspect the file pair directly before deciding no change is needed.)"
 
               print(f"### {index}. `{source}`")
+              if old_source is not None:
+                  print(f"- English path changed from `{old_source}`")
               print(f"- English source snapshot: `{snapshot_path}`")
               print(f"- Japanese target file: `{target}`")
               print(f"- Existing Japanese target before this run: {'yes' if target_exists else 'no'}")
@@ -208,7 +249,7 @@ jobs:
             exit 0
           fi
 
-          changed_count="$(printf '%s\n' "$changed_files" | sed '/^$/d' | wc -l | tr -d ' ')"
+          changed_count="$(wc -l < "$changed_entries_file" | tr -d ' ')"
           {
             echo "## JP sync"
             echo "- English docs changed: $changed_count"


### PR DESCRIPTION
Supersedes #1006.

## Description
### What changed
- Replaced the `sync-jp-docs` workflow's direct Anthropic translation path with a pinned Droid CLI install via `npm install -g droid@0.108.0` and a Droid Exec translation step using `--auto medium`, `gpt-5.4`, and `high` reasoning.
- Scoped Japanese edits to the English diff where possible by generating per-file source snapshots and diff manifests, while still requiring full-file context before edits.
- Changed the workflow to reuse a single `docs/auto-sync-jp-docs` branch and PR, only creating a new PR when one does not already exist.
- Added an explicit skip for `github-actions[bot]` pushes in addition to the existing no-change exits.

### Why
- JP docs sync should run through Droid Exec instead of calling Anthropic directly from this repo workflow.
- Diff-scoped updates reduce token burn and churn while keeping technical documentation accurate, clear, and non-redundant.
- Reusing one PR keeps translation review cumulative and avoids the current one-PR-per-merge clutter.

## Risk & Impact
- Low: this only changes the automated Japanese docs sync workflow and one prompt file under `.github/prompts/`.
- If the Droid Exec prompt or PR lookup logic is wrong, JP sync updates could stop or target the wrong rolling branch until corrected.

## How Tested
- Parsed `.github/workflows/sync-jp-docs.yml` with PyYAML.
- Ran shellcheck on the workflow `run` blocks after extracting them from YAML.
- Ran Prettier in check mode on the changed workflow and prompt file.
- Ran the PR file validation script against the clean worktree diff.

## Not in Scope
- The manual `translate-jp-docs-bulk.yml` workflow and the legacy `.github/scripts/translate-docs.py` helper used by that manual bulk path.
- Cleanup or closure of the older exploratory PRs.
