### PR TITLE
docs: refresh Academy workflow pages

### DIFF
--- a/docs/cli/configuration/plugin-marketplaces.mdx
+++ b/docs/cli/configuration/plugin-marketplaces.mdx
@@ -15,47 +15,62 @@ keywords:
 
 Plugin marketplaces are Git-backed catalogs of plugins that Droid can browse, install, and update. Use marketplaces to discover official plugins, connect external plugin ecosystems, develop plugins locally, or distribute approved team workflows.
 
-## Add and manage marketplaces
+## Marketplace commands
 
 Use `/plugins` and open the **Marketplaces** tab, or run marketplace commands from your shell.
 
-```bash
-droid plugin marketplace add https://github.com/owner/plugins
-droid plugin marketplace add /path/to/local/marketplace
-droid plugin marketplace list
-droid plugin marketplace update [name]
-droid plugin marketplace remove <name>
-```
+| Action               | Command                                                               |
+| -------------------- | --------------------------------------------------------------------- |
+| Add a marketplace    | `droid plugin marketplace add <source>`                               |
+| List marketplaces    | `droid plugin marketplace list`                                       |
+| Update marketplaces  | `droid plugin marketplace update [name]`                              |
+| Remove a marketplace | `droid plugin marketplace remove <name>`                              |
+| Install a plugin     | `droid plugin install <plugin@marketplace> [--scope user\|project]`   |
+| Update a plugin      | `droid plugin update [plugin@marketplace] [--scope user\|project]`    |
+| Uninstall a plugin   | `droid plugin uninstall <plugin@marketplace> [--scope user\|project]` |
+
+Plugin IDs use the format `pluginName@marketplaceName`.
 
 <Note>
   Removing a marketplace does not uninstall plugins that came from that
   marketplace. Installed plugins keep working from the local plugin cache.
 </Note>
 
-## Install plugins from a marketplace
+## Marketplace examples
 
-After a marketplace is registered, install plugins by ID. Plugin IDs use the format `pluginName@marketplaceName`.
+<CodeGroup>
 
-```bash
-droid plugin install code-standards@team-plugins
-droid plugin list
-droid plugin update code-standards@team-plugins
-droid plugin uninstall code-standards@team-plugins
+```bash Official Factory
+# Add the curated Factory marketplace
+droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
+
+# Install official plugins
+droid plugin install droid-control@factory-plugins
+droid plugin install droid-evolved@factory-plugins
+droid plugin install security-engineer@factory-plugins
 ```
 
-Add `--scope project` when the plugin should be shared through the repository. Omit `--scope` to install it for your user account.
+```bash External marketplace
+# Add a compatible external marketplace, including Claude Code-origin marketplaces
+droid plugin marketplace add https://github.com/owner/external-plugins
 
-```bash
+# Install from the external marketplace
+droid plugin install plugin-name@external-plugins
+```
+
+```bash Local or team marketplace
+# Add a local marketplace while developing plugins
+droid plugin marketplace add /path/to/local/marketplace
+
+# Install a team plugin and share it through the repository
 droid plugin install code-standards@team-plugins --scope project
 ```
 
+</CodeGroup>
+
 ## Official Factory marketplace
 
-Factory maintains a curated plugin marketplace at `Factory-AI/factory-plugins`:
-
-```bash
-droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
-```
+Factory maintains a curated plugin marketplace at `Factory-AI/factory-plugins`.
 
 Common official plugins include:
 
@@ -65,22 +80,9 @@ Common official plugins include:
 | **droid-evolved**     | Skills for session navigation, human writing, skill creation, visual design, frontend design, and browser automation |
 | **security-engineer** | Security review, threat modeling, commit scanning, and vulnerability validation                                      |
 
-Install official plugins from `/plugins` or with the CLI:
-
-```bash
-droid plugin install droid-control@factory-plugins
-droid plugin install droid-evolved@factory-plugins
-droid plugin install security-engineer@factory-plugins
-```
-
 ## External plugin marketplaces
 
 Droid can add external Git-backed marketplaces when they use a compatible marketplace and plugin structure. This includes marketplaces originally built for Claude Code, private team marketplaces, and local marketplace folders used during plugin development.
-
-```bash
-droid plugin marketplace add https://github.com/owner/external-plugins
-droid plugin install plugin-name@external-plugins
-```
 
 External marketplaces let teams reuse plugin ecosystems without copying plugin files into each repository.
 

--- a/docs/cli/configuration/plugin-marketplaces.mdx
+++ b/docs/cli/configuration/plugin-marketplaces.mdx
@@ -1,0 +1,128 @@
+---
+title: Plugin Marketplaces
+description: Add plugin marketplaces, install official plugins, and configure team plugin rollout.
+keywords:
+  [
+    'plugin marketplace',
+    'plugins',
+    'marketplaces',
+    'factory plugins',
+    'external plugins',
+    'team plugins',
+    'enterprise plugin registry',
+  ]
+---
+
+Plugin marketplaces are Git-backed catalogs of plugins that Droid can browse, install, and update. Use marketplaces to discover official plugins, connect external plugin ecosystems, develop plugins locally, or distribute approved team workflows.
+
+## Add and manage marketplaces
+
+Use `/plugins` and open the **Marketplaces** tab, or run marketplace commands from your shell.
+
+```bash
+droid plugin marketplace add https://github.com/owner/plugins
+droid plugin marketplace add /path/to/local/marketplace
+droid plugin marketplace list
+droid plugin marketplace update [name]
+droid plugin marketplace remove <name>
+```
+
+<Note>
+  Removing a marketplace does not uninstall plugins that came from that
+  marketplace. Installed plugins keep working from the local plugin cache.
+</Note>
+
+## Install plugins from a marketplace
+
+After a marketplace is registered, install plugins by ID. Plugin IDs use the format `pluginName@marketplaceName`.
+
+```bash
+droid plugin install code-standards@team-plugins
+droid plugin list
+droid plugin update code-standards@team-plugins
+droid plugin uninstall code-standards@team-plugins
+```
+
+Add `--scope project` when the plugin should be shared through the repository. Omit `--scope` to install it for your user account.
+
+```bash
+droid plugin install code-standards@team-plugins --scope project
+```
+
+## Official Factory marketplace
+
+Factory maintains a curated plugin marketplace at `Factory-AI/factory-plugins`:
+
+```bash
+droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
+```
+
+Common official plugins include:
+
+| Plugin                                           | Description                                                                                                          |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| **[droid-control](/cli/features/droid-control)** | Terminal, browser, and computer automation for demos, QA, and behavior verification                                  |
+| **droid-evolved**                                | Skills for session navigation, human writing, skill creation, visual design, frontend design, and browser automation |
+| **security-engineer**                            | Security review, threat modeling, commit scanning, and vulnerability validation                                      |
+
+Install official plugins from `/plugins` or with the CLI:
+
+```bash
+droid plugin install droid-control@factory-plugins
+droid plugin install droid-evolved@factory-plugins
+droid plugin install security-engineer@factory-plugins
+```
+
+## External plugin marketplaces
+
+Droid can add external Git-backed marketplaces when they use a compatible marketplace and plugin structure. This includes marketplaces originally built for Claude Code, private team marketplaces, and local marketplace folders used during plugin development.
+
+```bash
+droid plugin marketplace add https://github.com/owner/external-plugins
+droid plugin install plugin-name@external-plugins
+```
+
+External marketplaces let teams reuse plugin ecosystems without copying plugin files into each repository.
+
+<Warning>
+  Review external plugin code before installing it. Plugins can include hooks
+  and MCP server configuration that run in your local environment.
+</Warning>
+
+## Team and organization rollout
+
+Use `extraKnownMarketplaces` and `enabledPlugins` in settings when a team or organization should register marketplaces or install plugins automatically:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "team-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "your-org/internal-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "code-standards@team-plugins": true
+  }
+}
+```
+
+When Droid starts, it registers marketplaces from `extraKnownMarketplaces` and installs plugins listed in `enabledPlugins` if they are not already installed.
+
+The installation scope follows the settings location:
+
+| Settings location             | Plugin scope |
+| ----------------------------- | ------------ |
+| Organization managed settings | `org`        |
+| User settings                 | `user`       |
+| Project settings              | `project`    |
+
+Organizations that need centralized control over approved plugins can use an [Enterprise Plugin Registry](/enterprise/enterprise-plugin-registry) pattern with org-managed settings.
+
+## See also
+
+- [Plugins](/cli/configuration/plugins)
+- [Building plugins](/guides/building/building-plugins)
+- [Enterprise Plugin Registry](/enterprise/enterprise-plugin-registry)

--- a/docs/cli/configuration/plugin-marketplaces.mdx
+++ b/docs/cli/configuration/plugin-marketplaces.mdx
@@ -59,11 +59,11 @@ droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
 
 Common official plugins include:
 
-| Plugin                                           | Description                                                                                                          |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| **[droid-control](/cli/features/droid-control)** | Terminal, browser, and computer automation for demos, QA, and behavior verification                                  |
-| **droid-evolved**                                | Skills for session navigation, human writing, skill creation, visual design, frontend design, and browser automation |
-| **security-engineer**                            | Security review, threat modeling, commit scanning, and vulnerability validation                                      |
+| Plugin                | Description                                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **droid-control**     | Terminal, browser, and computer automation for demos, QA, and behavior verification                                  |
+| **droid-evolved**     | Skills for session navigation, human writing, skill creation, visual design, frontend design, and browser automation |
+| **security-engineer** | Security review, threat modeling, commit scanning, and vulnerability validation                                      |
 
 Install official plugins from `/plugins` or with the CLI:
 

--- a/docs/cli/configuration/plugins.mdx
+++ b/docs/cli/configuration/plugins.mdx
@@ -37,7 +37,7 @@ For example, a security engineering plugin might include a security review skill
 | -------------------------------- | ----------------------------------------------------------------------------------------- |
 | **Standalone `.factory/` files** | Personal workflows, project-specific context, experiments, one-off commands               |
 | **Plugins**                      | Shared team workflows, reusable conventions, curated tool bundles, versioned distribution |
-| **Enterprise Plugin Registry**   | Organization-approved marketplaces and mandatory plugin rollout                           |
+| **Org-managed plugin rollout**   | Organization-approved marketplaces and mandatory plugin installation                      |
 
 Start with standalone configuration when the workflow is still changing. Convert it to a plugin once the workflow is stable enough to share.
 
@@ -66,59 +66,7 @@ droid plugin list [--scope user|project]
 
 Plugin IDs use the format `pluginName@marketplaceName`, such as `security-engineer@factory-plugins`.
 
-Marketplaces are Git-backed plugin catalogs. Add marketplaces from the **Marketplaces** tab or with the CLI:
-
-```bash
-droid plugin marketplace add https://github.com/owner/plugins
-droid plugin marketplace add /path/to/local/marketplace
-droid plugin marketplace list
-droid plugin marketplace update [name]
-droid plugin marketplace remove <name>
-```
-
-After a marketplace is registered, install plugins by ID:
-
-```bash
-droid plugin install code-standards@team-plugins
-```
-
-### Official Factory marketplace
-
-Factory maintains a curated plugin marketplace at `Factory-AI/factory-plugins`:
-
-```bash
-droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
-```
-
-Common official plugins include:
-
-| Plugin                                           | Description                                                                                                          |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| **[droid-control](/cli/features/droid-control)** | Terminal, browser, and computer automation for demos, QA, and behavior verification                                  |
-| **droid-evolved**                                | Skills for session navigation, human writing, skill creation, visual design, frontend design, and browser automation |
-| **security-engineer**                            | Security review, threat modeling, commit scanning, and vulnerability validation                                      |
-
-Install official plugins with IDs like `droid-control@factory-plugins`, `droid-evolved@factory-plugins`, or `security-engineer@factory-plugins`.
-
-Use `extraKnownMarketplaces` and `enabledPlugins` in settings when a team or organization should register marketplaces or install plugins automatically:
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "team-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "your-org/internal-plugins"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "code-standards@team-plugins": true
-  }
-}
-```
-
-Removing a marketplace does not uninstall plugins that were installed from it. Installed plugins keep working from the local plugin cache.
+Marketplaces are Git-backed plugin catalogs. Use [Plugin Marketplaces](/cli/configuration/plugin-marketplaces) to add official, external, local, team, or organization-managed plugin sources.
 
 ## Plugin structure
 
