### PR TITLE
docs: centralize model ID reference

### DIFF
--- a/docs/cli/configuration/settings.mdx
+++ b/docs/cli/configuration/settings.mdx
@@ -44,7 +44,7 @@ Local overrides merge on top of the corresponding `settings.json` at the same le
 
 | Setting                    | Options                                                                                                                                                                                                                                                                  | Default                       | Description                                                                |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- | -------------------------------------------------------------------------- |
-| `model`                    | `opus`, `opus-4-7`, `opus-4-6`, `opus-4-6-fast`, `sonnet`, `sonnet-4-6`, `gpt-5.5`, `gpt-5.5-fast`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.2`, `gpt-5.2-codex`, `gpt-5.3-codex`, `haiku`, `gemini-3.1-pro`, `gemini-3-flash`, `droid-core`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.7`, `custom-model` | `opus`                        | The default AI model used by droid                                         |
+| `model`                    | Any [available model ID](/models)                                                                                                                                                                                                                                        | Product default               | The default AI model used by droid                                         |
 | `reasoningEffort`          | `off`, `none`, `low`, `medium`, `high` (availability depends on the model)                                                                                                                                                                                               | Model-dependent default       | Controls how much structured thinking the model performs.                  |
 | `sessionDefaultSettings.interactionMode` | `auto`, `spec`                                                                                                                                                                                                                                                           | `auto`                        | Sets whether new sessions start in Auto or Spec Mode.                      |
 | `sessionDefaultSettings.autonomyLevel`   | `off`, `low`, `medium`, `high`                                                                                                                                                                                                                                           | `off`                         | Sets the default [Autonomy Level](/cli/user-guides/auto-run) for new sessions. |
@@ -64,32 +64,7 @@ Local overrides merge on top of the corresponding `settings.json` at the same le
 
 ### Model
 
-Choose the default AI model that powers your droid:
-
-- **`opus`** - Claude Opus 4.5 (current default)
-- **`opus-4-7`** - Claude Opus 4.7, newest flagship with Max reasoning (2×; 1× promotional until April 30)
-- **`opus-4-6`** - Claude Opus 4.6, previous flagship with Max reasoning
-- **`opus-4-6-fast`** - Claude Opus 4.6 Fast, tuned for faster responses
-- **`sonnet`** - Claude Sonnet 4.5, balanced cost and quality
-- **`sonnet-4-6`** - Claude Sonnet 4.6, Max reasoning at the Sonnet price point
-- **`gpt-5.5`** - GPT-5.5, latest OpenAI flagship model with 1M context and Extra High reasoning
-- **`gpt-5.5-fast`** - GPT-5.5 on priority service tier, less susceptible to traffic surge
-- **`gpt-5.5-pro`** - GPT-5.5 Pro, higher-capability variant, ideal for research tasks
-- **`gpt-5.4`** - GPT-5.4, previous OpenAI model with 922K context and Extra High reasoning
-- **`gpt-5.2`** - OpenAI GPT-5.2
-- **`gpt-5.2-codex`** - GPT-5.2-Codex, OpenAI coding model with Extra High reasoning
-- **`gpt-5.3-codex`** - GPT-5.3-Codex, latest OpenAI coding model with Extra High reasoning and verbosity support
-- **`haiku`** - Claude Haiku 4.5, fast and cost-effective
-- **`gemini-3.1-pro`** - Gemini 3.1 Pro
-- **`gemini-3-flash`** - Gemini 3 Flash, fast and cheap (0.2× multiplier)
-- **`droid-core`** - GLM-5.1 open-source model
-- **`glm-5.1`** - GLM-5.1 open-source model
-- **`kimi-k2.5`** - Kimi K2.5 open-source model with image support
-- **`kimi-k2.6`** - Kimi K2.6 open-source model with image support and optional High reasoning
-- **`minimax-m2.7`** - MiniMax M2.7 open-source model with reasoning support for cost-sensitive agentic workflows
-- **`custom-model`** - Your own configured model via BYOK
-
-[You can also add custom models and BYOK.](/cli/byok/overview)
+Set `model` to a [model ID from Available Models](/models). For custom models, see [Bring Your Own Key (BYOK)](/cli/byok/overview).
 
 ### Reasoning effort
 
