### PR TITLE
fix: Use supported PR merged field in JP sync workflow

### DIFF
--- a/.github/workflows/sync-jp-docs.yml
+++ b/.github/workflows/sync-jp-docs.yml
@@ -293,8 +293,8 @@ jobs:
               --base main \
               --head "$BRANCH" \
               --state closed \
-              --json number,isCrossRepository,headRepositoryOwner,isMerged \
-              --jq ".[] | select((.isCrossRepository | not) and .headRepositoryOwner.login == \"$REPO_OWNER\" and (.isMerged | not)) | .number" \
+              --json number,isCrossRepository,headRepositoryOwner,mergedAt \
+              --jq ".[] | select((.isCrossRepository | not) and .headRepositoryOwner.login == \"$REPO_OWNER\" and (.mergedAt == null)) | .number" \
               | head -n 1
           }
 


### PR DESCRIPTION
## What changed
- Replace the unsupported `isMerged` field in the closed PR lookup with `mergedAt`.
- Treat `mergedAt == null` as the signal that a closed PR is reopenable, keeping merged PRs excluded.

## Risk / impact
Low. This only affects the JP docs sync workflow's PR-upsert path after translated docs have already been committed.

## Testing
- `git diff --check`
- `prettier --check .github/workflows/sync-jp-docs.yml`
- Parsed the workflow YAML with Ruby.
- Ran the replacement `gh pr list --json ... mergedAt` query successfully.