@@ -220,28 +168,16 @@ my-plugin/
 
 Use `${DROID_PLUGIN_ROOT}` to reference files inside the installed plugin directory. See the [Hooks reference](/reference/hooks-reference#plugin-hooks) for hook event schemas and security considerations.
 
-## External plugin marketplaces
-
-Droid can add external Git-backed marketplaces when they use a compatible marketplace and plugin structure. This includes marketplaces originally built for Claude Code, private team marketplaces, and local marketplace folders used during plugin development.
-
-Add an external marketplace with the same marketplace commands, then install plugins by ID:
-
-```bash
-droid plugin marketplace add https://github.com/owner/external-plugins
-droid plugin install plugin-name@external-plugins
-```
-
-This lets teams reuse external plugin ecosystems without copying plugin files into each repository. Review external plugin code before installing it, because plugins can include hooks and MCP server configuration that run in your local environment.
-
 ## Next steps
 
 <CardGroup cols={2}>
   <Card
-    title="Enterprise Plugin Registry"
-    href="/enterprise/enterprise-plugin-registry"
-    icon="building"
+    title="Plugin Marketplaces"
+    href="/cli/configuration/plugin-marketplaces"
+    icon="store"
   >
-    Approve marketplaces and pre-install mandatory plugins for an organization.
+    Add official, external, local, team, and organization-managed plugin
+    sources.
   </Card>
   <Card
     title="Building plugins"

--- a/docs/cli/configuration/plugins.mdx
+++ b/docs/cli/configuration/plugins.mdx
@@ -220,9 +220,18 @@ my-plugin/
 
 Use `${DROID_PLUGIN_ROOT}` to reference files inside the installed plugin directory. See the [Hooks reference](/reference/hooks-reference#plugin-hooks) for hook event schemas and security considerations.
 
-## Claude Code compatibility
+## External plugin marketplaces
 
-Droid can install plugins built for Claude Code when the plugin follows the compatible plugin structure. This lets teams reuse existing plugin investments while moving workflows into Droid.
+Droid can add external Git-backed marketplaces when they use a compatible marketplace and plugin structure. This includes marketplaces originally built for Claude Code, private team marketplaces, and local marketplace folders used during plugin development.
+
+Add an external marketplace with the same marketplace commands, then install plugins by ID:
+
+```bash
+droid plugin marketplace add https://github.com/owner/external-plugins
+droid plugin install plugin-name@external-plugins
+```
+
+This lets teams reuse external plugin ecosystems without copying plugin files into each repository. Review external plugin code before installing it, because plugins can include hooks and MCP server configuration that run in your local environment.
 
 ## Next steps
 

--- a/docs/cli/configuration/plugins.mdx
+++ b/docs/cli/configuration/plugins.mdx
@@ -1,115 +1,206 @@
 ---
 title: Plugins
-description: Extend Droid with shareable packages of skills, commands, and tools.
-keywords: ['plugins', 'extensions', 'marketplace', 'skills', 'commands', 'mcp', 'shareable']
+description: Extend Droid with shareable packages of skills, commands, droids, hooks, and MCP servers.
+keywords:
+  [
+    'plugins',
+    'extensions',
+    'marketplace',
+    'skills',
+    'commands',
+    'mcp',
+    'shareable',
+  ]
 ---
 
-Plugins let you extend Droid with custom functionality that can be shared across projects and teams. A plugin bundles skills, slash commands, agents, and MCP servers into a single, distributable package.
+Plugins package Droid customizations so they can be shared, installed, updated, and governed as one unit. A plugin can bundle skills, slash commands, custom droids, hooks, and MCP servers for a specific workflow, team, or organization.
 
-## What are plugins?
+Use standalone `.factory/` configuration for quick local iteration. Use a plugin when a customization should be reused across repositories, installed by teammates, or distributed through a marketplace.
 
-Plugins are directories containing a manifest file (`.factory-plugin/plugin.json`) and optional components like skills, commands, and agents. Unlike standalone configuration in `.factory/`, plugins are designed for sharing and distribution.
+## What plugins include
 
-**Plugin components:**
+A plugin is a directory with a required manifest at `.factory-plugin/plugin.json` and optional component folders at the plugin root.
 
-| Component | Purpose | Invocation |
-|-----------|---------|------------|
-| **Skills** | Reusable capabilities with instructions and tools | Model-invoked automatically based on task |
-| **Commands** | Slash commands for specific workflows | User-invoked via `/command-name` |
-| **Agents** | Specialized subagent definitions | Called via Task tool |
-| **Hooks** | Lifecycle event handlers | Automatic on matching events |
-| **MCP Servers** | External tool integrations | Available as tools when plugin is active |
+| Component       | Purpose                                                                 | Invocation                                         |
+| --------------- | ----------------------------------------------------------------------- | -------------------------------------------------- |
+| **Skills**      | Reusable capabilities with instructions, examples, and supporting files | Invoked by Droid when relevant or by `/skill-name` |
+| **Commands**    | User-invoked slash commands for repeatable workflows                    | Invoked directly by `/command-name`                |
+| **Droids**      | Specialized subagents with their own prompts, models, and tool policies | Used by the parent Droid through delegation        |
+| **Hooks**       | Lifecycle commands that enforce deterministic automation or guardrails  | Run automatically when matching events fire        |
+| **MCP servers** | External tools exposed to Droid through Model Context Protocol          | Available as tools when the plugin is active       |
 
-## When to use plugins vs standalone configuration
+For example, a security engineering plugin might include a security review skill, a `/threat-model` command, a security-focused custom droid, hooks that block risky files, and MCP configuration for a vulnerability database.
 
-| Approach | Best for |
-|----------|----------|
-| **Standalone** (`.factory/` directory) | Personal workflows, project-specific customizations, quick experiments |
-| **Plugins** | Sharing with teammates, distributing to community, versioned releases, reusable across projects |
+## When to use plugins
 
-Start with standalone configuration in `.factory/` for quick iteration, then convert to a plugin when you're ready to share.
+| Approach                         | Best for                                                                                  |
+| -------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Standalone `.factory/` files** | Personal workflows, project-specific context, experiments, one-off commands               |
+| **Plugins**                      | Shared team workflows, reusable conventions, curated tool bundles, versioned distribution |
+| **Enterprise Plugin Registry**   | Organization-approved marketplaces and mandatory plugin rollout                           |
+
+Start with standalone configuration when the workflow is still changing. Convert it to a plugin once the workflow is stable enough to share.
 
 ## Managing plugins
 
-Droid provides two ways to manage plugins:
+Use `/plugins` to browse, install, update, and remove plugins from the interactive CLI.
 
-### Interactive UI (recommended)
-
-Use the `/plugins` slash command to open the plugin manager:
-
-```
+```bash
 /plugins
 ```
 
-This opens a tabbed interface:
-- **Browse** - View and install plugins from registered marketplaces
-- **Installed** - Manage installed plugins (view info, update, uninstall)
-- **Marketplaces** - Add, update, or remove marketplaces
+The plugin manager has three tabs:
 
-**Navigation:**
-- Left/Right arrows: Switch between tabs
-- Up/Down arrows: Navigate within a tab
-- Enter: Select/confirm
-- Escape: Go back or close
+- **Browse** — view installable plugins from registered marketplaces.
+- **Installed** — inspect, update, or uninstall active plugins.
+- **Marketplaces** — add, update, or remove plugin sources.
 
-### CLI commands (for scripting)
-
-For automation, use CLI commands from your shell (not as slash commands):
+For scripting, use the `droid plugin` CLI commands from your shell:
 
 ```bash
-# Marketplace management
-droid plugin marketplace add <url>
-droid plugin marketplace remove <name>
-droid plugin marketplace list
-droid plugin marketplace update [name]
-
-# Plugin management
 droid plugin install <plugin@marketplace> [--scope user|project]
 droid plugin uninstall <plugin@marketplace> [--scope user|project]
 droid plugin update [plugin@marketplace] [--scope user|project]
 droid plugin list [--scope user|project]
 ```
 
-Plugin IDs use the format `pluginName@marketplaceName` (e.g., `security-guidance@claude-plugins-official`).
+Plugin IDs use the format `pluginName@marketplaceName`, such as `security-engineer@factory-plugins`.
+
+Marketplaces are Git-backed plugin catalogs. Add marketplaces from the **Marketplaces** tab or with the CLI:
+
+```bash
+droid plugin marketplace add https://github.com/owner/plugins
+droid plugin marketplace add /path/to/local/marketplace
+droid plugin marketplace list
+droid plugin marketplace update [name]
+droid plugin marketplace remove <name>
+```
+
+After a marketplace is registered, install plugins by ID:
+
+```bash
+droid plugin install code-standards@team-plugins
+```
+
+### Official Factory marketplace
+
+Factory maintains a curated plugin marketplace at `Factory-AI/factory-plugins`:
+
+```bash
+droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
+```
+
+Common official plugins include:
+
+| Plugin                                           | Description                                                                                                          |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| **[droid-control](/cli/features/droid-control)** | Terminal, browser, and computer automation for demos, QA, and behavior verification                                  |
+| **droid-evolved**                                | Skills for session navigation, human writing, skill creation, visual design, frontend design, and browser automation |
+| **security-engineer**                            | Security review, threat modeling, commit scanning, and vulnerability validation                                      |
+
+Install official plugins with IDs like `droid-control@factory-plugins`, `droid-evolved@factory-plugins`, or `security-engineer@factory-plugins`.
+
+Use `extraKnownMarketplaces` and `enabledPlugins` in settings when a team or organization should register marketplaces or install plugins automatically:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "team-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "your-org/internal-plugins"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "code-standards@team-plugins": true
+  }
+}
+```
+
+Removing a marketplace does not uninstall plugins that were installed from it. Installed plugins keep working from the local plugin cache.
 
 ## Plugin structure
 
-Every plugin follows this directory structure:
+Every plugin follows the same root-level layout:
 
-```
+```text
 my-plugin/
 ├── .factory-plugin/
 │   └── plugin.json          # Plugin manifest (required)
 ├── commands/                 # Slash commands (optional)
-│   └── my-command.md
-├── skills/                   # Agent skills (optional)
+├── skills/                   # Skills (optional)
 │   └── my-skill/
 │       └── SKILL.md
-├── droids/                   # Subagent definitions (optional)
-│   └── my-agent.md
+├── droids/                   # Custom droids (optional)
+├── hooks/                    # Hook configuration and scripts (optional)
+│   └── hooks.json
 ├── mcp.json                  # MCP server configs (optional)
-└── README.md                 # Documentation
+└── README.md                 # Human-facing documentation
 ```
 
 <Warning>
-Don't put `commands/`, `skills/`, `droids/`, or `hooks/` inside the `.factory-plugin/` directory. Only `plugin.json` goes inside `.factory-plugin/`. All other directories must be at the plugin root level.
+  Do not put `commands/`, `skills/`, `droids/`, `hooks/`, or `mcp.json` inside
+  `.factory-plugin/`. Only `plugin.json` belongs in `.factory-plugin/`; all
+  plugin components live at the plugin root.
 </Warning>
 
-### Plugin hooks
+## Plugin manifest
 
-Plugins can include hooks that execute at specific lifecycle events. Add a `hooks/` directory with a `hooks.json` file:
+The manifest defines the plugin's identity and display metadata.
 
+```json
+{
+  "name": "my-plugin",
+  "description": "A helpful description of what this plugin does",
+  "version": "1.0.0",
+  "author": {
+    "name": "Your Name"
+  }
+}
 ```
+
+| Field         | Purpose                                         |
+| ------------- | ----------------------------------------------- |
+| `name`        | Unique plugin identifier.                       |
+| `description` | Shown when browsing and installing the plugin.  |
+| `version`     | Human-readable release version in the manifest. |
+| `author`      | Optional attribution metadata.                  |
+
+Droid tracks installed plugin updates by marketplace Git commit. When you update a plugin, Droid fetches the latest version from the marketplace.
+
+<Note>
+  Version pinning is not currently supported. Plugin updates fetch the latest
+  marketplace version.
+</Note>
+
+## Plugin scopes
+
+Choose a scope when installing a plugin:
+
+| Scope       | Location              | Visibility                                   |
+| ----------- | --------------------- | -------------------------------------------- |
+| **User**    | `~/.factory/`         | Available across your projects               |
+| **Project** | `<project>/.factory/` | Shared with teammates through git            |
+| **Org**     | Managed settings      | Installed through organization configuration |
+
+You can manually install user or project scoped plugins. Org-scoped plugins are controlled by organization managed settings and are installed automatically.
+
+A plugin can only exist at one scope at a time. To change scope, uninstall it and install it again at the new scope.
+
+## Plugin hooks
+
+Plugins can include hooks that execute at specific Droid lifecycle events. Put hook definitions in `hooks/hooks.json` and scripts in the same `hooks/` directory.
+
+```text
 my-plugin/
 ├── .factory-plugin/
 │   └── plugin.json
 ├── hooks/
-│   ├── hooks.json         # Hook configuration
-│   └── my-script.sh       # Hook scripts
+│   ├── hooks.json
+│   └── format.sh
 └── ...
 ```
-
-**hooks/hooks.json example:**
 
 ```json
 {
@@ -127,178 +218,41 @@ my-plugin/
 }
 ```
 
-Use `${DROID_PLUGIN_ROOT}` to reference files within your plugin directory. This variable is expanded to the actual plugin path when the hook runs. See [Hooks reference](/reference/hooks-reference#plugin-hooks) for details.
+Use `${DROID_PLUGIN_ROOT}` to reference files inside the installed plugin directory. See the [Hooks reference](/reference/hooks-reference#plugin-hooks) for hook event schemas and security considerations.
 
-### Plugin manifest
+## Claude Code compatibility
 
-The manifest at `.factory-plugin/plugin.json` defines your plugin's identity:
-
-```json
-{
-  "name": "my-plugin",
-  "description": "A helpful description of what this plugin does",
-  "version": "1.0.0",
-  "author": {
-    "name": "Your Name"
-  }
-}
-```
-
-| Field | Purpose |
-|-------|---------|
-| `name` | Unique identifier for the plugin. |
-| `description` | Shown in the plugin manager when browsing or installing. |
-| `version` | Track releases using semantic versioning. |
-| `author` | Optional. Helpful for attribution. |
-
-## Plugin scopes
-
-When installing plugins, you choose an installation scope:
-
-| Scope | Location | Visibility |
-|-------|----------|------------|
-| **User** | `~/.factory/` | Available across all your projects |
-| **Project** | `<project>/.factory/` | Shared with teammates via git |
-
-<Note>
-**Org scope**: Plugins enabled via organization managed settings are automatically installed with `org` scope. You cannot manually set org scope.
-</Note>
-
-A plugin can only exist at one scope. To change scope, uninstall first and reinstall.
-
-## Version tracking
-
-Plugins are versioned by Git commit hash, not semantic version. When you update a plugin, Droid fetches the latest commit from the marketplace repository.
-
-<Note>
-Version pinning is not supported. Updates always fetch the latest version from the marketplace.
-</Note>
-
-## Marketplaces
-
-Marketplaces are catalogs of plugins that you can browse and install from.
-
-### Adding marketplaces
-
-Via UI: `/plugins` → Marketplaces tab → "Add new marketplace" → enter URL
-
-Via CLI:
-
-```bash
-# From GitHub
-droid plugin marketplace add https://github.com/owner/repo
-
-# From other Git hosts
-droid plugin marketplace add https://gitlab.com/company/plugins.git
-
-# From local path (for development)
-droid plugin marketplace add /path/to/local/marketplace
-```
-
-### Managing marketplaces
-
-Via UI: `/plugins` → Marketplaces tab → select marketplace → choose action (Update, Disable auto-update, Delete)
-
-Via CLI:
-
-```bash
-droid plugin marketplace list
-droid plugin marketplace update [marketplace-name]
-droid plugin marketplace remove <marketplace-name>
-```
-
-<Note>
-Removing a marketplace does not uninstall plugins from that marketplace. Installed plugins remain functional from cache.
-</Note>
-
-### Team marketplaces
-
-Configure automatic marketplace and plugin installation by adding to `.factory/settings.json`:
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "your-org-internal-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "your-org/internal-plugins"
-      }
-    }
-  },
-  "enabledPlugins": {
-    "code-standards@your-org-internal-plugins": true
-  }
-}
-```
-
-When Droid starts, it automatically:
-1. Registers any marketplaces from `extraKnownMarketplaces` that aren't already registered
-2. Installs any plugins from `enabledPlugins` that aren't already installed
-
-The installation scope depends on where the setting is defined:
-- Org-managed settings → `org` scope
-- User settings → `user` scope
-- Project settings → `project` scope
-
-## Discovering plugins
-
-### Official Factory plugins
-
-Factory maintains an official plugin marketplace at `Factory-AI/factory-plugins` with curated plugins.
-
-Add via `/plugins` UI or CLI:
-
-```bash
-droid plugin marketplace add https://github.com/Factory-AI/factory-plugins
-```
-
-**Available plugins:**
-
-| Plugin | Description |
-|--------|-------------|
-| **[droid-control](/cli/features/droid-control)** | Terminal, browser, and computer automation. Record demos, verify behavior claims, and run QA flows. |
-| **droid-evolved** | Skills for continuous learning: session navigation, human writing, skill creation, visual design, frontend design, browser automation |
-| **security-engineer** | Security review, threat modeling, commit scanning, and vulnerability validation |
-
-Install via `/plugins` UI (Browse tab) or CLI:
-
-```bash
-droid plugin install droid-control@factory-plugins
-droid plugin install droid-evolved@factory-plugins
-droid plugin install security-engineer@factory-plugins
-```
-
-### Community plugins
-
-| Plugin | Description | Source |
-|--------|-------------|--------|
-| **superpowers** | Complete software development workflow with brainstorming, planning, and subagent-driven development | `obra/superpowers` |
-
-### Enterprise Plugin Registry
-
-For organizations that need centralized control over approved plugins, see [Enterprise Plugin Registry](/enterprise/enterprise-plugin-registry). This allows you to:
-
-- Maintain a private marketplace of approved plugins
-- Pre-install mandatory plugins for all users
-- Organize plugins by team, role, or capability
-
-### Claude Code compatibility
-
-Droid is compatible with plugins built for Claude Code. If you find a Claude Code plugin you'd like to use, you can install it directly - the plugin format is interoperable. See the [Claude Code plugins documentation](https://code.claude.com/docs/en/plugins) for more details.
+Droid can install plugins built for Claude Code when the plugin follows the compatible plugin structure. This lets teams reuse existing plugin investments while moving workflows into Droid.
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Building plugins" href="/guides/building/building-plugins" icon="hammer">
-    Learn how to create your own plugins with skills and commands.
+  <Card
+    title="Enterprise Plugin Registry"
+    href="/enterprise/enterprise-plugin-registry"
+    icon="building"
+  >
+    Approve marketplaces and pre-install mandatory plugins for an organization.
   </Card>
-  <Card title="Skills" href="/cli/configuration/skills" icon="wand-magic-sparkles">
-    Understand how skills work and how to create them.
+  <Card
+    title="Building plugins"
+    href="/guides/building/building-plugins"
+    icon="hammer"
+  >
+    Create a plugin with skills, commands, droids, hooks, and MCP configuration.
   </Card>
-  <Card title="Custom commands" href="/cli/configuration/custom-slash-commands" icon="terminal">
-    Create user-invoked slash commands.
+  <Card
+    title="Skills"
+    href="/cli/configuration/skills"
+    icon="wand-magic-sparkles"
+  >
+    Define reusable capabilities that Droid can invoke on demand.
   </Card>
-  <Card title="Custom Droids" href="/cli/configuration/custom-droids" icon="robot">
-    Create specialized subagents for your plugins.
+  <Card
+    title="Custom Droids"
+    href="/cli/configuration/custom-droids"
+    icon="robot"
+  >
+    Create specialized subagents that plugins can package and distribute.
   </Card>
 </CardGroup>

--- a/docs/cli/features/code-review.mdx
+++ b/docs/cli/features/code-review.mdx
@@ -1,46 +1,45 @@
 ---
 title: Local Code Review
-description: Use the /review command to analyze local code changes with AI-powered review workflows
-keywords: ['local code review', 'code review', 'review', '/review', 'slash command', 'PR review', 'pull request', 'commit review', 'diff review', 'code quality', 'bug detection', 'security review', 'review workflow', 'AI review', 'code analysis']
+description: Use the /review command to analyze local code changes before you commit or open a pull request.
+keywords:
+  [
+    'local code review',
+    'code review',
+    'review',
+    '/review',
+    'slash command',
+    'PR review',
+    'pull request',
+    'commit review',
+    'diff review',
+    'bug detection',
+    'security review',
+  ]
 ---
 
-## Overview
+Use `/review` when you want Droid to inspect local code changes before you commit, push, or open a pull request. The command opens an interactive workflow for reviewing a branch diff, uncommitted work, a specific commit, or custom review instructions.
 
-The `/review` command provides a local workflow for analyzing code changes with AI-powered insights. It offers multiple review modes to fit different development scenarios—from reviewing uncommitted changes to analyzing full branches or specific commits.
-
-When you run `/review`, droid guides you through selecting a review type, configuring parameters, and then performs a comprehensive analysis of your code changes based on industry-standard review guidelines.
+`/review` is designed for local CLI sessions. For automated pull request reviews in CI, use the [Automated Code Review guide](/guides/droid-exec/code-review).
 
 ## Quick start
 
 <Steps>
   <Step title="Start the review flow">
-    In a local droid session, type:
+    Open Droid in your repository and run:
+
     ```bash
     /review
     ```
-  </Step>
 
-  <Step title="Select a review type">
-    Choose from four review presets:
-    - **Review against a base branch** - PR-style review comparing your branch to a base branch
-    - **Review uncommitted changes** - Analyze working directory changes (staged, unstaged, and untracked)
-    - **Review a commit** - Examine a specific commit from history
-    - **Custom review instructions** - Define your own review criteria
   </Step>
-
-  <Step title="Configure parameters">
-    Depending on your selection:
-    - For **base branch reviews**: Select the target branch (e.g., `main`, `develop`)
-    - For **commit reviews**: Choose a commit from the interactive list
-    - For **custom reviews**: Enter your review instructions
+  <Step title="Choose what to review">
+    Select one of the review types: base branch, uncommitted changes, commit, or custom instructions.
   </Step>
-
+  <Step title="Configure the target">
+    Choose the base branch, commit, or custom instructions requested by the selected review type.
+  </Step>
   <Step title="Review the findings">
-    Droid analyzes the code changes and provides:
-    - Prioritized findings with severity levels [P0-P3]
-    - Specific file locations and line numbers
-    - Suggested fixes with code suggestions
-    - Overall assessment of the changes
+    Droid returns prioritized findings with file locations and concise explanations.
   </Step>
 </Steps>
 
@@ -48,228 +47,97 @@ When you run `/review`, droid guides you through selecting a review type, config
 
 ### Review against a base branch
 
-Compare your current branch against a base branch (like a pull request review). This is ideal for pre-PR reviews or checking what changes would be merged.
+Use a base branch review when you want PR-style feedback before you open or update a pull request.
 
-**How it works:**
-1. Select "Review against a base branch"
-2. Choose your target base branch from the list (local and remote branches shown)
-3. Droid finds the merge base and reviews the diff
-
-**Use cases:**
-- Pre-commit PR reviews
-- Checking branch changes before creating a pull request
-- Validating feature branch against main/develop
-
-**Example workflow:**
 ```bash
 > /review
 # Select: Review against a base branch
-# Choose: origin/main
-# Droid reviews all changes that would be merged
+# Choose: main
 ```
+
+Droid finds the merge base and reviews the diff between your branch and the selected base branch.
 
 ### Review uncommitted changes
 
-Analyze all current working directory changes—staged files, unstaged modifications, and untracked files.
+Use an uncommitted review for work in progress. Droid analyzes staged files, unstaged modifications, and untracked files in the current working tree.
 
-**Use cases:**
-- Quick sanity check before committing
-- Reviewing work in progress
-- Finding issues early in development
-
-**Example workflow:**
 ```bash
 > /review
 # Select: Review uncommitted changes
-# Droid immediately reviews all working directory changes
 ```
 
 ### Review a commit
 
-Examine the changes introduced by a specific commit in your repository history.
+Use a commit review when you want to inspect one commit from repository history.
 
-**How it works:**
-1. Select "Review a commit"
-2. Browse commits with hash, message, author, and date
-3. Select a commit to review
-
-**Use cases:**
-- Reviewing recent commits for issues
-- Understanding changes in a specific commit
-- Post-merge review of teammate's work
-
-**Example workflow:**
 ```bash
 > /review
 # Select: Review a commit
-# Browse and select: abc1234 - "Add user authentication"
-# Droid reviews that specific commit's changes
+# Choose a commit from the interactive list
 ```
+
+Droid reviews the changes introduced by the selected commit.
 
 ### Custom review instructions
 
-Define your own review criteria for specialized analysis.
+Use custom instructions for targeted checks such as security, performance, migration safety, or team-specific conventions.
 
-**Use cases:**
-- Security-focused reviews
-- Performance analysis
-- Checking specific coding standards
-- Domain-specific validations
-
-**Example workflow:**
 ```bash
 > /review
 # Select: Custom review instructions
-# Enter: "Check for SQL injection vulnerabilities and ensure all database queries use parameterized statements"
-# Droid performs a targeted security review
+# Enter: Check for SQL injection risks and ensure all database queries use parameterized statements.
 ```
 
-## Review guidelines
+Custom reviews work best when the instruction names the risk, affected surface, and expected evidence.
 
-All code reviews follow a structured rubric designed to provide actionable, high-quality feedback:
+## What Droid reviews
 
-### Severity levels
+Droid focuses on high-confidence, actionable bugs rather than stylistic preferences. It looks for issues such as:
 
-Reviews categorize findings using priority levels:
+- Runtime failures, broken control flow, and incorrect variable usage
+- Null or undefined dereferences
+- Missing error handling for critical operations
+- Resource leaks and unsafe async patterns
+- Injection vulnerabilities, exposed secrets, and authentication or authorization bugs
+- Breaking API, schema, serialization, or contract changes
+- Dead or unreachable production code introduced by the change
 
-- **[P0]** - Critical issues blocking release or operations
-- **[P1]** - Urgent issues that should be addressed in the next cycle
-- **[P2]** - Normal priority issues to fix eventually
-- **[P3]** - Low priority nice-to-have improvements
+Droid avoids speculative feedback, cosmetic preferences, and broad architectural opinions unless your custom instructions ask for them.
 
-### Bug detection criteria
+## Severity levels
 
-The AI only flags issues as bugs when they meet ALL of these criteria:
+Findings use priority labels so you can triage quickly:
 
-1. **Meaningful impact** - Affects accuracy, performance, security, or maintainability
-2. **Discrete and actionable** - Clear, specific issue with a clear fix
-3. **Appropriate rigor** - Fix doesn't demand more rigor than the rest of the codebase
-4. **Introduced in changes** - Bug was added in the reviewed changes (not pre-existing)
-5. **Worth fixing** - Author would likely fix if made aware
-6. **No unstated assumptions** - Based on verifiable facts, not speculation
-7. **Provably affected** - Can identify specific affected code, not theoretical
-8. **Not intentional** - Clearly not a deliberate design choice
+| Priority | Meaning                                                                   |
+| -------- | ------------------------------------------------------------------------- |
+| **[P0]** | Blocking issue: likely crash, exploit, data loss, or release blocker      |
+| **[P1]** | High-confidence correctness or security issue that should be fixed soon   |
+| **[P2]** | Plausible bug with a realistic trigger path but lower certainty or impact |
+| **[P3]** | Minor but real bug                                                        |
 
-### Comment style
+A good finding identifies the affected file and line, explains why the issue matters, and describes the trigger path or affected condition.
 
-Review comments follow these principles:
+## Output format
 
-- **Clear reasoning** - Explains why something is an issue
-- **Appropriate severity** - Communicates impact accurately
-- **Brief** - Maximum 1 paragraph per finding
-- **Minimal code** - Code chunks limited to 3 lines in markdown
-- **Scenario-specific** - Describes affected environments/conditions
-- **Matter-of-fact tone** - Avoids accusatory language
-- **Immediately graspable** - Easy for the author to understand
-- **No excessive flattery** - Focuses on actionable feedback
+Local `/review` output is a structured summary. Each finding includes a priority, file and line when available, and a concise description of the failure mode. If there are no findings, Droid returns a short LGTM message.
 
-### Output format
+## Tips
 
-Each finding includes:
+- Use base branch reviews before opening a pull request.
+- Review smaller uncommitted diffs during active development.
+- Add custom instructions for security, migrations, payments, authentication, or other high-risk surfaces.
 
-- **Clear title** (≤80 characters, imperative mood)
-- **Explanation** of why this is a problem
-- **File path and line numbers** where applicable
-- **Priority level** [P0-P3]
-- **Suggested fix** (when concrete replacement code is available)
+## Local review versus automated review
 
-Plus an **overall assessment**:
-- Whether changes are correct or incorrect
-- 1-3 sentence summary
-
-## Tips and best practices
-
-<AccordionGroup>
-  <Accordion title="When to use each review type">
-    - **Uncommitted changes**: During active development, before staging commits
-    - **Base branch review**: Before creating PRs, to catch issues early
-    - **Commit review**: After merging, to understand historical changes or review teammate's commits
-    - **Custom instructions**: When you need focused analysis (security, performance, specific patterns)
-  </Accordion>
-
-  <Accordion title="Making the most of reviews">
-    - Run reviews frequently during development, not just before commits
-    - Use custom instructions for domain-specific concerns your team cares about
-    - Treat P0/P1 findings seriously—they represent real issues worth addressing
-    - Review the overall assessment for context on whether changes are sound
-  </Accordion>
-
-  <Accordion title="Navigating the review UI">
-    - Press **Esc** to go back at any step in the review flow
-    - From the preset selection, **Esc** closes the review overlay
-    - Use arrow keys to navigate branch/commit lists
-    - Type to filter branches by name in real-time
-  </Accordion>
-
-  <Accordion title="Integration with workflows">
-    The `/review` command is meant for local CLI sessions. For automated reviews in CI/CD, use:
-    ```bash
-    droid exec "Review the changes in this PR for security issues and performance regressions"
-    ```
-    See the [Automated Code Review guide](/guides/droid-exec/code-review) for automation setup.
-  </Accordion>
-</AccordionGroup>
-
-## Examples
-
-### Pre-PR review
-
-```bash
-# Before creating a pull request
-> /review
-# Select: Review against a base branch
-# Choose: origin/main
-# Review findings, fix issues, then create PR
-```
-
-### Quick WIP check
-
-```bash
-# Check work in progress
-> /review
-# Select: Review uncommitted changes
-# Get immediate feedback on current changes
-```
-
-### Security-focused review
-
-```bash
-# Custom security review
-> /review
-# Select: Custom review instructions
-# Enter: "Check for security vulnerabilities: SQL injection, XSS, CSRF, insecure dependencies, exposed secrets, and authentication bypasses"
-```
-
-### Post-merge review
-
-```bash
-# Review a teammate's recent commit
-> /review
-# Select: Review a commit
-# Choose the recent commit to understand changes
-```
-
-## Automated reviews in CI
-
-For automated PR reviews, use the [Automated Code Review](/guides/droid-exec/code-review) workflow. It supports:
-
-- **Review depth** (`deep` or `shallow`) to control thoroughness and cost
-- **Security review** with STRIDE-based vulnerability scanning and configurable severity thresholds
-- **On-demand security scans** via `@droid security` comments on PRs, or `@droid security --full` for a full-repo scan
-- **Scheduled full-repo scans** via cron-based workflow triggers
-
-Set up with:
-
-```bash
-droid
-> /install-code-review
-```
-
-See the [Automated Code Review guide](/guides/droid-exec/code-review) for full configuration options.
+| Workflow                                                 | Best for                                        | Setup                               |
+| -------------------------------------------------------- | ----------------------------------------------- | ----------------------------------- |
+| `/review`                                                | Local, interactive pre-commit or pre-PR checks  | Run from a Droid CLI session        |
+| [`/install-code-review`](/guides/droid-exec/code-review) | Automated GitHub or GitLab PR/MR review         | Guided setup creates workflow files |
+| [`droid exec` in CI](/guides/droid-exec/github-actions)  | Custom CI automation and repository maintenance | Write a GitHub Actions workflow     |
 
 ## See also
 
-- [CLI Reference](/reference/cli-reference) - Complete command reference including `/review`
-- [Automated Code Review guide](/guides/droid-exec/code-review) - Set up automated PR reviews with deep/shallow modes and security scanning
-- [Common use cases](/cli/getting-started/common-use-cases) - Other workflows and patterns
-- [How to talk to a droid](/cli/getting-started/how-to-talk-to-a-droid) - Getting better results from AI reviews
+- [Automated Code Review](/guides/droid-exec/code-review)
+- [GitHub Actions with Droid Exec](/guides/droid-exec/github-actions)
+- [CLI Reference](/reference/cli-reference)
+- [How to Talk to a Droid](/cli/getting-started/how-to-talk-to-a-droid)

--- a/docs/cli/features/code-review.mdx
+++ b/docs/cli/features/code-review.mdx
@@ -129,11 +129,11 @@ Local `/review` output is a structured summary. Each finding includes a priority
 
 ## Local review versus automated review
 
-| Workflow                                                 | Best for                                        | Setup                               |
-| -------------------------------------------------------- | ----------------------------------------------- | ----------------------------------- |
-| `/review`                                                | Local, interactive pre-commit or pre-PR checks  | Run from a Droid CLI session        |
-| [`/install-code-review`](/guides/droid-exec/code-review) | Automated GitHub or GitLab PR/MR review         | Guided setup creates workflow files |
-| [`droid exec` in CI](/guides/droid-exec/github-actions)  | Custom CI automation and repository maintenance | Write a GitHub Actions workflow     |
+| Workflow              | Best for                                        | Setup                           |
+| --------------------- | ----------------------------------------------- | ------------------------------- |
+| `/review`             | Local, interactive pre-commit or pre-PR checks  | Run from a Droid CLI session    |
+| Automated code review | Automated GitHub or GitLab PR/MR review         | Run `/install-code-review`      |
+| Droid Exec in CI      | Custom CI automation and repository maintenance | Write a GitHub Actions workflow |
 
 ## See also
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,7 +110,13 @@
                   "cli/configuration/custom-droids",
                   "cli/configuration/hooks-guide",
                   "cli/configuration/custom-slash-commands",
-                  "cli/configuration/plugins",
+                  {
+                    "group": "Plugins",
+                    "pages": [
+                      "cli/configuration/plugins",
+                      "cli/configuration/plugin-marketplaces"
+                    ]
+                  },
                   "cli/configuration/mixed-models",
                   {
                     "group": "Bring Your Own Key",

--- a/docs/guides/droid-exec/github-actions.mdx
+++ b/docs/guides/droid-exec/github-actions.mdx
@@ -14,7 +14,7 @@ keywords:
 
 Use Droid Exec in GitHub Actions when you want Factory to run a one-shot task from CI: review a pull request, refresh generated docs, scan for security risks, or run any repeatable repository workflow.
 
-Use these examples when you need a custom workflow that calls `droid exec` directly.
+Use the base scaffold once, then swap in the task-specific snippet that matches your workflow.
 
 ## Prerequisites
 
@@ -28,7 +28,7 @@ Before adding Droid Exec to a workflow:
 Never hardcode a Factory API key in a workflow file. Always reference `${{ secrets.FACTORY_API_KEY }}`.
 </Warning>
 
-## Basic workflow pattern
+## Base workflow scaffold
 
 Every GitHub Actions workflow using Droid Exec follows the same shape: check out the repository, install the Droid CLI, pass `FACTORY_API_KEY`, and run `droid exec` with a scoped prompt.
 
@@ -58,166 +58,113 @@ jobs:
 
 Raise `permissions` and the autonomy level only for workflows that need to write files, create pull requests, or open issues.
 
-## Example 1: Pull request review and fix
+## Task snippets
 
-This workflow reviews a pull request diff, applies safe fixes, writes a review summary, commits any changes, and posts the summary back to the pull request. Use it only for trusted repositories where your Actions token is allowed to push to the source branch.
+Keep the checkout and `Setup Droid CLI` steps from the scaffold, then replace the final `Run Droid Exec` step with the relevant snippet. Also update the workflow trigger and job permissions as shown in the customization table below.
 
-```yaml
-name: Droid PR Review
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+<CodeGroup>
 
-jobs:
-  review:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+```yaml PR review and fix
+- name: Review and fix
+  env:
+    FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+  run: |
+    git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
 
-      - name: Setup Droid CLI
-        run: |
-          curl -fsSL https://app.factory.ai/cli | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+    droid exec --auto low \
+      "Review /tmp/pr.diff and fix only high-confidence bugs, typos, missing error handling, or broken tests introduced by this pull request. Do not make stylistic rewrites."
 
-      - name: Review and fix
-        env:
-          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-        run: |
-          git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
+    droid exec --auto low \
+      "Write /tmp/review.md with: summary of fixes made, remaining issues for humans, security or performance concerns, and test recommendations."
 
-          droid exec --auto low "Review /tmp/pr.diff and fix only high-confidence bugs, typos, missing error handling, or broken tests introduced by this pull request. Do not make stylistic rewrites."
+- name: Commit fixes
+  run: |
+    if [ -n "$(git status --porcelain)" ]; then
+      git config user.name "github-actions[bot]"
+      git config user.email "github-actions[bot]@users.noreply.github.com"
+      git add -A
+      git commit -m "fix: apply Droid review fixes"
+      git push
+    fi
 
-          droid exec --auto low "Write /tmp/review.md with: summary of fixes made, remaining issues for humans, security or performance concerns, and test recommendations."
-
-      - name: Commit fixes
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add -A
-            git commit -m "fix: apply Droid review fixes"
-            git push
-          fi
-
-      - name: Comment on pull request
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.existsSync('/tmp/review.md')
-              ? fs.readFileSync('/tmp/review.md', 'utf8')
-              : 'Droid review completed.';
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+- name: Comment on pull request
+  if: always()
+  uses: actions/github-script@v7
+  with:
+    script: |
+      const fs = require('fs');
+      const body = fs.existsSync('/tmp/review.md')
+        ? fs.readFileSync('/tmp/review.md', 'utf8')
+        : 'Droid review completed.';
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+        body,
+      });
 ```
+
+```yaml Scheduled maintenance
+- name: Update documentation and tests
+  env:
+    FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+  run: |
+    droid exec --auto low \
+      "Review code changed in the last 7 days. Update stale docstrings, add missing tests for changed behavior, follow existing project conventions, and write a summary to /tmp/maintenance-summary.md."
+
+- name: Open pull request
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    if [ -n "$(git status --porcelain)" ]; then
+      branch="droid-maintenance-$(date +%Y%m%d)"
+      git config user.name "github-actions[bot]"
+      git config user.email "github-actions[bot]@users.noreply.github.com"
+      git checkout -b "$branch"
+      git add -A
+      git commit -m "chore: apply Droid maintenance updates"
+      git push -u origin "$branch"
+      gh pr create \
+        --title "Droid maintenance updates" \
+        --body-file /tmp/maintenance-summary.md
+    fi
+```
+
+```yaml Security scan
+- name: Run security scan
+  env:
+    FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+  run: |
+    droid exec --auto low \
+      "Scan this repository for high-confidence security issues: exposed secrets, injection risks, unsafe authentication flows, dependency risks, and missing authorization checks. Write actionable findings to /tmp/security-report.md."
+
+- name: Create issue if findings exist
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    if [ -s /tmp/security-report.md ] && grep -Eqi "critical|high|vulnerability|secret|injection|authorization" /tmp/security-report.md; then
+      gh issue create \
+        --title "Droid security scan findings" \
+        --body-file /tmp/security-report.md \
+        --label security
+    fi
+```
+
+</CodeGroup>
+
+## What to customize
+
+| Workflow              | Trigger                                                                     | Job permissions                           | Notes                                                                                    |
+| --------------------- | --------------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| PR review and fix     | `pull_request` with `opened`, `synchronize`, `reopened`, `ready_for_review` | `contents: write`, `pull-requests: write` | Use only for trusted repositories where the Actions token may push to the source branch. |
+| Scheduled maintenance | `schedule` plus `workflow_dispatch`                                         | `contents: write`, `pull-requests: write` | Good for recurring docs, test, or lightweight maintenance PRs.                           |
+| Security scan         | `schedule` plus `workflow_dispatch`                                         | `contents: read`, `issues: write`         | Creates an issue when Droid writes actionable findings.                                  |
 
 <Info>
   For a maintained review workflow with inline comments, review depth, security
   review, and scheduled scans, use the [Automated Code Review
   guide](/guides/droid-exec/code-review).
 </Info>
-
-## Example 2: Daily documentation and test maintenance
-
-Use scheduled workflows for routine maintenance that benefits from repeatable prompts and a human-reviewed pull request.
-
-```yaml
-name: Daily Maintenance
-on:
-  schedule:
-    - cron: '0 3 * * *'
-  workflow_dispatch:
-
-jobs:
-  maintenance:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Droid CLI
-        run: |
-          curl -fsSL https://app.factory.ai/cli | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Update documentation and tests
-        env:
-          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-        run: |
-          droid exec --auto low "Review code changed in the last 7 days. Update stale docstrings, add missing tests for changed behavior, follow existing project conventions, and write a summary to /tmp/maintenance-summary.md."
-
-      - name: Open pull request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            branch="droid-maintenance-$(date +%Y%m%d)"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git checkout -b "$branch"
-            git add -A
-            git commit -m "chore: apply Droid maintenance updates"
-            git push -u origin "$branch"
-            gh pr create \
-              --title "Droid maintenance updates" \
-              --body-file /tmp/maintenance-summary.md
-          fi
-```
-
-## Example 3: Scheduled security scan
-
-Use scheduled scans when you want Droid to inspect a repository periodically and open an issue when it finds actionable risks.
-
-```yaml
-name: Droid Security Scan
-on:
-  schedule:
-    - cron: '0 6 * * 1'
-  workflow_dispatch:
-
-jobs:
-  security:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Droid CLI
-        run: |
-          curl -fsSL https://app.factory.ai/cli | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Run security scan
-        env:
-          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-        run: |
-          droid exec --auto low "Scan this repository for high-confidence security issues: exposed secrets, injection risks, unsafe authentication flows, dependency risks, and missing authorization checks. Write actionable findings to /tmp/security-report.md."
-
-      - name: Create issue if findings exist
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -s /tmp/security-report.md ] && grep -Eqi "critical|high|vulnerability|secret|injection|authorization" /tmp/security-report.md; then
-            gh issue create \
-              --title "Droid security scan findings" \
-              --body-file /tmp/security-report.md \
-              --label security
-          fi
-```
 
 ## Prompt design for CI
 

--- a/docs/guides/droid-exec/github-actions.mdx
+++ b/docs/guides/droid-exec/github-actions.mdx
@@ -1,250 +1,236 @@
 ---
 title: GitHub Actions
-description: Ready-to-use GitHub Actions workflows with droid exec.
-keywords: ['github actions', 'ci/cd', 'workflow', 'automation', 'pr review', 'droid exec']
+description: Run Droid Exec from GitHub Actions for pull request reviews, scheduled maintenance, and security checks.
+keywords:
+  [
+    'github actions',
+    'ci/cd',
+    'workflow',
+    'automation',
+    'pr review',
+    'droid exec',
+  ]
 ---
 
-# GitHub Actions
+Use Droid Exec in GitHub Actions when you want Factory to run a one-shot task from CI: review a pull request, refresh generated docs, scan for security risks, or run any repeatable repository workflow.
 
-**Prerequisites:** Add `FACTORY_API_KEY` to repository secrets (Settings → Secrets → Actions)
+Use these examples when you need a custom workflow that calls `droid exec` directly.
 
-## Example 1: Automated PR Review and Fix
+## Prerequisites
 
-Automatically reviews PRs, fixes issues, and posts detailed feedback.
+Before adding Droid Exec to a workflow:
 
-<Info>
-For a simpler setup, use the [`/install-github-app`](/cli/features/install-github-app) command which configures the Factory GitHub App with guided steps.
-</Info>
+1. Generate a Factory API key from [Factory Settings → API Keys](https://app.factory.ai/settings/api-keys).
+2. Add it to your repository secrets as `FACTORY_API_KEY` under **Settings → Secrets and variables → Actions**.
+3. Decide the minimum autonomy level the workflow needs. Most CI workflows should start with `--auto low` and only use broader permissions when the task truly requires them.
+
+<Warning>
+Never hardcode a Factory API key in a workflow file. Always reference `${{ secrets.FACTORY_API_KEY }}`.
+</Warning>
+
+## Basic workflow pattern
+
+Every GitHub Actions workflow using Droid Exec follows the same shape: check out the repository, install the Droid CLI, pass `FACTORY_API_KEY`, and run `droid exec` with a scoped prompt.
 
 ```yaml
