### PR TITLE
docs: migrate to Mintlify Luma theme + fix Support nav link (redo of #1011)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "theme": "willow",
+  "theme": "luma",
   "name": "Factory Documentation",
   "description": "Factory is an AI-native software development platform. Delegate complete tasks like refactors, incident response, and migrations to Droids without changing your tools, models, or workflow.",
   "colors": {
@@ -536,22 +536,33 @@
     "light": "/logo/light.png",
     "dark": "/logo/dark.svg"
   },
-  "topbarLinks": [
-    {
-      "name": "Plans & Models",
-      "url": "/pricing"
-    },
-    {
-      "name": "Enterprise",
-      "url": "/enterprise"
-    },
-    {
-      "name": "Support",
-      "url": "/support"
-    }
-  ],
   "navbar": {
-    "links": []
+    "links": [
+      {
+        "label": "Docs",
+        "href": "/welcome"
+      },
+      {
+        "label": "Guides",
+        "href": "/guides/power-user/setup-checklist"
+      },
+      {
+        "label": "Changelog",
+        "href": "/changelog/release-notes"
+      },
+      {
+        "label": "Leaderboards",
+        "href": "/leaderboards"
+      },
+      {
+        "label": "Support",
+        "href": "/support"
+      },
+      {
+        "label": "API Reference",
+        "href": "/api-reference/computers/list-computers"
+      }
+    ]
   },
   "footer": {
     "socials": {

--- a/docs/style.css
+++ b/docs/style.css
@@ -50,23 +50,13 @@
   background-color: #ffcccc;
 }
 
-/* Restore wider content layout for the current Mintlify Willow theme */
-@media (min-width: 1024px) {
-  #content-area {
-    max-width: none !important;
-    width: 100% !important;
-  }
-
-  #content-area > div:first-child {
-    max-width: none !important;
-    width: 100% !important;
-    background: transparent !important;
-  }
-
-  #content-area > div:first-child > div:first-child {
-    max-width: min(1200px, calc(100vw - 23rem - 19rem)) !important;
-    width: 100% !important;
-  }
+/* Hide Luma's auto-generated top-level tabs nav in favor of explicit navbar.links.
+   Luma renders a <nav> containing <li><a class="link …"> for each tab defined in
+   docs.json. We use navbar.links for the primary header nav, so this suppresses
+   the duplicate row. Identified via the unique `.link` class Luma applies to
+   auto-tab anchors (navbar.links anchors use a `.navbar-link` li wrapper instead). */
+#navbar nav:has(> ul > li > a.link) {
+  display: none !important;
 }
 
 /* Restore a flat page background */
@@ -79,13 +69,16 @@
 }
 
 /* Slightly enlarge and vertically center the Factory logo in the upper-left */
-#sidebar a.select-none {
+#sidebar a.select-none,
+#navbar a.select-none {
   display: inline-flex;
   align-items: center;
 }
 
-#sidebar .nav-logo {
+#sidebar .nav-logo,
+#navbar .nav-logo {
   height: 1.75rem !important;
+  width: auto !important;
   padding-left: 0 !important;
   padding-right: 0 !important;
 }


### PR DESCRIPTION
## Summary

Redo of #1011 (which was reverted in #1013 after breaking the live docs).

This PR achieves the same intent — switch to Mintlify's Luma theme and reorganize the top-nav — but with CSS rules that actually target Luma's DOM instead of Willow's, and with full visual QA.

## What changed

**docs/docs.json**
- `theme` willow → luma
- Removed `topbarLinks` (deprecated in Luma)
- Populated `navbar.links` with 6 entries: Docs / Guides / Changelog / Leaderboards / **Support** / API Reference
  - Support was orphaned on the English side after #1011 — now a first-class nav entry
  - Plans & Models and Enterprise remain reachable from the "Start Here" sidebar group

**docs/style.css**
- **Dropped** the `Restore wider content layout for the current Mintlify Willow theme` `@media (min-width: 1024px)` block. Those `max-width: none !important` overrides were tuned for Willow's layout and caused the TOC/body overlap under Luma.
- **Added** a single rule to hide Luma's auto-generated tabs nav in favor of `navbar.links`:
  ```css
  #navbar nav:has(> ul > li > a.link) { display: none !important; }
  ```
  Selector is anchored on Luma's `.link` class, which only appears on auto-tab anchors (explicit `navbar.links` anchors live inside `<li class="navbar-link">` instead). This is why #1011's `#navbar div.h-12:has(> .nav-tabs)` selector missed — those classes are Willow-only.
- Extended the logo centering rule from `#sidebar` to also apply to `#navbar` so the header logo sizes consistently with the sidebar logo (added `width: auto !important` so it doesn't stretch).

## Verification

Ran `mintlify dev` locally and validated via headless Chromium (Playwright) across **16 test cases** (4 pages × 4 viewports):

| Page | Viewports |
|------|-----------|
| /welcome | 390×844, 1024×768, 1440×900, 1920×1080 |
| /guides/power-user/setup-checklist | same |
| /changelog/release-notes | same |
| /cli/getting-started/overview | same |

For each, the test asserts:
- Luma's auto-tabs `<nav>` is in the DOM but `getComputedStyle().display === 'none'` (CSS hide works)
- Exactly **6** `li.navbar-link` elements render (explicit nav)
- Exactly **1** `a[href="/support"]` renders inside `#navbar` (Support nav entry present)

Result: **all 16 cases clean, no duplicate nav rows, no TOC/body overlap, no sidebar clipping**. Screenshots at 1024/1440/1920px all show a single navbar row with the correct 6 entries and proper body/TOC layout.

## Risk

Moderate — site-wide chrome change. But (a) the bad CSS selectors that caused #1011's regression have been replaced with Luma-matching ones, (b) all the Willow-specific overrides that caused the body/TOC overlap have been removed entirely, and (c) the change has been exercised in a live Mintlify preview at multiple breakpoints.

## Not in scope

- Any deeper Luma theme customization beyond fixing the duplicate-nav + body-layout regressions.
- Further iteration on the navbar.links list (e.g. reorganizing order) — current list matches the intent expressed in #1011.