@@ -183,7 +158,7 @@ Review and update these arrays periodically to match your workflow and security 
 
 ```json
 {
-  "model": "opus",
+  "model": "claude-opus-4-7",
   "reasoningEffort": "low",
   "diffMode": "github",
   "cloudSessionSync": true,

--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -68,35 +68,7 @@ Options:
   -h, --help                      display help for command
 ```
 
-Supported models (examples):
-
-- claude-opus-4-7
-- claude-opus-4-6
-- claude-opus-4-6-fast
-- claude-opus-4-5-20251101
-- claude-sonnet-4-6
-- claude-sonnet-4-5-20250929
-- claude-haiku-4-5-20251001
-- gpt-5.2
-- gpt-5.2-codex
-- gpt-5.3-codex
-- gpt-5.3-codex-fast
-- gpt-5.5
-- gpt-5.5-fast
-- gpt-5.5-pro
-- gpt-5.4
-- gpt-5.4-fast
-- gpt-5.4-mini
-- gemini-3.1-pro-preview
-- gemini-3-flash-preview
-- glm-5.1
-- kimi-k2.5
-- kimi-k2.6
-- minimax-m2.7
-
-<Note>
-See the [Available Models](/models) for the full list of available models.
-</Note>
+Use any [available model ID](/models) with `--model` or `--spec-model`. For custom models, see [Bring Your Own Key (BYOK)](/cli/byok/overview).
 
 ## Installation
 

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -6,48 +6,48 @@ keywords: ['models', 'model id', 'available models', 'model families', 'model mu
 
 ## <span className="provider-heading"><img src="/images/model-icons/anthropic.png" alt="" className="provider-icon anthropic-icon" />Anthropic</span>
 
-| Model | Multiplier | Best for |
-| ----- | ---------- | -------- |
-| Claude Opus 4.7 | 2x | Anthropic flagship, Max reasoning |
-| Claude Opus 4.6 | 2× | Previous flagship, Max reasoning |
-| Claude Opus 4.6 Fast | 12× | Opus 4.6 tuned for faster responses |
-| Claude Sonnet 4.6 | 1.2× | Max reasoning at the Sonnet price point |
-| Claude Opus 4.5 | 2× | Complex reasoning, architecture |
-| Claude Sonnet 4.5 | 1.2× | Balanced quality/cost |
-| Claude Haiku 4.5 | 0.4× | Quick edits, routine work |
+| Model | Model ID | Multiplier | Reasoning |
+| --- | --- | --- | --- |
+| Claude Opus 4.7 | `claude-opus-4-7` | 2x | `Off`, `Low`, `Medium`, `High (default)`, `Max` |
+| Claude Opus 4.6 | `claude-opus-4-6` | 2× | `Off`, `Low`, `Medium`, `High (default)`, `Max` |
+| Claude Opus 4.6 Fast | `claude-opus-4-6-fast` | 12× | `Off`, `Low`, `Medium`, `High (default)`, `Max` |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | 1.2× | `Off`, `Low`, `Medium`, `High (default)`, `Max` |
+| Claude Opus 4.5 | `claude-opus-4-5-20251101` | 2× | `Off (default)`, `Low`, `Medium`, `High` |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | 1.2× | `Off (default)`, `Low`, `Medium`, `High` |
+| Claude Haiku 4.5 | `claude-haiku-4-5-20251001` | 0.4× | `Off (default)`, `Low`, `Medium`, `High` |
 
 ## <span className="provider-heading"><img src="/images/model-icons/openai.svg" alt="" className="provider-icon openai-icon" />OpenAI</span>
 
-| Model | Multiplier | Best for |
-| ----- | ---------- | -------- |
-| GPT-5.5 | 2× | OpenAI flagship, supports Extra High reasoning |
-| GPT-5.5 Fast | 5× | GPT-5.5 on a priority service tier |
-| GPT-5.5 Pro | 12× | Higher-capability GPT-5.5 variant for research-heavy tasks |
-| GPT-5.4 | 1× | Large-context GPT model with Extra High reasoning |
-| GPT-5.4 Fast | 2× | Faster GPT-5.4 responses |
-| GPT-5.4 Mini | 0.3× | Cost-sensitive GPT work |
-| GPT-5.3-Codex | 0.7× | Advanced coding with Extra High reasoning |
-| GPT-5.3-Codex Fast | 1.4× | Faster GPT-5.3-Codex responses |
-| GPT-5.2 | 0.7× | General GPT work with Extra High reasoning |
-| GPT-5.2-Codex | 0.7× | Advanced coding with Extra High reasoning |
+| Model | Model ID | Multiplier | Reasoning |
+| --- | --- | --- | --- |
+| GPT-5.5 | `gpt-5.5` | 2× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
+| GPT-5.5 Fast | `gpt-5.5-fast` | 5× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
+| GPT-5.5 Pro | `gpt-5.5-pro` | 12× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
+| GPT-5.4 | `gpt-5.4` | 1× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
+| GPT-5.4 Fast | `gpt-5.4-fast` | 2× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
+| GPT-5.4 Mini | `gpt-5.4-mini` | 0.3× | `None`, `Low`, `Medium`, `High (default)`, `Extra High` |
+| GPT-5.3-Codex | `gpt-5.3-codex` | 0.7× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
+| GPT-5.3-Codex Fast | `gpt-5.3-codex-fast` | 1.4× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
+| GPT-5.2 | `gpt-5.2` | 0.7× | `Off`, `Low (default)`, `Medium`, `High`, `Extra High` |
+| GPT-5.2-Codex | `gpt-5.2-codex` | 0.7× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
 
 ## <span className="provider-heading"><img src="/images/model-icons/google.ico" alt="" className="provider-icon" />Google</span>
 
-| Model | Multiplier | Best for |
-| ----- | ---------- | -------- |
-| Gemini 3.1 Pro | 0.8× | Research, analysis with newer Gemini generation |
-| Gemini 3 Pro | 0.8× | Research, analysis |
-| Gemini 3 Flash | 0.2× | Fast, cheap for high-volume tasks |
+| Model | Model ID | Multiplier | Reasoning |
+| --- | --- | --- | --- |
+| Gemini 3.1 Pro | `gemini-3.1-pro-preview` | 0.8× | `Low`, `Medium`, `High (default)` |
+| Gemini 3 Pro | `gemini-3-pro-preview` | 0.8× | `None`, `Low`, `Medium`, `High (default)` |
+| Gemini 3 Flash | `gemini-3-flash-preview` | 0.2× | `Minimal`, `Low`, `Medium`, `High (default)` |
 
 ## <span className="provider-heading"><img src="/favicon.svg" alt="" className="provider-icon factory-icon" />Droid Core (Open Models)</span>
 
-| Model | Multiplier | Best for |
-| ----- | ---------- | -------- |
-| GLM-5.1 | 0.55× | Newer open-source GLM model when you want stronger quality in Droid Core |
-| Kimi K2.6 | 0.4× | Cost-sensitive work, supports images, optional High reasoning |
-| Kimi K2.5 | 0.25× | Cost-sensitive work, supports images |
-| MiniMax M2.7 | 0.12× | Cheapest option with reasoning support |
+| Model | Model ID | Multiplier | Reasoning |
+| --- | --- | --- | --- |
+| GLM-5.1 | `glm-5.1` | 0.55× | `Off`, `High (default)` |
+| Kimi K2.6 | `kimi-k2.6` | 0.4× | `Off`, `High (default)` |
+| Kimi K2.5 | `kimi-k2.5` | 0.25× | `Off`, `High (default)` |
+| MiniMax M2.7 | `minimax-m2.7` | 0.12× | `High (default)` |
 
 ## Custom models
 
-Configure custom models through [Bring Your Own Key (BYOK)](/cli/byok/overview). Custom models use the `custom:<alias>` model ID format. Context windows, reasoning support, and multipliers depend on the configured provider and model.
+Configure custom models through [Bring Your Own Key (BYOK)](/cli/byok/overview).

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -42,7 +42,7 @@ Customize droid's behavior with command-line flags:
 | Flag                              | Description                                                        | Example                                                      |
 | :-------------------------------- | :----------------------------------------------------------------- | :----------------------------------------------------------- |
 | `-f, --file <path>`               | Read prompt from a file                                            | `droid exec -f plan.md`                                      |
-| `-m, --model <id>`                | Select a specific model (see [model IDs](#available-models))       | `droid exec -m claude-opus-4-6`                              |
+| `-m, --model <id>`                | Select a specific [model ID](/models)                              | `droid exec -m claude-opus-4-7`                              |
 | `-s, --session-id <id>`           | Continue an existing session                                       | `droid exec -s session-abc123`                               |
 | `--auto <level>`                  | Set [autonomy level](#autonomy-levels) (`low`, `medium`, `high`)   | `droid exec --auto medium "run tests"`                       |
 | `--enabled-tools <ids>`           | Force-enable specific tools (comma or space separated)             | `droid exec --enabled-tools ApplyPatch,Bash`                 |
@@ -51,7 +51,7 @@ Customize droid's behavior with command-line flags:
 | `-o, --output-format <format>`    | Output format (`text`, `json`, `stream-json`, `stream-jsonrpc`)    | `droid exec -o json "document API"`                          |
 | `--input-format <format>`         | Input format (`stream-json`, `stream-jsonrpc` for multi-turn)      | `droid exec --input-format stream-jsonrpc -o stream-jsonrpc` |
 | `-r, --reasoning-effort <level>`  | Override reasoning effort (`off`, `none`, `low`, `medium`, `high`) | `droid exec -r high "debug flaky test"`                      |
-| `--spec-model <id>`               | Use a different model for specification planning                   | `droid exec --spec-model claude-sonnet-4-5-20250929`         |
+| `--spec-model <id>`               | Use a different [model ID](/models) for specification planning     | `droid exec --spec-model claude-sonnet-4-6`                  |
 | `--spec-reasoning-effort <level>` | Override reasoning effort for spec mode                            | `droid exec --use-spec --spec-reasoning-effort high`         |
 | `--use-spec`                      | Start in specification mode (plan before executing)                | `droid exec --use-spec "add user profiles"`                  |
 | `--skip-permissions-unsafe`       | Skip all permission prompts (⚠️ use with extreme caution)          | `droid exec --skip-permissions-unsafe`                       |
@@ -99,32 +99,9 @@ droid exec --auto high "Run tests, commit, and push changes"
   containers.
 </Warning>
 
-## Available models
+## Model IDs
 
-| Model ID                     | Name                      | Reasoning support                     | Default reasoning |
-| :--------------------------- | :------------------------ | :------------------------------------ | :---------------- |
-| `claude-opus-4-7`            | Claude Opus 4.7           | Yes (Off/Low/Medium/High/Max)         | high              |
-| `claude-opus-4-6`            | Claude Opus 4.6           | Yes (Off/Low/Medium/High/Max)         | high              |
-| `claude-opus-4-6-fast`       | Claude Opus 4.6 Fast      | Yes (Off/Low/Medium/High/Max)         | high              |
-| `claude-opus-4-5-20251101`   | Claude Opus 4.5           | Yes (Off/Low/Medium/High)             | off               |
-| `claude-sonnet-4-6`          | Claude Sonnet 4.6         | Yes (Off/Low/Medium/High/Max)         | high              |
-| `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5         | Yes (Off/Low/Medium/High)             | off               |
-| `claude-haiku-4-5-20251001`  | Claude Haiku 4.5          | Yes (Off/Low/Medium/High)             | off               |
-| `gpt-5.5`                    | GPT-5.5                   | Yes (None/Low/Medium/High/Extra High) | medium            |
-| `gpt-5.5-fast`               | GPT-5.5 Fast              | Yes (None/Low/Medium/High/Extra High) | medium            |
-| `gpt-5.5-pro`                | GPT-5.5 Pro               | Yes (None/Low/Medium/High/Extra High) | medium            |
-| `gpt-5.4`                    | GPT-5.4                   | Yes (None/Low/Medium/High/Extra High) | medium            |
-| `gpt-5.3-codex`              | GPT-5.3-Codex             | Yes (None/Low/Medium/High/Extra High) | medium            |
-| `gpt-5.2-codex`              | GPT-5.2-Codex             | Yes (None/Low/Medium/High/Extra High) | medium            |
-| `gpt-5.2`                    | GPT-5.2                   | Yes (Off/Low/Medium/High/Extra High)  | low               |
-| `gemini-3.1-pro-preview`     | Gemini 3.1 Pro            | Yes (Low/Medium/High)                 | high              |
-| `gemini-3-flash-preview`     | Gemini 3 Flash            | Yes (Minimal/Low/Medium/High)         | high              |
-| `glm-5.1`                    | Droid Core (GLM-5.1)      | None only                             | none              |
-| `kimi-k2.5`                  | Droid Core (Kimi K2.5)    | None only                             | none              |
-| `kimi-k2.6`                  | Droid Core (Kimi K2.6)    | Yes (Off/High)                        | high              |
-| `minimax-m2.7`               | Droid Core (MiniMax M2.7) | Yes (Low/Medium/High)                 | high              |
-
-Custom models configured via [BYOK](/cli/byok/overview) use the format: `custom:<alias>`
+Use any [available model ID](/models) with `-m, --model` or `--spec-model`. For custom models, see [Bring Your Own Key (BYOK)](/cli/byok/overview).
 
 See [Choosing Your Model](/cli/user-guides/choosing-your-model) for detailed guidance on which model to use for different tasks.
 


### PR DESCRIPTION
## Diff stats

| File | + | - | Rationale |
|---|---:|---:|---|
| `docs/models.mdx` | 33 | 33 | Makes `/models` the canonical model ID reference with multipliers, reasoning levels, and inline default markers in basic Markdown tables. |
| `docs/cli/configuration/settings.mdx` | 3 | 28 | Replaces duplicated model inventory with links to `/models` and BYOK. |
| `docs/cli/droid-exec/overview.mdx` | 1 | 29 | Keeps Droid Exec model guidance focused on supported model ID inputs instead of repeating the full list. |
| `docs/reference/cli-reference.mdx` | 5 | 28 | Replaces the duplicate model table with a short pointer to `/models` and BYOK. |

Total: `4 files changed, 42 insertions(+), 118 deletions(-)`.

## What

### Centralize model metadata

- Adds model IDs, multipliers, supported reasoning levels, and default reasoning markers to `/models`.
- Uses basic Markdown tables without custom table layout, fixed widths, or alignment styling.
- Points settings, Droid Exec, and CLI reference docs to `/models` instead of repeating model inventories.

### Keep BYOK guidance simple

- Points custom model readers to the BYOK page instead of documenting custom model ID internals in duplicate locations.

## Risk / impact

Low. This is a docs-only change that removes duplicated model lists while preserving model ID, multiplier, supported reasoning, and default reasoning details on `/models`.

## Testing

- `cd docs && fnm exec --using 22 ../node_modules/.bin/mintlify validate`
- `cd docs && fnm exec --using 22 ../node_modules/.bin/mintlify broken-links --check-redirects`
- PR file formatting validation passed
