### PR TITLE
docs: update public model list for GPT-5.5

### DIFF
--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -36,7 +36,7 @@ Local overrides merge on top of the corresponding `settings.json` at the same le
 
 | Setting                    | Options                                                                                                                                                                                                                                                                  | Default                       | Description                                                                |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- | -------------------------------------------------------------------------- |
-| `model`                    | `opus`, `opus-4-7`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `sonnet-4-6`, `gpt-5.4`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3.1-pro`, `gemini-3-flash`, `droid-core`, `glm-5`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.7`, `custom-model` | `opus`                        | The default AI model used by droid                                         |
+| `model`                    | `opus`, `opus-4-7`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `sonnet-4-6`, `gpt-5.5`, `gpt-5.5-fast`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3.1-pro`, `gemini-3-flash`, `droid-core`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.7`, `custom-model` | `opus`                        | The default AI model used by droid                                         |
 | `reasoningEffort`          | `off`, `none`, `low`, `medium`, `high` (availability depends on the model)                                                                                                                                                                                               | Model-dependent default       | Controls how much structured thinking the model performs.                  |
 | `autonomyMode`             | `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high`                                                                                                                                                                                                                 | `normal`                      | Sets the default autonomy mode when starting droid.                        |
 | `cloudSessionSync`         | `true`, `false`                                                                                                                                                                                                                                                          | `true`                        | Mirror CLI sessions to Factory web.                                        |
@@ -64,7 +64,10 @@ Choose the default AI model that powers your droid:
 - **`opus-4-6-fast`** - Claude Opus 4.6 Fast, tuned for faster responses
 - **`sonnet`** - Claude Sonnet 4.5, balanced cost and quality
 - **`sonnet-4-6`** - Claude Sonnet 4.6, Max reasoning at the Sonnet price point
-- **`gpt-5.4`** - GPT-5.4, latest OpenAI model with 922K context and Extra High reasoning
+- **`gpt-5.5`** - GPT-5.5, latest OpenAI flagship model
+- **`gpt-5.5-fast`** - GPT-5.5 Fast, tuned for faster responses
+- **`gpt-5.5-pro`** - GPT-5.5 Pro, higher-capability variant
+- **`gpt-5.4`** - GPT-5.4, previous OpenAI model with 922K context and Extra High reasoning
 - **`gpt-5.2`** - OpenAI GPT-5.2
 - **`gpt-5.2-codex`** - GPT-5.2-Codex, OpenAI coding model with Extra High reasoning
 - **`gpt-5.3-codex`** - GPT-5.3-Codex, latest OpenAI coding model with Extra High reasoning and verbosity support
@@ -72,7 +75,6 @@ Choose the default AI model that powers your droid:
 - **`gemini-3.1-pro`** - Gemini 3.1 Pro
 - **`gemini-3-flash`** - Gemini 3 Flash, fast and cheap (0.2× multiplier)
 - **`droid-core`** - GLM-5.1 open-source model
-- **`glm-5`** - GLM-5 open-source model
 - **`glm-5.1`** - GLM-5.1 open-source model
 - **`kimi-k2.5`** - Kimi K2.5 open-source model with image support
 - **`kimi-k2.6`** - Kimi K2.6 open-source model with image support and optional High reasoning

--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -64,9 +64,9 @@ Choose the default AI model that powers your droid:
 - **`opus-4-6-fast`** - Claude Opus 4.6 Fast, tuned for faster responses
 - **`sonnet`** - Claude Sonnet 4.5, balanced cost and quality
 - **`sonnet-4-6`** - Claude Sonnet 4.6, Max reasoning at the Sonnet price point
-- **`gpt-5.5`** - GPT-5.5, latest OpenAI flagship model
-- **`gpt-5.5-fast`** - GPT-5.5 Fast, tuned for faster responses
-- **`gpt-5.5-pro`** - GPT-5.5 Pro, higher-capability variant
+- **`gpt-5.5`** - GPT-5.5, latest OpenAI flagship model with 1M context and Extra High reasoning
+- **`gpt-5.5-fast`** - GPT-5.5 on priority service tier, less susceptible to traffic surge
+- **`gpt-5.5-pro`** - GPT-5.5 Pro, higher-capability variant, ideal for research tasks
 - **`gpt-5.4`** - GPT-5.4, previous OpenAI model with 922K context and Extra High reasoning
 - **`gpt-5.2`** - OpenAI GPT-5.2
 - **`gpt-5.2-codex`** - GPT-5.2-Codex, OpenAI coding model with Extra High reasoning

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -81,12 +81,14 @@ Supported models (examples):
 - gpt-5.2-codex
 - gpt-5.3-codex
 - gpt-5.3-codex-fast