-name: PR Assistant
-on:
-  pull_request:
-    types: [opened, synchronize]
+name: Droid Task
+on: pull_request
 
 jobs:
-  review-and-fix:
+  droid-task:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Droid CLI
+        run: |
+          curl -fsSL https://app.factory.ai/cli | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Run Droid Exec
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          droid exec --auto low "Summarize the key risks in this change. Do not modify files."
+```
+
+Raise `permissions` and the autonomy level only for workflows that need to write files, create pull requests, or open issues.
+
+## Example 1: Pull request review and fix
+
+This workflow reviews a pull request diff, applies safe fixes, writes a review summary, commits any changes, and posts the summary back to the pull request. Use it only for trusted repositories where your Actions token is allowed to push to the source branch.
+
+```yaml
+name: Droid PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Setup droid CLI
+
+      - name: Setup Droid CLI
         run: |
           curl -fsSL https://app.factory.ai/cli | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      
-      - name: Analyze and fix code
+
+      - name: Review and fix
         env:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
-          # Get the diff
-          git diff origin/${{ github.base_ref }}...HEAD > pr_changes.diff
-          
-          # Review and fix issues (pipe diff to stdin)
-          cat pr_changes.diff | droid exec --auto low "
-          Review this PR diff and:
-          1. Fix any obvious bugs, typos, or linting errors
-          2. Add missing error handling
-          3. Improve code comments where unclear
-          4. DO NOT commit or push changes
-          "
-          
-          # Generate review report (needs --auto to write files)
-          droid exec --auto low "Analyze the changes again and write a detailed review to review.md with:
-          - Summary of automated fixes made
-          - Remaining issues that need human attention
-          - Security or performance concerns
-          - Test coverage recommendations"
-      
-      - name: Commit fixes if any
+          git diff origin/${{ github.base_ref }}...HEAD > /tmp/pr.diff
+
+          droid exec --auto low "Review /tmp/pr.diff and fix only high-confidence bugs, typos, missing error handling, or broken tests introduced by this pull request. Do not make stylistic rewrites."
+
+          droid exec --auto low "Write /tmp/review.md with: summary of fixes made, remaining issues for humans, security or performance concerns, and test recommendations."
+
+      - name: Commit fixes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "fix: automated improvements for PR #${{ github.event.pull_request.number }}
-            
-            Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
+            git commit -m "fix: apply Droid review fixes"
             git push
           fi
