### PR TITLE
docs: switch mintlify theme and flatten top bar nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -555,6 +555,10 @@
         "href": "/leaderboards"
       },
       {
+        "label": "Support",
+        "href": "/support"
+      },
+      {
         "label": "API Reference",
         "href": "/api-reference/computers/list-computers"
       }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "willow",
+  "theme": "luma",
   "name": "Factory Documentation",
   "description": "Factory is an AI-native software development platform. Delegate complete tasks like refactors, incident response, and migrations to Droids without changing your tools, models, or workflow.",
   "colors": {
@@ -536,22 +536,29 @@
     "light": "/logo/light.png",
     "dark": "/logo/dark.svg"
   },
-  "topbarLinks": [
-    {
-      "name": "Plans & Models",
-      "url": "/pricing"
-    },
-    {
-      "name": "Enterprise",
-      "url": "/enterprise"
-    },
-    {
-      "name": "Support",
-      "url": "/support"
-    }
-  ],
   "navbar": {
-    "links": []
+    "links": [
+      {
+        "label": "Docs",
+        "href": "/welcome"
+      },
+      {
+        "label": "Guides",
+        "href": "/guides/power-user/setup-checklist"
+      },
+      {
+        "label": "Changelog",
+        "href": "/changelog/release-notes"
+      },
+      {
+        "label": "Leaderboards",
+        "href": "/leaderboards"
+      },
+      {
+        "label": "API Reference",
+        "href": "/api-reference/computers/list-computers"
+      }
+    ]
   },
   "footer": {
     "socials": {

--- a/docs/style.css
+++ b/docs/style.css
@@ -52,6 +52,15 @@
 
 /* Restore wider content layout for the current Mintlify Willow theme */
 @media (min-width: 1024px) {
+  #sidebar {
+    top: 4rem !important;
+    height: calc(100vh - 4rem) !important;
+  }
+
+  #content-container > div:first-child {
+    padding-top: 1rem !important;
+  }
+
   #content-area {
     max-width: none !important;
     width: 100% !important;
@@ -79,13 +88,55 @@
 }
 
 /* Slightly enlarge and vertically center the Factory logo in the upper-left */
+#navbar a.select-none,
 #sidebar a.select-none {
   display: inline-flex;
   align-items: center;
 }
 
+#navbar a.select-none {
+  height: 100% !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  padding-right: 0 !important;
+}
+
+#navbar button[data-component-part="tabs-dropdown-trigger"] {
+  display: none !important;
+}
+
+#navbar div.h-12:has(> .nav-tabs) {
+  display: none !important;
+}
+
+@media (min-width: 1024px) {
+  #navbar .h-full.relative.flex-1.flex.items-center.gap-x-4.min-w-0 {
+    gap: 0.75rem !important;
+  }
+
+  #navbar div:has(> a.select-none):has(> #localization-select-trigger) {
+    flex: 0 0 auto !important;
+  }
+
+  #navbar div:has(> #search-bar-entry) {
+    flex: 0 0 auto !important;
+    justify-content: flex-start !important;
+  }
+
+  #navbar div:has(> nav.text-sm) {
+    flex: 1 1 auto !important;
+  }
+
+  #search-bar-entry {
+    width: 14rem !important;
+    min-width: 14rem !important;
+  }
+}
+
+#navbar .nav-logo,
 #sidebar .nav-logo {
   height: 1.75rem !important;
+  width: auto !important;
   padding-left: 0 !important;
   padding-right: 0 !important;
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -50,7 +50,7 @@
   background-color: #ffcccc;
 }
 
-/* Restore wider content layout for the current Mintlify Willow theme */
+/* Restore wider content layout for the current Mintlify Luma theme */
 @media (min-width: 1024px) {
   #sidebar {
     top: 4rem !important;


### PR DESCRIPTION
## Summary

Polish the docs chrome so the header and sidebar feel intentional after the IA reorg. This switches the site to Mintlify's `luma` theme, moves the primary docs destinations into a flat top nav, and tightens the logo, header, and sidebar spacing.

## What changed

- switched the docs theme from `willow` to `luma`
- replaced the old header links with a flat `navbar.links` top nav for:
  - `Docs`
  - `Guides`
  - `Changelog`
  - `Leaderboards`
  - `API Reference`
- adjusted custom CSS to:
  - enlarge and vertically center the top-left logo
  - tighten the spacing between logo, language selector, search, and top-nav links
  - remove the extra sidebar top gap so the left nav starts directly below the navbar
  - reduce the extra top padding above the page eyebrow/header
  - hide the legacy tab/dropdown header elements Mintlify still emits in this configuration

## Risk / impact

Moderate. This is a site-wide docs chrome change, so it affects the global header, sidebar offset, and overall theme styling across the docs site, even though content and IA are unchanged.

## How it was tested

- `prettier --check docs/docs.json docs/style.css`
- parsed `docs/docs.json`
- verified the local Mintlify preview on:
  - `/welcome`
  - `/guides/power-user/setup-checklist`
  - `/enterprise`
  - `/changelog/release-notes`
- spot-checked responsive header behavior around `1100px` and `1440px`