+- gpt-5.5
+- gpt-5.5-fast
+- gpt-5.5-pro
 - gpt-5.4
 - gpt-5.4-fast
 - gpt-5.4-mini
 - gemini-3.1-pro-preview
 - gemini-3-flash-preview
-- glm-5
 - glm-5.1
 - kimi-k2.5
 - kimi-k2.6

--- a/docs/jp/cli/configuration/settings.mdx
+++ b/docs/jp/cli/configuration/settings.mdx
@@ -36,7 +36,7 @@ droidの設定を構成するには：
 
 | 設定 | オプション | デフォルト | 説明 |
 | ------- | ------- | ------- | ----------- |
-| `model` | `opus`, `opus-4-7`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `sonnet-4-6`, `gpt-5.4`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3.1-pro`, `gemini-3-flash`, `droid-core`, `glm-5`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.7`, `custom-model` | `opus` | droidが使用するデフォルトのAIモデル |
+| `model` | `opus`, `opus-4-7`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `sonnet-4-6`, `gpt-5.5`, `gpt-5.5-fast`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3.1-pro`, `gemini-3-flash`, `droid-core`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.7`, `custom-model` | `opus` | droidが使用するデフォルトのAIモデル |
 | `reasoningEffort` | `off`, `none`, `low`, `medium`, `high`（利用可能性はモデルに依存） | モデル依存のデフォルト | モデルが実行する構造化思考の量を制御します。 |
 | `autonomyMode` | `normal`, `spec`, `auto-low`, `auto-medium`, `auto-high` | `normal` | droid開始時のデフォルト自律モードを設定します。 |
 | `cloudSessionSync` | `true`, `false` | `true` | CLIセッションをFactory webにミラーします。 |
@@ -64,7 +64,10 @@ droidを動かすデフォルトのAIモデルを選択します：
 - **`opus-4-6-fast`** - Claude Opus 4.6 Fast、高速レスポンス用にチューニングされたモデル
 - **`sonnet`** - Claude Sonnet 4.5、コストと品質のバランス型
 - **`sonnet-4-6`** - Claude Sonnet 4.6、Sonnet価格帯でMax推論を搭載
-- **`gpt-5.4`** - GPT-5.4、922Kコンテキストと Extra High推論を搭載した最新OpenAIモデル
+- **`gpt-5.5`** - GPT-5.5、最新OpenAIフラグシップモデル
+- **`gpt-5.5-fast`** - GPT-5.5 Fast、高速レスポンス用にチューニング
+- **`gpt-5.5-pro`** - GPT-5.5 Pro、高性能バリアント
+- **`gpt-5.4`** - GPT-5.4、922Kコンテキストと Extra High推論を搭載した前世代OpenAIモデル
 - **`gpt-5.2`** - OpenAI GPT-5.2
 - **`gpt-5.2-codex`** - GPT-5.2-Codex、Extra High推論機能を持つOpenAIコーディングモデル
 - **`gpt-5.3-codex`** - GPT-5.3-Codex、Extra High推論と詳細性サポートを持つ最新OpenAIコーディングモデル
@@ -72,7 +75,6 @@ droidを動かすデフォルトのAIモデルを選択します：
 - **`gemini-3.1-pro`** - Gemini 3.1 Pro
 - **`gemini-3-flash`** - Gemini 3 Flash、高速で安価（0.2×倍率）
 - **`droid-core`** - GLM-5.1 オープンソースモデル
-- **`glm-5`** - GLM-5 オープンソースモデル
 - **`glm-5.1`** - GLM-5.1 オープンソースモデル
 - **`kimi-k2.5`** - Kimi K2.5 画像サポート付きオープンソースモデル
 - **`kimi-k2.6`** - Kimi K2.6 画像サポートとHigh推論切り替え付きオープンソースモデル

--- a/docs/jp/cli/configuration/settings.mdx
+++ b/docs/jp/cli/configuration/settings.mdx
@@ -64,9 +64,9 @@ droidを動かすデフォルトのAIモデルを選択します：
 - **`opus-4-6-fast`** - Claude Opus 4.6 Fast、高速レスポンス用にチューニングされたモデル
 - **`sonnet`** - Claude Sonnet 4.5、コストと品質のバランス型
 - **`sonnet-4-6`** - Claude Sonnet 4.6、Sonnet価格帯でMax推論を搭載