-      
-      - name: Post review comment
+
+      - name: Comment on pull request
         if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            let review = '## 🤖 Automated Review\n\n';
-            
-            if (fs.existsSync('review.md')) {
-              review += fs.readFileSync('review.md', 'utf8');
-            } else {
-              review += 'Review completed successfully.';
-            }
-            
+            const body = fs.existsSync('/tmp/review.md')
+              ? fs.readFileSync('/tmp/review.md', 'utf8')
+              : 'Droid review completed.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: review
+              body,
             });
 ```
 
-## Example 2: Daily Documentation and Test Updates
+<Info>
+  For a maintained review workflow with inline comments, review depth, security
+  review, and scheduled scans, use the [Automated Code Review
+  guide](/guides/droid-exec/code-review).
+</Info>
 
-Keeps documentation and tests in sync with code changes automatically.
+## Example 2: Daily documentation and test maintenance
+
+Use scheduled workflows for routine maintenance that benefits from repeatable prompts and a human-reviewed pull request.
 
 ```yaml
 name: Daily Maintenance
 on:
   schedule:
-    - cron: '0 3 * * *'  # 3 AM UTC daily
-  workflow_dispatch:  # Allow manual trigger
-
-jobs:
-  update-docs-and-tests:
-    runs-on: ubuntu-latest
-    
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup droid CLI
-        run: |
-          curl -fsSL https://app.factory.ai/cli | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-      
-      - name: Update documentation
-        env:
-          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-        run: |
-          droid exec --auto low "
-          Review all code files modified in the last 7 days and:
-          1. Update any outdated JSDoc/docstring comments
-          2. Update README.md if new features were added
-          3. Add missing documentation for public APIs
-          4. Update examples to match current implementation
-          Write a summary of changes to docs-updates.md
-          "
-      
-      - name: Generate missing tests
-        env:
-          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
-        run: |
-          droid exec --auto low "
-          Find functions and components without test coverage and:
-          1. Generate unit tests for utility functions
-          2. Create basic test cases for React components
-          3. Add edge case tests for error handling
-          4. Follow existing test patterns in the codebase
-          Write a summary to test-updates.md
-          "
-      
-      - name: Create PR if changes exist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Note: gh CLI is pre-installed on GitHub-hosted runners
-          if [ -n "$(git status --porcelain)" ]; then
-            BRANCH="auto-updates-$(date +%Y%m%d)"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            
-            git checkout -b $BRANCH
-            git add -A
-            git commit -m "chore: automated documentation and test updates
-            
-            Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
-            git push origin $BRANCH
-            
-            # Combine summaries for PR body
-            PR_BODY="## Automated Updates\n\n"
-            [ -f docs-updates.md ] && PR_BODY="${PR_BODY}### Documentation\n$(cat docs-updates.md)\n\n"
-            [ -f test-updates.md ] && PR_BODY="${PR_BODY}### Tests\n$(cat test-updates.md)\n\n"
-            
-            gh pr create \
-              --title "🤖 Daily automated updates" \
-              --body "$PR_BODY" \
-              --label "automated,documentation,tests"
-          fi
-```
-
-## Example 3: Security and Dependency Scanner
-
-Scans for vulnerabilities and outdated dependencies on a schedule.
-
-```yaml
-name: Security Scanner
-on:
-  schedule:
-    - cron: '0 9 * * 1'  # Mondays at 9 AM UTC
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 jobs:
-  security-scan:
+  maintenance:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Setup droid CLI
+
+      - name: Setup Droid CLI
         run: |
           curl -fsSL https://app.factory.ai/cli | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      
