### PR TITLE
ci: bump droid-action to @main with security review on public docs

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, ready_for_review, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   droid-review:
     if: github.event.pull_request.draft == false
@@ -21,8 +25,9 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Auto Review
-        uses: Factory-AI/droid-action@v4
+        uses: Factory-AI/droid-action@main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}
           automatic_review: true
-          allowed_bots: 'dependabot'
+          automatic_security_review: true
+          allowed_bots: "dependabot"

--- a/.github/workflows/droid.yml
+++ b/.github/workflows/droid.yml
@@ -31,6 +31,6 @@ jobs:
           fetch-depth: 1
 
       - name: Run Droid Exec
-        uses: Factory-AI/droid-action@v4
+        uses: Factory-AI/droid-action@main
         with:
           factory_api_key: ${{ secrets.FACTORY_API_KEY }}


### PR DESCRIPTION
## Summary

Bumps `Factory-AI/droid-action` from `@v4` to `@main` in both CI workflows on this public docs repo, and tightens the review config appropriately for external contributions.

## Changes

`.github/workflows/droid-review.yml`:
- `Factory-AI/droid-action@v4` -> `@main`
- Add `automatic_security_review: true` (public repo receives external PRs and workflow/script edits; worth catching security-relevant changes)
- Add a `concurrency` group so re-pushes cancel the prior review run (saves action minutes + avoids duplicate comments)
- Keep `allowed_bots: 'dependabot'`

`.github/workflows/droid.yml` (`@droid` tag):
- `Factory-AI/droid-action@v4` -> `@main`

## Why @main and not a pinned tag

- Matches the default we recommend to external customers via the `install-code-review` slash command.
- Public-facing docs repo: we want fresh behavior, not to lag on a v-tag that ships monthly. `@main` is the stable release branch.