-- **`gpt-5.5`** - GPT-5.5、最新OpenAIフラグシップモデル
-- **`gpt-5.5-fast`** - GPT-5.5 Fast、高速レスポンス用にチューニング
-- **`gpt-5.5-pro`** - GPT-5.5 Pro、高性能バリアント
+- **`gpt-5.5`** - GPT-5.5、1Mコンテキストと Extra High推論を搭載した最新OpenAIフラグシップモデル
+- **`gpt-5.5-fast`** - GPT-5.5 優先サービスティア、トラフィック急増の影響を受けにくい
+- **`gpt-5.5-pro`** - GPT-5.5 Pro、高性能バリアント、リサーチタスクに最適
 - **`gpt-5.4`** - GPT-5.4、922Kコンテキストと Extra High推論を搭載した前世代OpenAIモデル
 - **`gpt-5.2`** - OpenAI GPT-5.2
 - **`gpt-5.2-codex`** - GPT-5.2-Codex、Extra High推論機能を持つOpenAIコーディングモデル

--- a/docs/jp/cli/droid-exec/overview.mdx
+++ b/docs/jp/cli/droid-exec/overview.mdx
@@ -81,12 +81,14 @@ Options:
 - gpt-5.2-codex
 - gpt-5.3-codex
 - gpt-5.3-codex-fast
+- gpt-5.5
+- gpt-5.5-fast
+- gpt-5.5-pro
 - gpt-5.4
 - gpt-5.4-fast
 - gpt-5.4-mini
 - gemini-3.1-pro-preview
 - gemini-3-flash-preview
-- glm-5
 - glm-5.1
 - kimi-k2.5
 - kimi-k2.6