-      - name: Security audit
+
+      - name: Update documentation and tests
         env:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
-          droid exec --auto medium "
-          Perform a comprehensive security audit:
-          1. Check package.json for known vulnerabilities
-          2. Update vulnerable dependencies to safe versions
-          3. Scan code for hardcoded secrets or API keys
-          4. Review authentication and authorization patterns
-          5. Check for SQL injection or XSS vulnerabilities
-          6. Generate security-report.md with all findings and fixes
-          "
-      
-      - name: Create issue if vulnerabilities found
+          droid exec --auto low "Review code changed in the last 7 days. Update stale docstrings, add missing tests for changed behavior, follow existing project conventions, and write a summary to /tmp/maintenance-summary.md."
+
+      - name: Open pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Note: gh CLI is pre-installed on GitHub-hosted runners
-          if [ -f security-report.md ] && grep -q "vulnerability\|security\|risk" security-report.md; then
-            gh issue create \
-              --title "🔒 Security audit findings - $(date +%Y-%m-%d)" \
-              --body-file security-report.md \
-              --label "security,high-priority" \
-              --assignee "${{ github.repository_owner }}"
-          fi
-      
-      - name: Create PR for fixes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Note: gh CLI is pre-installed on GitHub-hosted runners
           if [ -n "$(git status --porcelain)" ]; then
