### PR TITLE
docs: add wiki feature documentation

### DIFF
--- a/docs/cli/features/wiki/auto-refresh.mdx
+++ b/docs/cli/features/wiki/auto-refresh.mdx
@@ -40,14 +40,14 @@ Droid detects your CI framework and creates the appropriate configuration.
 
 ### GitHub Actions
 
-Creates `.github/workflows/droid-wiki-refresh.yml`:
+Creates `.github/workflows/droid-wiki-refresh.yml` (replace `main` with your default branch if different):
 
 ```yaml
 name: Droid Wiki Refresh
 
 on:
   push:
-    branches: [main]
+    branches: [main] # change to your default branch if not main
 
 jobs:
   wiki-refresh:
@@ -76,7 +76,7 @@ droid-wiki-refresh:
   script:
     - droid exec --auto high "/wiki"
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
   variables:
     FACTORY_API_KEY: $FACTORY_API_KEY
 ```

--- a/docs/cli/features/wiki/auto-refresh.mdx
+++ b/docs/cli/features/wiki/auto-refresh.mdx
@@ -23,8 +23,8 @@ The `/install-wiki` command creates a CI workflow that automatically regenerates
   </Step>
   <Step title="Add the Factory API key">
     Add `FACTORY_API_KEY` as a secret in your CI settings:
-    - **GitHub**: Repository **Settings > Secrets and variables > Actions**
-    - **GitLab**: Repository **Settings > CI/CD > Variables**
+    - **GitHub**: Repository **Settings > Secrets and variables > Actions** (or at the organization level under **Organization Settings > Secrets and variables > Actions**)
+    - **GitLab**: Repository **Settings > CI/CD > Variables** (or at the group level under **Group Settings > CI/CD > Variables**)
 
     Generate a key at [app.factory.ai/settings/api-keys](https://app.factory.ai/settings/api-keys).
   </Step>

--- a/docs/cli/features/wiki/auto-refresh.mdx
+++ b/docs/cli/features/wiki/auto-refresh.mdx
@@ -1,0 +1,146 @@
+---
+title: Auto-Refresh
+description: Use /install-wiki to set up a CI action that regenerates your wiki on every push to the default branch.
+keywords: ['wiki', '/install-wiki', 'auto-refresh', 'github actions', 'gitlab ci', 'CI', 'recurring', 'workflow', 'automation']
+---
+
+The `/install-wiki` command creates a CI workflow that automatically regenerates your wiki every time code is pushed to the default branch. It detects your CI framework -- GitHub Actions or GitLab CI -- and generates the appropriate configuration. This keeps your documentation in sync with your codebase without manual intervention.
+
+## Quick start
+
+<Steps>
+  <Step title="Open a Droid session in your repo">
+    ```bash
+    cd /path/to/your/project
+    droid
+    ```
+  </Step>
+  <Step title="Run the install command">
+    ```
+    > /install-wiki
+    ```
+    Droid creates a workflow file and opens a pull request for you to review.
+  </Step>
+  <Step title="Add the Factory API key">
+    Add `FACTORY_API_KEY` as a secret in your CI settings:
+    - **GitHub**: Repository **Settings > Secrets and variables > Actions**
+    - **GitLab**: Repository **Settings > CI/CD > Variables**
+
+    Generate a key at [app.factory.ai/settings/api-keys](https://app.factory.ai/settings/api-keys).
+  </Step>
+  <Step title="Merge the PR">
+    Once the secret is configured, merge the workflow PR. The wiki will now
+    refresh automatically on every push to the default branch.
+  </Step>
+</Steps>
+
+## Generated workflows
+
+Droid detects your CI framework and creates the appropriate configuration.
+
+### GitHub Actions
+
+Creates `.github/workflows/droid-wiki-refresh.yml`:
+
+```yaml
+name: Droid Wiki Refresh
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  wiki-refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Factory Droid
+        run: curl -fsSL https://app.factory.ai/cli | sh
+
+      - name: Generate wiki
+        run: droid exec --auto high "/wiki"
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+```
+
+### GitLab CI
+
+Appends a job to your existing `.gitlab-ci.yml`:
+
+```yaml
+droid-wiki-refresh:
+  stage: deploy
+  before_script:
+    - curl -fsSL https://app.factory.ai/cli | sh
+  script:
+    - droid exec --auto high "/wiki"
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  variables:
+    FACTORY_API_KEY: $FACTORY_API_KEY
+```
+
+Both workflows:
+
+- **Trigger on push** to the default branch
+- **Install the Droid CLI** using the official installer
+- **Run `/wiki`** in headless mode with high autonomy, generating and uploading the wiki
+
+<Tip>
+  You can customize the workflow after installation. For example, change the
+  trigger branch, add path filters to only regenerate when source files change,
+  or adjust the timeout.
+</Tip>
+
+## Prerequisites
+
+- A GitHub or GitLab hosted repository
+- A Factory API key -- generate one at [app.factory.ai/settings/api-keys](https://app.factory.ai/settings/api-keys)
+- Permission to add secrets and merge PRs in the target repository
+
+## Refreshing from the web
+
+You can also set up recurring refreshes from the Factory web app:
+
+1. Go to [app.factory.ai/wiki](https://app.factory.ai/wiki)
+2. Click **Refresh** on the wiki page
+3. Select **Recurring (on push)**
+4. Choose a **Local** or **Cloud** method:
+   - **Local** -- Copies the `/install-wiki` command for you to run in a local clone
+   - **Cloud** -- Selects a cloud template or Droid Computer to run the setup remotely
+
+For batch operations across multiple repositories, the web UI lets you select several repos and run the setup on a Droid Computer in a single operation.
+
+See [Web Viewer](/cli/features/wiki/web-viewer) for more on the web interface.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Workflow fails with authentication error">
+    Verify the `FACTORY_API_KEY` secret is set correctly in your repository's
+    **Settings > Secrets and variables > Actions**. Generate a new key at
+    [app.factory.ai/settings/api-keys](https://app.factory.ai/settings/api-keys)
+    if needed.
+  </Accordion>
+
+  <Accordion title="Wiki not updating after push">
+    Check that the workflow file exists at `.github/workflows/droid-wiki-refresh.yml`
+    and that the branch trigger matches your default branch. View the Actions
+    tab in your repository to see workflow run logs.
+  </Accordion>
+
+  <Accordion title="GitHub wiki not syncing">
+    The GitHub wiki tab must be initialized before Factory can push to it. Create
+    the first page manually at `https://github.com/{owner}/{repo}/wiki`. Also
+    verify that your organization hasn't disabled
+    [Wiki Cloud Sync](/cli/features/wiki/overview#wiki-cloud-sync).
+  </Accordion>
+</AccordionGroup>
+
+## See also
+
+- [Generate a wiki](/cli/features/wiki/generate) -- One-time wiki generation with `/wiki`
+- [Browse your wiki](/cli/features/wiki/web-viewer) -- Read and search from the web
+- [GitHub App installation](/cli/features/install-github-app) -- Similar workflow for code review automation
+- [Droid Exec](/cli/droid-exec/overview) -- Headless mode used by the generated workflow

--- a/docs/cli/features/wiki/generate.mdx
+++ b/docs/cli/features/wiki/generate.mdx
@@ -1,0 +1,124 @@
+---
+title: Generate a Wiki
+description: Use the /wiki command to generate comprehensive codebase documentation from the CLI.
+keywords: ['wiki', '/wiki', 'generate', 'documentation', 'codebase docs', 'slash command', 'upload', 'github wiki sync']
+---
+
+The `/wiki` command analyzes your repository and generates structured documentation covering architecture, modules, APIs, and conventions. The resulting wiki is uploaded to Factory cloud and optionally synced to your GitHub wiki tab.
+
+## Quick start
+
+<Steps>
+  <Step title="Open a Droid session in your repo">
+    Navigate to your project directory and start Droid:
+    ```bash
+    cd /path/to/your/project
+    droid
+    ```
+  </Step>
+  <Step title="Run the wiki command">
+    ```
+    > /wiki
+    ```
+    Droid analyzes your codebase and generates markdown files into a local
+    `droid-wiki/` folder in your project directory. Once generation is
+    complete, it uploads the contents to Factory cloud.
+  </Step>
+  <Step title="View the result">
+    After upload completes, Droid prints a link to your wiki:
+    ```
+    Wiki uploaded successfully: https://app.factory.ai/wiki/{wikiRunId}
+    ```
+    Open the link to browse your documentation, or visit
+    [app.factory.ai/wiki](https://app.factory.ai/wiki) to see all your
+    wikis.
+  </Step>
+</Steps>
+
+## What happens during generation
+
+When you run `/wiki`, Droid performs several steps:
+
+1. **Codebase analysis** -- Reads source files, configuration, tests, and documentation to understand the project structure
+2. **Page generation** -- Produces a set of structured markdown files organized by topic (architecture, modules, APIs, setup, etc.)
+3. **Visual screenshots** -- If the repository has a [QA skill](/guides/skills/automated-qa) installed, Droid launches the application and captures screenshots of web UIs and TUIs to include in the wiki. Run `/install-qa` to set one up if your repo doesn't have one yet.
+4. **Image handling** -- Detects and includes images (PNG, JPEG, GIF, WebP) found alongside the wiki content, up to 50MB total
+5. **Upload to Factory cloud** -- Sends the pages, page tree, images, and git metadata (commit hash, branch, dirty state) to Factory's API
+6. **GitHub wiki sync** -- For GitHub repos, automatically flattens pages and pushes to the repo's wiki tab
+
+<Note>
+  Wiki generation uses your current branch and working directory state.
+  For the most accurate documentation, run `/wiki` from a clean checkout
+  of your default branch.
+</Note>
+
+<Tip>
+  The first wiki generation for a repository can take a while -- Droid needs
+  to analyze the entire codebase from scratch. Subsequent runs are
+  significantly faster because they use incremental mode, only updating pages
+  affected by code changes since the last generation.
+</Tip>
+
+## GitHub wiki sync
+
+After uploading to Factory cloud, the CLI automatically syncs the generated wiki to GitHub's built-in wiki tab for GitHub-hosted repositories. The sync:
+
+- Flattens the hierarchical page tree into GitHub's flat wiki format (e.g., `overview/architecture.md` becomes `overview--architecture.md`)
+- Rewrites internal links to use the flat filenames
+- Generates `_Sidebar.md` with a navigable table of contents
+- Generates `Home.md` from your wiki's root page
+- Clones `{repo}.wiki.git`, replaces all content, and pushes
+
+### Prerequisites for GitHub sync
+
+- Your repository must be hosted on GitHub
+- The wiki tab must be initialized -- if you've never used it, create the first page at `https://github.com/{owner}/{repo}/wiki`
+- Your Git credentials must have push access to the wiki repository
+- [Wiki Cloud Sync](/cli/features/wiki/overview#wiki-cloud-sync) must not be disabled for your organization
+
+If the wiki isn't initialized, the CLI prints a message with a link to create the first page and skips the sync without failing.
+
+### Upload targets
+
+By default, `/wiki` uploads to Factory cloud. The underlying `wiki-upload` command supports an `--upload-to` flag to control where content goes:
+
+| Target | Description |
+|--------|-------------|
+| `factory` | Upload to Factory cloud (default) |
+| `github` | Sync to GitHub wiki only |
+| `factory,github` | Upload to both |
+
+## Page ordering
+
+You can control the order pages appear in the sidebar and navigation by creating a `.wiki-meta.json` file in the wiki output directory:
+
+```json
+{
+  "pageOrder": [
+    "index.md",
+    "overview/index.md",
+    "overview/architecture.md",
+    "overview/setup.md",
+    "modules/index.md"
+  ]
+}
+```
+
+Pages listed in `pageOrder` appear first in the specified order. Unlisted pages are appended alphabetically after.
+
+## Versioning
+
+Each wiki generation creates a new **wiki run** with metadata including:
+
+- Commit hash and branch name
+- Whether there were local uncommitted changes
+- Droid CLI version used
+- Timestamp
+
+You can browse previous versions from the [web viewer](/cli/features/wiki/web-viewer) using the version dropdown.
+
+## See also
+
+- [Set up auto-refresh](/cli/features/wiki/auto-refresh) -- Keep your wiki current with a CI action
+- [Browse your wiki](/cli/features/wiki/web-viewer) -- Read, search, and export from the web
+- [Wiki overview](/cli/features/wiki/overview) -- How all the pieces fit together

--- a/docs/cli/features/wiki/generate.mdx
+++ b/docs/cli/features/wiki/generate.mdx
@@ -42,9 +42,8 @@ When you run `/wiki`, Droid performs several steps:
 1. **Codebase analysis** -- Reads source files, configuration, tests, and documentation to understand the project structure
 2. **Page generation** -- Produces a set of structured markdown files organized by topic (architecture, modules, APIs, setup, etc.)
 3. **Visual screenshots** -- If the repository has a [QA skill](/guides/skills/automated-qa) installed, Droid launches the application and captures screenshots of web UIs and TUIs to include in the wiki. Run `/install-qa` to set one up if your repo doesn't have one yet.
-4. **Image handling** -- Detects and includes images (PNG, JPEG, GIF, WebP) found alongside the wiki content, up to 50MB total
-5. **Upload to Factory cloud** -- Sends the pages, page tree, images, and git metadata (commit hash, branch, dirty state) to Factory's API
-6. **GitHub wiki sync** -- For GitHub repos, automatically flattens pages and pushes to the repo's wiki tab
+4. **Upload to Factory cloud** -- Sends the pages and images to Factory's API
+5. **GitHub wiki sync** -- For GitHub repos, flattens pages and pushes to the repo's wiki tab
 
 <Note>
   Wiki generation uses your current branch and working directory state.
@@ -77,34 +76,6 @@ After uploading to Factory cloud, the CLI automatically syncs the generated wiki
 - [Wiki Cloud Sync](/cli/features/wiki/overview#wiki-cloud-sync) must not be disabled for your organization
 
 If the wiki isn't initialized, the CLI prints a message with a link to create the first page and skips the sync without failing.
-
-### Upload targets
-
-By default, `/wiki` uploads to Factory cloud. The underlying `wiki-upload` command supports an `--upload-to` flag to control where content goes:
-
-| Target | Description |
-|--------|-------------|
-| `factory` | Upload to Factory cloud (default) |
-| `github` | Sync to GitHub wiki only |
-| `factory,github` | Upload to both |
-
-## Page ordering
-
-You can control the order pages appear in the sidebar and navigation by creating a `.wiki-meta.json` file in the wiki output directory:
-
-```json
-{
-  "pageOrder": [
-    "index.md",
-    "overview/index.md",
-    "overview/architecture.md",
-    "overview/setup.md",
-    "modules/index.md"
-  ]
-}
-```
-
-Pages listed in `pageOrder` appear first in the specified order. Unlisted pages are appended alphabetically after.
 
 ## Versioning
 

--- a/docs/cli/features/wiki/overview.mdx
+++ b/docs/cli/features/wiki/overview.mdx
@@ -1,0 +1,93 @@
+---
+title: Wiki
+sidebarTitle: Overview
+description: Codebase documentation that stays up to date across your repository, web, and GitHub.
+keywords: ['wiki', 'documentation', 'codebase', '/wiki', '/install-wiki', 'github wiki', 'auto-refresh', 'generate docs']
+---
+
+Factory Wiki generates comprehensive, structured documentation for your repositories. It analyzes your codebase and produces a browsable wiki with architecture overviews, module breakdowns, and cross-linked pages -- then keeps it current as your code changes.
+
+<CardGroup cols={3}>
+  <Card title="Generate" icon="terminal" href="/cli/features/wiki/generate">
+    Run `/wiki` in the CLI to produce a wiki from any repo
+  </Card>
+  <Card title="Auto-refresh" icon="rotate" href="/cli/features/wiki/auto-refresh">
+    Run `/install-wiki` to refresh the wiki on every push
+  </Card>
+  <Card title="Browse" icon="book-open" href="/cli/features/wiki/web-viewer">
+    Read, search, and export wikis in the Factory app
+  </Card>
+</CardGroup>
+
+## How it works
+
+<Steps>
+  <Step title="Generate from the CLI">
+    Run `/wiki` inside a Droid session. Droid analyzes the codebase and produces
+    a set of structured markdown pages covering architecture, modules, APIs,
+    and conventions.
+  </Step>
+  <Step title="Upload to Factory cloud">
+    The generated wiki is uploaded to Factory's cloud, where it becomes
+    browsable at [app.factory.ai/wiki](https://app.factory.ai/wiki). Each
+    upload is versioned so you can compare changes over time.
+  </Step>
+  <Step title="Sync to GitHub wiki">
+    For GitHub-hosted repositories, the wiki is automatically pushed to the
+    repo's built-in wiki tab. Internal links are rewritten, a sidebar is
+    generated, and the content is pushed to `{repo}.wiki.git`.
+  </Step>
+  <Step title="Keep it current">
+    Run `/install-wiki` to create a CI workflow (GitHub Actions or GitLab CI)
+    that regenerates the wiki on every push to the default branch -- or
+    trigger a refresh from the web UI at any time.
+  </Step>
+</Steps>
+
+## GitHub wiki sync
+
+When you generate a wiki for a GitHub-hosted repository, Factory automatically syncs the content to GitHub's built-in wiki tab. Your team can browse the wiki directly from the repository page without visiting the Factory app. For details on how the sync works, see [Generate a Wiki](/cli/features/wiki/generate#github-wiki-sync).
+
+<Note>
+  GitHub requires the wiki to be initialized before Factory can sync to it.
+  If you haven't used the wiki tab before, create the first page manually at
+  `https://github.com/{owner}/{repo}/wiki`, then re-run `/wiki`.
+</Note>
+
+## Enterprise controls
+
+### Wiki Cloud Sync
+
+Organizations that need to prevent wiki content from being stored in Factory's cloud can disable **Wiki Cloud Sync**. This is an org-level enterprise control available at [app.factory.ai](https://app.factory.ai) under **Settings > Enterprise Controls > Wiki**.
+
+When Wiki Cloud Sync is **disabled**:
+
+- All wiki API endpoints return 403 for your organization
+- The `/wiki` command will not upload content to Factory cloud
+- GitHub wiki sync is also skipped from the CLI
+- The web viewer at `app.factory.ai/wiki` shows no content
+
+Wiki Cloud Sync is **enabled by default**. Only org managers can toggle this setting.
+
+<Tip>
+  Even with cloud sync disabled, you can still use `/wiki` with `--upload-to github` to generate and push documentation directly to your GitHub wiki without touching Factory's cloud.
+</Tip>
+
+For more on how enterprise controls work, see [Hierarchical Settings & Org Control](/enterprise/hierarchical-settings-and-org-control).
+
+## What's next
+
+<CardGroup cols={2}>
+  <Card title="Generate a Wiki" icon="terminal" href="/cli/features/wiki/generate">
+    Step-by-step guide to producing your first wiki
+  </Card>
+  <Card title="Set Up Auto-Refresh" icon="rotate" href="/cli/features/wiki/auto-refresh">
+    Install a CI action that keeps your wiki current
+  </Card>
+  <Card title="Browse in the Web App" icon="book-open" href="/cli/features/wiki/web-viewer">
+    Search, read, and export your wiki documentation
+  </Card>
+  <Card title="Enterprise Settings" icon="building" href="/enterprise/hierarchical-settings-and-org-control">
+    Learn how org-level controls govern wiki and other features
+  </Card>
+</CardGroup>

--- a/docs/cli/features/wiki/overview.mdx
+++ b/docs/cli/features/wiki/overview.mdx
@@ -46,7 +46,7 @@ Factory Wiki generates comprehensive, structured documentation for your reposito
 
 ## GitHub wiki sync
 
-When you generate a wiki for a GitHub-hosted repository, Factory automatically syncs the content to GitHub's built-in wiki tab. Your team can browse the wiki directly from the repository page without visiting the Factory app. For details on how the sync works, see [Generate a Wiki](/cli/features/wiki/generate#github-wiki-sync).
+When you generate a wiki for a GitHub-hosted repository, Factory optionally syncs the content to GitHub's built-in wiki tab. Your team can browse the wiki directly from the repository page without visiting the Factory app. For details on how the sync works, see [Generate a Wiki](/cli/features/wiki/generate#github-wiki-sync).
 
 <Note>
   GitHub requires the wiki to be initialized before Factory can sync to it.
@@ -68,10 +68,6 @@ When Wiki Cloud Sync is **disabled**:
 - The web viewer at `app.factory.ai/wiki` shows no content
 
 Wiki Cloud Sync is **enabled by default**. Only org managers can toggle this setting.
-
-<Tip>
-  Even with cloud sync disabled, you can still use `/wiki` with `--upload-to github` to generate and push documentation directly to your GitHub wiki without touching Factory's cloud.
-</Tip>
 
 For more on how enterprise controls work, see [Hierarchical Settings & Org Control](/enterprise/hierarchical-settings-and-org-control).
 

--- a/docs/cli/features/wiki/web-viewer.mdx
+++ b/docs/cli/features/wiki/web-viewer.mdx
@@ -26,10 +26,10 @@ The wiki reader provides:
 Click the **Refresh** button on the wiki page to regenerate documentation. A modal presents two options:
 
 <CardGroup cols={2}>
-  <Card title="One-time refresh" icon="refresh-ccw">
+  <Card title="One-time refresh">
     Regenerate the wiki once using the latest code on the default branch.
   </Card>
-  <Card title="Recurring (on push)" icon="settings-2">
+  <Card title="Recurring (on push)">
     Install a CI action that refreshes the wiki on every push to the
     default branch.
   </Card>

--- a/docs/cli/features/wiki/web-viewer.mdx
+++ b/docs/cli/features/wiki/web-viewer.mdx
@@ -1,0 +1,60 @@
+---
+title: Web Viewer
+description: Browse, search, and manage your generated wikis from the Factory web app.
+keywords: ['wiki', 'web', 'viewer', 'browse', 'search', 'refresh', 'export', 'app.factory.ai']
+---
+
+The wiki web viewer at [app.factory.ai/wiki](https://app.factory.ai/wiki) lets you browse, search, and manage AI-generated documentation for all your repositories in one place.
+
+## Browsing your wikis
+
+The main wiki page shows a table of repositories that have generated wikis. Each row displays the repository name, last refresh date, and branch. Click a repository to open its wiki.
+
+### Wiki reader
+
+The wiki reader provides:
+
+- **Markdown rendering** -- Full-fidelity rendering of the generated documentation with syntax-highlighted code blocks
+- **Table of contents** -- A sidebar outline of the current page for quick navigation
+- **Breadcrumbs** -- Hierarchical navigation showing your position in the page tree
+- **Search** -- Full-text search across all pages in the wiki
+- **Version history** -- A dropdown to browse previous wiki generations and compare how documentation has evolved
+- **Export** -- Download the wiki as markdown files
+
+## Refreshing a wiki
+
+Click the **Refresh** button on the wiki page to regenerate documentation. A modal presents two options:
+
+<CardGroup cols={2}>
+  <Card title="One-time refresh" icon="refresh-ccw">
+    Regenerate the wiki once using the latest code on the default branch.
+  </Card>
+  <Card title="Recurring (on push)" icon="settings-2">
+    Install a CI action that refreshes the wiki on every push to the
+    default branch.
+  </Card>
+</CardGroup>
+
+After choosing a mode, select how to run the generation:
+
+| Method | Description |
+|--------|-------------|
+| **Local** | Copies the CLI command (`/wiki` or `/install-wiki`) for you to paste into a local Droid session |
+| **Cloud** | Runs the generation on a cloud template linked to the repository |
+
+### Batch refresh
+
+From the top-level wiki page at [app.factory.ai/wiki](https://app.factory.ai/wiki), you can refresh multiple repositories at once:
+
+1. Click **Refresh** to enter selection mode
+2. Select the repositories you want to refresh
+3. Choose **One-time** or **Recurring**
+4. Select a **Droid Computer** to run the work
+
+Droid clones each repository on the selected computer and generates (or sets up recurring generation for) the wikis, running them in parallel where possible.
+
+## See also
+
+- [Generate a wiki](/cli/features/wiki/generate) -- Produce a wiki from the CLI with `/wiki`
+- [Set up auto-refresh](/cli/features/wiki/auto-refresh) -- Keep wikis current with a CI action
+- [Wiki overview](/cli/features/wiki/overview) -- How all the pieces fit together

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,15 @@
                     ]
                   },
                   "cli/features/missions",
+                  {
+                    "group": "Wiki",
+                    "pages": [
+                      "cli/features/wiki/overview",
+                      "cli/features/wiki/generate",
+                      "cli/features/wiki/web-viewer",
+                      "cli/features/wiki/auto-refresh"
+                    ]
+                  },
                   "cli/features/code-review",
                   "cli/features/droid-control",
                   "guides/skills/automated-qa",

--- a/docs/enterprise/hierarchical-settings-and-org-control.mdx
+++ b/docs/enterprise/hierarchical-settings-and-org-control.mdx
@@ -442,6 +442,17 @@ Again, users cannot override these rules; they can only choose safer personal de
 
 ---
 
+## Feature‑specific enterprise controls
+
+Beyond the general hierarchy, several features have dedicated org‑level toggles that override all lower levels:
+
+- **Wiki Cloud Sync** (`wikiCloudSync`) – Controls whether wiki content can be generated and stored in Factory's cloud. When disabled, all wiki API endpoints are blocked and the CLI skips cloud upload and GitHub wiki sync. Enabled by default. See [Wiki](/cli/features/wiki/overview#wiki-cloud-sync).
+- **Cloud Session Sync** (`cloudSessionSync`) – Controls whether session data is synced to Factory's cloud.
+
+These controls are managed by org administrators in the **Enterprise Controls** section at [app.factory.ai](https://app.factory.ai).
+
+---
+
 ## Putting it all together
 
 The hierarchical settings system underpins everything described in the other enterprise pages:


### PR DESCRIPTION
## Summary

Add comprehensive documentation for the Factory Wiki feature.

### New pages (under Capabilities > Wiki)

- **Overview** -- What Factory Wiki is, how the pieces fit together, GitHub wiki sync, Wiki Cloud Sync enterprise control
- **Generate** -- The `/wiki` CLI command: quick start, generation steps (including QA skill screenshots and incremental mode), GitHub sync details, page ordering, versioning
- **Web Viewer** -- Browsing, searching, and managing wikis from `app.factory.ai/wiki`, refresh modal (one-time vs recurring), batch refresh across multiple repos
- **Auto-Refresh** -- The `/install-wiki` command for both GitHub Actions and GitLab CI, generated workflow examples, web-based setup, troubleshooting

## Screen Recording
https://github.com/user-attachments/assets/437c1ba4-ea6f-4b7f-940a-2e5895cdb6f5

### Modified pages

- **docs.json** -- Added Wiki group under Capabilities (after Missions)
- **enterprise/hierarchical-settings-and-org-control.mdx** -- Added Feature-specific enterprise controls section mentioning `wikiCloudSync` and `cloudSessionSync`

## TODO
- Add screenshots for wiki website
- Document `browse-wiki` skill

Closes FAC-19427