--- a/docs/jp/pricing.mdx
+++ b/docs/jp/pricing.mdx
@@ -43,7 +43,6 @@ Enterpriseの料金については[営業チームにお問い合わせ](https:/
 | Droid Core (Kimi K2.6)   | `kimi-k2.6`                  |
 | GPT-5.4 Mini             | `gpt-5.4-mini`               |
 | Claude Haiku 4.5         | `claude-haiku-4-5-20251001`  |
-| Droid Core (GLM-5)       | `glm-5`                      |
 | Droid Core (GLM-5.1)     | `glm-5.1`                    |
 | GPT-5.2                  | `gpt-5.2`                    |
 | GPT-5.2-Codex            | `gpt-5.2-codex`              |
@@ -56,5 +55,7 @@ Enterpriseの料金については[営業チームにお問い合わせ](https:/
 | Claude Opus 4.5          | `claude-opus-4-5-20251101`   |
 | Claude Opus 4.7          | `claude-opus-4-7`            |
 | Claude Opus 4.6          | `claude-opus-4-6`            |
+| GPT-5.5                  | `gpt-5.5`                    |
 | GPT-5.4 Fast             | `gpt-5.4-fast`               |
 | Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       |
+| GPT-5.5 Pro              | `gpt-5.5-pro`                |

--- a/docs/jp/pricing.mdx
+++ b/docs/jp/pricing.mdx
@@ -56,6 +56,7 @@ Enterpriseの料金については[営業チームにお問い合わせ](https:/
 | Claude Opus 4.7          | `claude-opus-4-7`            |
 | Claude Opus 4.6          | `claude-opus-4-6`            |
 | GPT-5.5                  | `gpt-5.5`                    |
+| GPT-5.5 Fast             | `gpt-5.5-fast`               |
 | GPT-5.4 Fast             | `gpt-5.4-fast`               |
 | Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       |
 | GPT-5.5 Pro              | `gpt-5.5-pro`                |

--- a/docs/jp/reference/cli-reference.mdx
+++ b/docs/jp/reference/cli-reference.mdx
@@ -108,13 +108,15 @@ droid exec --auto high "Run tests, commit, and push changes"
 | `claude-sonnet-4-6`           | Claude Sonnet 4.6            | Yes (Off/Low/Medium/High/Max)            | high              |
 | `claude-sonnet-4-5-20250929`  | Claude Sonnet 4.5            | Yes (Off/Low/Medium/High)                | off               |
 | `claude-haiku-4-5-20251001`   | Claude Haiku 4.5             | Yes (Off/Low/Medium/High)                | off               |
+| `gpt-5.5`                     | GPT-5.5                      | Yes (None/Low/Medium/High/Extra High)    | medium            |
+| `gpt-5.5-fast`                | GPT-5.5 Fast                 | Yes (None/Low/Medium/High/Extra High)    | medium            |
+| `gpt-5.5-pro`                 | GPT-5.5 Pro                  | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `gpt-5.4`                     | GPT-5.4                      | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `gpt-5.3-codex`               | GPT-5.3-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `gpt-5.2-codex`               | GPT-5.2-Codex                | Yes (None/Low/Medium/High/Extra High)    | medium            |
 | `gpt-5.2`                     | GPT-5.2                      | Yes (Off/Low/Medium/High/Extra High)     | low               |
 | `gemini-3.1-pro-preview`      | Gemini 3.1 Pro               | Yes (Low/Medium/High)                    | high              |
 | `gemini-3-flash-preview`      | Gemini 3 Flash               | Yes (Minimal/Low/Medium/High)            | high              |
-| `glm-5`                       | Droid Core (GLM-5)           | None only                                | none              |
 | `glm-5.1`                     | Droid Core (GLM-5.1)         | None only                                | none              |
 | `kimi-k2.5`                   | Droid Core (Kimi K2.5)       | None only                                | none              |
 | `kimi-k2.6`                   | Droid Core (Kimi K2.6)       | Yes (Off/High)                           | high              |

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -56,6 +56,7 @@ Everything in Max, plus:
 | Claude Opus 4.7          | `claude-opus-4-7`            |
 | Claude Opus 4.6          | `claude-opus-4-6`            |
 | GPT-5.5                  | `gpt-5.5`                    |
+| GPT-5.5 Fast             | `gpt-5.5-fast`               |
 | GPT-5.4 Fast             | `gpt-5.4-fast`               |
 | Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       |
 | GPT-5.5 Pro              | `gpt-5.5-pro`                |

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -43,7 +43,6 @@ Everything in Max, plus:
 | Droid Core (Kimi K2.6)   | `kimi-k2.6`                  |
 | GPT-5.4 Mini             | `gpt-5.4-mini`               |
 | Claude Haiku 4.5         | `claude-haiku-4-5-20251001`  |
-| Droid Core (GLM-5)       | `glm-5`                      |
 | Droid Core (GLM-5.1)     | `glm-5.1`                    |
 | GPT-5.2                  | `gpt-5.2`                    |
 | GPT-5.2-Codex            | `gpt-5.2-codex`              |
@@ -56,5 +55,7 @@ Everything in Max, plus:
 | Claude Opus 4.5          | `claude-opus-4-5-20251101`   |
 | Claude Opus 4.7          | `claude-opus-4-7`            |
 | Claude Opus 4.6          | `claude-opus-4-6`            |
+| GPT-5.5                  | `gpt-5.5`                    |
 | GPT-5.4 Fast             | `gpt-5.4-fast`               |
 | Claude Opus 4.6 Fast     | `claude-opus-4-6-fast`       |
+| GPT-5.5 Pro              | `gpt-5.5-pro`                |

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -110,13 +110,15 @@ droid exec --auto high "Run tests, commit, and push changes"
 | `claude-sonnet-4-6`          | Claude Sonnet 4.6         | Yes (Off/Low/Medium/High/Max)         | high              |
 | `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5         | Yes (Off/Low/Medium/High)             | off               |
 | `claude-haiku-4-5-20251001`  | Claude Haiku 4.5          | Yes (Off/Low/Medium/High)             | off               |
+| `gpt-5.5`                    | GPT-5.5                   | Yes (None/Low/Medium/High/Extra High) | medium            |
+| `gpt-5.5-fast`               | GPT-5.5 Fast              | Yes (None/Low/Medium/High/Extra High) | medium            |
+| `gpt-5.5-pro`                | GPT-5.5 Pro               | Yes (None/Low/Medium/High/Extra High) | medium            |
 | `gpt-5.4`                    | GPT-5.4                   | Yes (None/Low/Medium/High/Extra High) | medium            |
 | `gpt-5.3-codex`              | GPT-5.3-Codex             | Yes (None/Low/Medium/High/Extra High) | medium            |
 | `gpt-5.2-codex`              | GPT-5.2-Codex             | Yes (None/Low/Medium/High/Extra High) | medium            |
 | `gpt-5.2`                    | GPT-5.2                   | Yes (Off/Low/Medium/High/Extra High)  | low               |
 | `gemini-3.1-pro-preview`     | Gemini 3.1 Pro            | Yes (Low/Medium/High)                 | high              |
 | `gemini-3-flash-preview`     | Gemini 3 Flash            | Yes (Minimal/Low/Medium/High)         | high              |
-| `glm-5`                      | Droid Core (GLM-5)        | None only                             | none              |
 | `glm-5.1`                    | Droid Core (GLM-5.1)      | None only                             | none              |
 | `kimi-k2.5`                  | Droid Core (Kimi K2.5)    | None only                             | none              |
 | `kimi-k2.6`                  | Droid Core (Kimi K2.6)    | Yes (Off/High)                        | high              |


### PR DESCRIPTION
## Summary
- Adds GPT-5.5 and GPT-5.5 Pro to the public docs model list.
- Removes GLM-5 now that the model is deprecated ahead of Fireworks serverless decommissioning.
- Keeps EN and JP pricing docs in sync.

## Testing
- `git diff --check`
