### PR TITLE
docs: add GPT-5.4, Claude Sonnet 4.6, and GPT-5.5 to cost multipliers

### DIFF
--- a/docs/guides/power-user/token-efficiency.mdx
+++ b/docs/guides/power-user/token-efficiency.mdx
@@ -144,7 +144,10 @@ Different models have different cost multipliers and capabilities. Match the mod
 | GPT-5.2-Codex / GPT-5.3-Codex | 0.7×                   | Advanced coding with Extra High reasoning                                |
 | Gemini 3 Pro                  | 0.8×                   | Research, analysis                                                       |
 | Gemini 3.1 Pro                | 0.8×                   | Research, analysis with newer Gemini generation                          |
+| GPT-5.4                       | 1×                     | Implementation, debugging                                                |
 | Claude Sonnet 4.5             | 1.2×                   | Balanced quality/cost                                                    |
+| Claude Sonnet 4.6             | 1.2×                   | Balanced quality/cost                                                    |
+| GPT-5.5                       | 2×                     | Complex reasoning, architecture                                          |
 | Claude Opus 4.5               | 2×                     | Complex reasoning, architecture                                          |
 | Claude Opus 4.6               | 2×                     | Previous flagship, Max reasoning                                         |
 | Claude Opus 4.6 Fast          | 12×                    | Opus 4.6 tuned for faster responses                                      |


### PR DESCRIPTION
Adds three new model rows to the cost multipliers table in the token efficiency guide:

- GPT-5.4 (1×) — Implementation, debugging
- Claude Sonnet 4.6 (1.2×) — Balanced quality/cost
- GPT-5.5 (2×) — Complex reasoning, architecture

Inserted in ascending multiplier order to match the existing table convention.