### PR TITLE
Revert #1011: restore prior mintlify theme/navbar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "luma",
+  "theme": "willow",
   "name": "Factory Documentation",
   "description": "Factory is an AI-native software development platform. Delegate complete tasks like refactors, incident response, and migrations to Droids without changing your tools, models, or workflow.",
   "colors": {
@@ -536,33 +536,22 @@
     "light": "/logo/light.png",
     "dark": "/logo/dark.svg"
   },
+  "topbarLinks": [
+    {
+      "name": "Plans & Models",
+      "url": "/pricing"
+    },
+    {
+      "name": "Enterprise",
+      "url": "/enterprise"
+    },
+    {
+      "name": "Support",
+      "url": "/support"
+    }
+  ],
   "navbar": {
-    "links": [
-      {
-        "label": "Docs",
-        "href": "/welcome"
-      },
-      {
-        "label": "Guides",
-        "href": "/guides/power-user/setup-checklist"
-      },
-      {
-        "label": "Changelog",
-        "href": "/changelog/release-notes"
-      },
-      {
-        "label": "Leaderboards",
-        "href": "/leaderboards"
-      },
-      {
-        "label": "Support",
-        "href": "/support"
-      },
-      {
-        "label": "API Reference",
-        "href": "/api-reference/computers/list-computers"
-      }
-    ]
+    "links": []
   },
   "footer": {
     "socials": {

--- a/docs/style.css
+++ b/docs/style.css
@@ -50,17 +50,8 @@
   background-color: #ffcccc;
 }
 
-/* Restore wider content layout for the current Mintlify Luma theme */
+/* Restore wider content layout for the current Mintlify Willow theme */
 @media (min-width: 1024px) {
-  #sidebar {
-    top: 4rem !important;
-    height: calc(100vh - 4rem) !important;
-  }
-
-  #content-container > div:first-child {
-    padding-top: 1rem !important;
-  }
-
   #content-area {
     max-width: none !important;
     width: 100% !important;
@@ -88,55 +79,13 @@
 }
 
 /* Slightly enlarge and vertically center the Factory logo in the upper-left */
-#navbar a.select-none,
 #sidebar a.select-none {
   display: inline-flex;
   align-items: center;
 }
 
-#navbar a.select-none {
-  height: 100% !important;
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-  padding-right: 0 !important;
-}
-
-#navbar button[data-component-part="tabs-dropdown-trigger"] {
-  display: none !important;
-}
-
-#navbar div.h-12:has(> .nav-tabs) {
-  display: none !important;
-}
-
-@media (min-width: 1024px) {
-  #navbar .h-full.relative.flex-1.flex.items-center.gap-x-4.min-w-0 {
-    gap: 0.75rem !important;
-  }
-
-  #navbar div:has(> a.select-none):has(> #localization-select-trigger) {
-    flex: 0 0 auto !important;
-  }
-
-  #navbar div:has(> #search-bar-entry) {
-    flex: 0 0 auto !important;
-    justify-content: flex-start !important;
-  }
-
-  #navbar div:has(> nav.text-sm) {
-    flex: 1 1 auto !important;
-  }
-
-  #search-bar-entry {
-    width: 14rem !important;
-    min-width: 14rem !important;
-  }
-}
-
-#navbar .nav-logo,
 #sidebar .nav-logo {
   height: 1.75rem !important;
-  width: auto !important;
   padding-left: 0 !important;
   padding-right: 0 !important;
 }


### PR DESCRIPTION
Reverts #1011.

Live docs site broke after the Luma theme switch:

- Duplicate nav rows rendered (legacy Mintlify tab/dropdown elements the PR's CSS tried to hide via `#navbar button[data-component-part="tabs-dropdown-trigger"]` and `#navbar div.h-12:has(> .nav-tabs)` — selectors don't match in Luma so both the legacy tabs and the new `navbar.links` render simultaneously).
- Language selector + "Docs" tab collision in left sidebar ("EnglisDocs" clipping).
- Right-side TOC entries stack/overlap and bleed into main content column.

Rolling back to restore the site while the theme switch is redone properly against Luma.