+            branch="droid-maintenance-$(date +%Y%m%d)"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            
-            git checkout -b security-fixes-$(date +%Y%m%d)
+            git checkout -b "$branch"
             git add -A
-            git commit -m "fix: security updates and dependency patches
-            
-            Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
-            git push origin HEAD
-            
+            git commit -m "chore: apply Droid maintenance updates"
+            git push -u origin "$branch"
             gh pr create \
-              --title "🔒 Security fixes" \
-              --body-file security-report.md \
-              --label "security,dependencies" \
-              --assignee "${{ github.repository_owner }}"
+              --title "Droid maintenance updates" \
+              --body-file /tmp/maintenance-summary.md
           fi
 ```
+
+## Example 3: Scheduled security scan
+
+Use scheduled scans when you want Droid to inspect a repository periodically and open an issue when it finds actionable risks.
+
+```yaml
+name: Droid Security Scan
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Droid CLI
+        run: |
+          curl -fsSL https://app.factory.ai/cli | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Run security scan
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          droid exec --auto low "Scan this repository for high-confidence security issues: exposed secrets, injection risks, unsafe authentication flows, dependency risks, and missing authorization checks. Write actionable findings to /tmp/security-report.md."
+
+      - name: Create issue if findings exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -s /tmp/security-report.md ] && grep -Eqi "critical|high|vulnerability|secret|injection|authorization" /tmp/security-report.md; then
+            gh issue create \
+              --title "Droid security scan findings" \
+              --body-file /tmp/security-report.md \
+              --label security
+          fi
+```
+
+## Prompt design for CI
+
+CI prompts should be durable enough to run without a human in the loop.
+
+- **Name the input**: tell Droid whether to inspect a diff file, changed files, the whole repository, or a prompt file.
+- **Constrain writes**: say whether Droid may edit files, create reports, open issues, or only print findings.
+- **Define success**: request a specific artifact such as `review.md`, `maintenance-summary.md`, or `security-report.md`.
+- **Exclude low-value work**: tell Droid not to make stylistic rewrites unless the workflow exists for cleanup.
+- **Start read-only**: use no `--auto` flag for analysis-only tasks; use `--auto low` when the workflow needs safe file operations.
+
+## See also
+
+- [Droid Exec overview](/cli/droid-exec/overview)
+- [Automated Code Review](/guides/droid-exec/code-review)
+- [CLI reference](/reference/cli-reference)


### PR DESCRIPTION
## What changed

- Reworked the GitHub Actions guide around direct `droid exec` workflows for pull request review, scheduled maintenance, and security scans.
- Tightened the local `/review` page around review modes, severity levels, output, and when to use automated review instead.
- Refreshed the Plugins page around plugin concepts, package structure, manifests, scopes, hooks, and when to package reusable Droid customization.
- Added a dedicated Plugin Marketplaces page for adding and managing marketplaces, installing official Factory plugins, using external marketplaces, and rolling out team or organization-managed plugins.

## Why

These pages now align more closely with the Academy training flow while separating plugin concepts from marketplace distribution so each page is easier to scan and follow.

## Risk / impact

Docs-only. No product behavior changes.

## Testing

- `git diff --check`
- Custom docs navigation and changed-file local link check
- `npx --yes prettier --check docs/guides/droid-exec/github-actions.mdx docs/cli/features/code-review.mdx docs/cli/configuration/plugins.mdx docs/cli/configuration/plugin-marketplaces.mdx docs/docs.json`
