### PR TITLE
Rename Pro Plus to Plus and update pricing wording

### DIFF
--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Plans & Pricing"
 description: "Factory plans and pricing"
-keywords: ['pricing', 'plans', 'limits', 'pro', 'pro plus', 'max', 'enterprise', 'subscription', 'rate limits', 'droid core', 'extra usage']
+keywords: ['pricing', 'plans', 'limits', 'pro', 'plus', 'max', 'enterprise', 'subscription', 'rate limits', 'droid core', 'extra usage']
 ---
 
 ## Pricing Structure
@@ -27,9 +27,9 @@ Complete software development agents for individuals.
   - Track billing and usage statistics
   - Agent-readiness dashboard
 
-### Pro Plus -- $100/mo
+### Plus -- $100/mo
 
-Everything in Pro, plus:
+Everything in Pro, and:
 
 - Expanded rolling rate limits
   - ~5x the usage of Pro
@@ -37,7 +37,7 @@ Everything in Pro, plus:
 
 ### Max -- $200/mo
 
-Everything in Pro Plus, plus:
+Everything in Plus, and:
 
 - Expanded rolling rate limits
   - ~10x the usage of Pro
@@ -59,7 +59,7 @@ Teams plans are not affected by rate limit changes. [Contact Sales](https://fact
 
 ### Enterprise
 
-Every feature prior, plus:
+Every feature prior, and:
 
 - Enterprise scale
   - Unlimited team members


### PR DESCRIPTION
Updates docs/pricing.mdx:
- Rename "Pro Plus" plan to "Plus"
- Change "plus:" to "and:" in plan descriptions (Plus, Max, Enterprise)
- Update keywords accordingly