### PR TITLE
Remove per-seat pricing from self-serve billing tiers

### DIFF
--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -24,7 +24,6 @@ Complete software development agents for individuals.
 - Agent-native, multi-platform experience
   - Desktop / CLI / SDK
   - Cloud & local background agents
-  - Up to 2 seats ($5 per additional seat)
   - Track billing and usage statistics
   - Agent-readiness dashboard
 
@@ -35,7 +34,6 @@ Everything in Pro, plus:
 - Expanded rolling rate limits
   - ~5x the usage of Pro
   - Droid Computers -- access to Factory-managed cloud computers for remote Droids
-  - 3-seat cap ($5 per additional seat)
 
 ### Max -- $200/mo
 
@@ -44,13 +42,12 @@ Everything in Pro Plus, plus:
 - Expanded rolling rate limits
   - ~10x the usage of Pro
   - Early access to new features
-  - 5-seat cap ($5 per additional seat)
 
 ### Teams
 
 For growing teams that need tailored plans.
 
-- Up to 150 seats
+- Multiple team members up to 150 seats
 - Custom usage limits
 - Dedicated onboarding and support
 - Single Sign-On (SSO) integration


### PR DESCRIPTION
Removes the per-seat pricing lines ($5 per additional seat) and seat cap mentions from the Pro, Pro Plus, and Max tiers in `docs/pricing.mdx`.