### PR TITLE
docs: Standardize cloud template page titles

### DIFF
--- a/docs/jp/web/machine-connection/cloud-templates/best-practices.mdx
+++ b/docs/jp/web/machine-connection/cloud-templates/best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-title: "クラウドテンプレート – ベストプラクティス"
+title: "ベストプラクティス"
 description: Proven tips and workflows to get the most out of cloud templates in Factory
 ---
 

--- a/docs/jp/web/machine-connection/cloud-templates/index.mdx
+++ b/docs/jp/web/machine-connection/cloud-templates/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "クラウドテンプレート"
+title: "概要"
 description: Spin-up instant, cloud-hosted templates that mirror your local dev setup. No install required
 ---
 

--- a/docs/jp/web/machine-connection/cloud-templates/installation-and-usage.mdx
+++ b/docs/jp/web/machine-connection/cloud-templates/installation-and-usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: "クラウドテンプレート – インストールと使用方法"
+title: "インストールと使用方法"
 description: Set up, connect to, and use Cloud Templates inside Factory sessions
 ---
 

--- a/docs/jp/web/machine-connection/cloud-templates/setup-script.mdx
+++ b/docs/jp/web/machine-connection/cloud-templates/setup-script.mdx
@@ -1,5 +1,5 @@
 ---
-title: "クラウドテンプレート – セットアップスクリプト"
+title: "セットアップスクリプト"
 description: Configure a setup script to run during template creation
 ---
 

--- a/docs/jp/web/machine-connection/cloud-templates/troubleshooting.mdx
+++ b/docs/jp/web/machine-connection/cloud-templates/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: "クラウドテンプレート – トラブルシューティング"
+title: "トラブルシューティング"
 description: Diagnose and resolve common problems when creating, connecting to, or working inside a cloud template
 ---
 

--- a/docs/web/machine-connection/cloud-templates/best-practices.mdx
+++ b/docs/web/machine-connection/cloud-templates/best-practices.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud Templates - Best Practices
+title: Best Practices
 description: Proven tips and workflows to get the most out of cloud templates in Factory
 ---
 

--- a/docs/web/machine-connection/cloud-templates/index.mdx
+++ b/docs/web/machine-connection/cloud-templates/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud Templates
+title: Overview
 description: Spin-up instant, cloud-hosted templates that mirror your local dev setup. No install required
 ---
 

--- a/docs/web/machine-connection/cloud-templates/installation-and-usage.mdx
+++ b/docs/web/machine-connection/cloud-templates/installation-and-usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud Templates – Installation & Usage
+title: Installation & Usage
 description: Set up, connect to, and use Cloud Templates inside Factory sessions
 ---
 

--- a/docs/web/machine-connection/cloud-templates/setup-script.mdx
+++ b/docs/web/machine-connection/cloud-templates/setup-script.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud Templates – Setup Script
+title: Setup Script
 description: Configure a setup script to run during template creation
 ---
 

--- a/docs/web/machine-connection/cloud-templates/troubleshooting.mdx
+++ b/docs/web/machine-connection/cloud-templates/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cloud Templates – Troubleshooting
+title: Troubleshooting
 description: Diagnose and resolve common problems when creating, connecting to, or working inside a cloud template
 ---
 


### PR DESCRIPTION
## What changed

- Standardized Cloud Templates child page titles so sidebar labels do not repeat the parent section name.
- Mirrored the same title cleanup in the Japanese Cloud Templates pages.

## Why

This aligns the Cloud Templates section with nearby docs sections that use concise child page titles under a named parent group.

## Risk / impact

Low. These are title-only frontmatter changes; no page content, URLs, filenames, or navigation paths changed.

## How tested

- `npx -y mintlify@4.2.529 validate`
- `npx -y mintlify@4.2.529 broken-links --check-redirects`
- `python3 /Users/andy/.factory/skills/apply-pr-standards/scripts/validate-pr-files.py --base origin/main`
