### PR TITLE
docs: add security review guide

### DIFF
--- a/docs/cli/features/code-review.mdx
+++ b/docs/cli/features/code-review.mdx
@@ -1,7 +1,7 @@
 ---
 title: Local Code Review
 description: Use the /review command to analyze local code changes with AI-powered review workflows
-keywords: ['local code review', 'code review', 'review', '/review', 'slash command', 'PR review', 'pull request', 'commit review', 'diff review', 'code quality', 'bug detection', 'security review', 'review workflow', 'AI review', 'code analysis']
+keywords: ['local code review', 'code review', 'review', '/review', 'slash command', 'PR review', 'pull request', 'commit review', 'diff review', 'code quality', 'bug detection', 'review workflow', 'AI review', 'code analysis']
 ---
 
 ## Overview
@@ -111,7 +111,6 @@ Examine the changes introduced by a specific commit in your repository history.
 Define your own review criteria for specialized analysis.
 
 **Use cases:**
-- Security-focused reviews
 - Performance analysis
 - Checking specific coding standards
 - Domain-specific validations
@@ -120,8 +119,8 @@ Define your own review criteria for specialized analysis.
 ```bash
 > /review
 # Select: Custom review instructions
-# Enter: "Check for SQL injection vulnerabilities and ensure all database queries use parameterized statements"
-# Droid performs a targeted security review
+# Enter: "Focus on performance regressions and unnecessary re-renders"
+# Droid performs a targeted review
 ```
 
 ## Review guidelines
@@ -204,7 +203,7 @@ Plus an **overall assessment**:
   <Accordion title="Integration with workflows">
     The `/review` command is meant for local CLI sessions. For automated reviews in CI/CD, use:
     ```bash
-    droid exec "Review the changes in this PR for security issues and performance regressions"
+    droid exec "Review the changes in this PR for correctness and performance regressions"
     ```
     See the [Automated Code Review guide](/guides/droid-exec/code-review) for automation setup.
   </Accordion>
@@ -231,15 +230,6 @@ Plus an **overall assessment**:
 # Get immediate feedback on current changes
 ```
 
-### Security-focused review
-
-```bash
-# Custom security review
-> /review
-# Select: Custom review instructions
-# Enter: "Check for security vulnerabilities: SQL injection, XSS, CSRF, insecure dependencies, exposed secrets, and authentication bypasses"
-```
-
 ### Post-merge review
 
 ```bash
@@ -253,10 +243,9 @@ Plus an **overall assessment**:
 
 For automated PR reviews, use the [Automated Code Review](/guides/droid-exec/code-review) workflow. It supports:
 
+- **Automatic PR reviews** triggered by pull request events or comments
 - **Review depth** (`deep` or `shallow`) to control thoroughness and cost
-- **Security review** with STRIDE-based vulnerability scanning and configurable severity thresholds
-- **On-demand security scans** via `@droid security` comments on PRs, or `@droid security --full` for a full-repo scan
-- **Scheduled full-repo scans** via cron-based workflow triggers
+- **Custom review guidelines** for repository-specific checks
 
 Set up with:
 
@@ -270,6 +259,6 @@ See the [Automated Code Review guide](/guides/droid-exec/code-review) for full c
 ## See also
 
 - [CLI Reference](/reference/cli-reference) - Complete command reference including `/review`
-- [Automated Code Review guide](/guides/droid-exec/code-review) - Set up automated PR reviews with deep/shallow modes and security scanning
+- [Automated Code Review guide](/guides/droid-exec/code-review) - Set up automated PR reviews with deep/shallow modes
 - [Common use cases](/cli/getting-started/common-use-cases) - Other workflows and patterns
 - [How to talk to a droid](/cli/getting-started/how-to-talk-to-a-droid) - Getting better results from AI reviews

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,7 @@
                   },
                   "guides/droid-exec/code-review",
                   "cli/features/code-review",
+                  "enterprise/security-review",
                   "cli/features/droid-control",
                   "guides/skills/automated-qa",
                   "cli/account/droid-shield"
@@ -147,7 +148,6 @@
                     "group": "Security",
                     "pages": [
                       "cli/account/security",
-                      "enterprise/security-review",
                       "cli/account/droid-shield-plus",
                       "enterprise/privacy-and-data-flows",
                       "enterprise/llm-safety-and-agent-controls"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -147,6 +147,7 @@
                     "group": "Security",
                     "pages": [
                       "cli/account/security",
+                      "enterprise/security-review",
                       "cli/account/droid-shield-plus",
                       "enterprise/privacy-and-data-flows",
                       "enterprise/llm-safety-and-agent-controls"

--- a/docs/enterprise/security-review.mdx
+++ b/docs/enterprise/security-review.mdx
@@ -21,18 +21,18 @@ Security review uses the built-in `security-review` skill. In PR automation, Dro
 
 The methodology applies multiple security frameworks together:
 
-- **STRIDE threat modeling** — Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, and Elevation of Privilege.
-- **OWASP Top 10:2021** — Broken access control, cryptographic failures, injection, insecure design, misconfiguration, vulnerable components, authentication failures, integrity failures, logging failures, and SSRF.
-- **OWASP Top 10 for LLM Applications:2025** — prompt injection, sensitive information disclosure, insecure LLM output handling, excessive agency, vector/embedding weaknesses, and other AI-specific risks when the codebase uses LLMs.
-- **Supply-chain analysis** — dependency manifest and lockfile review, including typosquatting signals, install scripts, overly broad version ranges, and newly published packages.
-- **Repository threat-model context** — if `.factory/threat-model.md` exists, Droid uses it as the attack-surface map.
+- **STRIDE threat modeling**: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, and Elevation of Privilege.
+- **OWASP Top 10:2021**: Broken access control, cryptographic failures, injection, insecure design, misconfiguration, vulnerable components, authentication failures, integrity failures, logging failures, and SSRF.
+- **OWASP Top 10 for LLM Applications:2025**: prompt injection, sensitive information disclosure, insecure LLM output handling, excessive agency, vector/embedding weaknesses, and other AI-specific risks when the codebase uses LLMs.
+- **Supply-chain analysis**: dependency manifest and lockfile review, including typosquatting signals, install scripts, overly broad version ranges, and newly published packages.
+- **Repository threat-model context**: if `.factory/threat-model.md` exists, Droid uses it as the attack-surface map.
 
 ## Review pipeline
 
 Security review uses a two-pass workflow:
 
-1. **Candidate generation** — Droid reads the diff or codebase, identifies security-relevant areas, traces untrusted input across trust boundaries, and produces candidate vulnerabilities.
-2. **Validation** — Droid re-checks each candidate for reachability, exploitability, existing controls, and false positives before reporting it.
+1. **Candidate generation**: Droid reads the diff or codebase, identifies security-relevant areas, traces untrusted input across trust boundaries, and produces candidate vulnerabilities.
+2. **Validation**: Droid re-checks each candidate for reachability, exploitability, existing controls, and false positives before reporting it.
 
 Findings are reported only when there is a realistic exploit path, such as an injection vulnerability, missing authentication or authorization on a sensitive operation, hardcoded secret, data exposure, unsafe LLM output handling, or risky supply-chain change.
 
@@ -97,6 +97,6 @@ These are the Droid Action security inputs currently wired for the workflows doc
 
 ## See also
 
-- [Automated Code Review](/guides/droid-exec/code-review) — Standard PR code review automation.
-- [Skills](/cli/configuration/skills) — How to invoke and customize skills.
-- [GitHub Integration Security](/enterprise/github-integration-security) — Security architecture for the GitHub App integration.
+- [Automated Code Review](/guides/droid-exec/code-review): Standard PR code review automation.
+- [Skills](/cli/configuration/skills): How to invoke and customize skills.
+- [GitHub Integration Security](/enterprise/github-integration-security): Security architecture for the GitHub App integration.

--- a/docs/enterprise/security-review.mdx
+++ b/docs/enterprise/security-review.mdx
@@ -76,51 +76,24 @@ When `automatic_review` and `automatic_security_review` are both enabled, Droid 
 
 ## Full repository scans in GitHub Actions
 
-Use `@droid security --full` on a PR, or schedule a recurring full-repository scan:
+For a full repository security scan, comment on a PR:
 
-```yaml
-name: Droid Security Scan
-
-on:
-  schedule:
-    - cron: "0 9 * * 1" # Every Monday at 09:00 UTC
-  workflow_dispatch:
-
-jobs:
-  security-scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - uses: Factory-AI/droid-action@main
-        with:
-          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
-          security_scan_schedule: true
-          security_scan_days: 7
+```text
+@droid security --full
 ```
 
 Full scans create a `droid/security-report-{date}` branch, write a report to `.factory/security/reports/security-report-{date}.md`, and open a PR with the findings.
 
 ## Configuration
 
+These are the Droid Action security inputs currently wired for the workflows documented on this page:
+
 | Input | Default | Description |
 | --- | --- | --- |
 | `automatic_security_review` | `false` | Run security review automatically on PRs without requiring `@droid security`. |
-| `security_model` | `""` | Override the model used for security review. Falls back to `review_model` if unset. |
-| `security_severity_threshold` | `medium` | Minimum severity to report: `critical`, `high`, `medium`, or `low`. |
-| `security_block_on_critical` | `true` | Submit a `REQUEST_CHANGES` review when critical findings are detected. |
-| `security_block_on_high` | `false` | Submit a `REQUEST_CHANGES` review when high-severity findings are detected. |
-| `security_notify_team` | `""` | GitHub team to mention on critical findings, such as `@org/security-team`. |
-| `security_scan_schedule` | `false` | Enable scheduled full-repository security scans. |
-| `security_scan_days` | `7` | Number of days of commits to include in scheduled scans. |
+| `security_model` | `""` | Override the model used for security review candidate generation and full-repository scans. Falls back to `review_model` if unset. |
+| `security_severity_threshold` | `medium` | Full-repository scans only: minimum severity to include in the generated report. |
+| `security_notify_team` | `""` | Full-repository scans only: GitHub team to cc in the generated scan PR body, such as `@org/security-team`. |
 
 ## See also
 

--- a/docs/enterprise/security-review.mdx
+++ b/docs/enterprise/security-review.mdx
@@ -47,19 +47,11 @@ Findings are reported only when there is a realistic exploit path, such as an in
 
 ## Run locally
 
-Run the built-in skill directly from Droid:
+Run the built-in skill directly from Droid on any repo:
 
 ```text
-/security-review Run a full-project security audit of this repository. Review every source file and report high-confidence findings only.
+/security-review
 ```
-
-For a headless local run, pass the same request to `droid exec`:
-
-```bash
-droid exec --auto high "/security-review Run a full-project security audit of this repository. Review every source file, apply STRIDE, OWASP Top 10, OWASP LLM Top 10 when applicable, and supply-chain checks. Report only high-confidence findings with severity, file, line, exploit path, and suggested fix."
-```
-
-In full-project mode, Droid enumerates source files, excludes generated and vendored directories, groups files by module or directory, uses parallel subagents to review each group, validates findings, and summarizes which files or directories were covered.
 
 ## Run on pull requests
 

--- a/docs/enterprise/security-review.mdx
+++ b/docs/enterprise/security-review.mdx
@@ -47,22 +47,16 @@ Findings are reported only when there is a realistic exploit path, such as an in
 
 ## Run locally
 
-Use the skill directly from Droid when you want an interactive local audit:
+Run the built-in skill directly from Droid:
 
-```bash
-cd /path/to/repo
-droid
-> /security-review Run a full-project security audit of this repository. Review every source file and report high-confidence findings only.
+```text
+/security-review Run a full-project security audit of this repository. Review every source file and report high-confidence findings only.
 ```
 
-For a headless local run, put the same instruction in a prompt file and run `droid exec`:
+For a headless local run, pass the same request to `droid exec`:
 
 ```bash
-cat > security-audit-prompt.txt <<'EOF'
-Use the security-review skill to run a full-project security audit of this repository. Review every source file, apply STRIDE, OWASP Top 10, OWASP LLM Top 10 when applicable, and supply-chain checks. Report only high-confidence findings with severity, file, line, exploit path, and suggested fix.
-EOF
-
-droid exec --auto high -f security-audit-prompt.txt
+droid exec --auto high "/security-review Run a full-project security audit of this repository. Review every source file, apply STRIDE, OWASP Top 10, OWASP LLM Top 10 when applicable, and supply-chain checks. Report only high-confidence findings with severity, file, line, exploit path, and suggested fix."
 ```
 
 In full-project mode, Droid enumerates source files, excludes generated and vendored directories, groups files by module or directory, uses parallel subagents to review each group, validates findings, and summarizes which files or directories were covered.

--- a/docs/enterprise/security-review.mdx
+++ b/docs/enterprise/security-review.mdx
@@ -1,0 +1,143 @@
+---
+title: Security Review
+description: Run security-focused PR reviews and full-codebase audits with Droid using STRIDE, OWASP, and supply-chain methodology.
+keywords: ['security review', 'security audit', 'STRIDE', 'OWASP', 'OWASP LLM Top 10', 'supply chain', 'code review', 'droid action']
+---
+
+Droid security review is a dedicated security workflow for finding high-confidence vulnerabilities in pull requests or across an entire repository. It can run locally from the CLI or automatically in GitHub Actions.
+
+<CardGroup cols={2}>
+  <Card title="PR security review" icon="shield-halved">
+    Review only the pull request diff, trace changed data flows, and post inline security findings with severity and suggested fixes.
+  </Card>
+  <Card title="Full-codebase audit" icon="magnifying-glass">
+    Audit every source file in the repository, group files for parallel review, and produce a structured report of validated findings.
+  </Card>
+</CardGroup>
+
+## Methodology
+
+Security review uses the built-in `security-review` skill. In PR automation, Droid Action runs a dedicated `security-reviewer` subagent that loads this methodology before reading files, then traces changed data flows across authentication, authorization, validation, database, network, filesystem, and LLM boundaries.
+
+The methodology applies multiple security frameworks together:
+
+- **STRIDE threat modeling** — Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, and Elevation of Privilege.
+- **OWASP Top 10:2021** — Broken access control, cryptographic failures, injection, insecure design, misconfiguration, vulnerable components, authentication failures, integrity failures, logging failures, and SSRF.
+- **OWASP Top 10 for LLM Applications:2025** — prompt injection, sensitive information disclosure, insecure LLM output handling, excessive agency, vector/embedding weaknesses, and other AI-specific risks when the codebase uses LLMs.
+- **Supply-chain analysis** — dependency manifest and lockfile review, including typosquatting signals, install scripts, overly broad version ranges, and newly published packages.
+- **Repository threat-model context** — if `.factory/threat-model.md` exists, Droid uses it as the attack-surface map.
+
+## Review pipeline
+
+Security review uses a two-pass workflow:
+
+1. **Candidate generation** — Droid reads the diff or codebase, identifies security-relevant areas, traces untrusted input across trust boundaries, and produces candidate vulnerabilities.
+2. **Validation** — Droid re-checks each candidate for reachability, exploitability, existing controls, and false positives before reporting it.
+
+Findings are reported only when there is a realistic exploit path, such as an injection vulnerability, missing authentication or authorization on a sensitive operation, hardcoded secret, data exposure, unsafe LLM output handling, or risky supply-chain change.
+
+## Severity levels
+
+| Severity | Priority | Examples |
+| --- | --- | --- |
+| Critical | `P0` | RCE, hardcoded production secret, auth bypass, unauthenticated admin endpoint |
+| High | `P1` | SQL injection behind auth, stored XSS, sensitive-data IDOR, very new dependency |
+| Medium | `P2` | CSRF on state-changing operations, information disclosure, prompt injection behind auth |
+| Low | `P3` | Minor security hardening with a concrete but low-impact exploit path |
+
+## Run locally
+
+Use the skill directly from Droid when you want an interactive local audit:
+
+```bash
+cd /path/to/repo
+droid
+> /security-review Run a full-project security audit of this repository. Review every source file and report high-confidence findings only.
+```
+
+For a headless local run, put the same instruction in a prompt file and run `droid exec`:
+
+```bash
+cat > security-audit-prompt.txt <<'EOF'
+Use the security-review skill to run a full-project security audit of this repository. Review every source file, apply STRIDE, OWASP Top 10, OWASP LLM Top 10 when applicable, and supply-chain checks. Report only high-confidence findings with severity, file, line, exploit path, and suggested fix.
+EOF
+
+droid exec --auto high -f security-audit-prompt.txt
+```
+
+In full-project mode, Droid enumerates source files, excludes generated and vendored directories, groups files by module or directory, uses parallel subagents to review each group, validates findings, and summarizes which files or directories were covered.
+
+## Run on pull requests
+
+With [Droid Action](https://github.com/Factory-AI/droid-action), comment on a pull request to trigger an on-demand security review:
+
+```text
+@droid security
+```
+
+To run security review automatically on every non-draft PR, add `automatic_security_review: true` to your review workflow:
+
+```yaml
+- name: Run Droid Auto Review
+  uses: Factory-AI/droid-action@main
+  with:
+    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+    automatic_review: true
+    automatic_security_review: true
+```
+
+When `automatic_review` and `automatic_security_review` are both enabled, Droid runs the security pass alongside the standard code review and includes the security summary in the PR feedback.
+
+## Full repository scans in GitHub Actions
+
+Use `@droid security --full` on a PR, or schedule a recurring full-repository scan:
+
+```yaml
+name: Droid Security Scan
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: Factory-AI/droid-action@main
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          security_scan_schedule: true
+          security_scan_days: 7
+```
+
+Full scans create a `droid/security-report-{date}` branch, write a report to `.factory/security/reports/security-report-{date}.md`, and open a PR with the findings.
+
+## Configuration
+
+| Input | Default | Description |
+| --- | --- | --- |
+| `automatic_security_review` | `false` | Run security review automatically on PRs without requiring `@droid security`. |
+| `security_model` | `""` | Override the model used for security review. Falls back to `review_model` if unset. |
+| `security_severity_threshold` | `medium` | Minimum severity to report: `critical`, `high`, `medium`, or `low`. |
+| `security_block_on_critical` | `true` | Submit a `REQUEST_CHANGES` review when critical findings are detected. |
+| `security_block_on_high` | `false` | Submit a `REQUEST_CHANGES` review when high-severity findings are detected. |
+| `security_notify_team` | `""` | GitHub team to mention on critical findings, such as `@org/security-team`. |
+| `security_scan_schedule` | `false` | Enable scheduled full-repository security scans. |
+| `security_scan_days` | `7` | Number of days of commits to include in scheduled scans. |
+
+## See also
+
+- [Automated Code Review](/guides/droid-exec/code-review) — Standard PR code review automation.
+- [Skills](/cli/configuration/skills) — How to invoke and customize skills.
+- [GitHub Integration Security](/enterprise/github-integration-security) — Security architecture for the GitHub App integration.

--- a/docs/enterprise/security-review.mdx
+++ b/docs/enterprise/security-review.mdx
@@ -53,6 +53,8 @@ Run the built-in skill directly from Droid on any repo:
 /security-review
 ```
 
+Local security review can audit the full codebase, not just the current diff. Droid enumerates source files in the repository, skips generated and vendored directories, groups files by module or directory, and validates findings before reporting them.
+
 ## Run on pull requests
 
 With [Droid Action](https://github.com/Factory-AI/droid-action), comment on a pull request to trigger an on-demand security review:

--- a/docs/guides/droid-exec/code-review.mdx
+++ b/docs/guides/droid-exec/code-review.mdx
@@ -58,63 +58,7 @@ You can also override the model or reasoning effort directly with `review_model`
 
 ## Security review
 
-Security review runs a STRIDE-based analysis alongside (or instead of) the standard code review. It uses a dedicated security-reviewer subagent that scans for spoofing, tampering, repudiation, information disclosure, denial of service, and elevation of privilege vulnerabilities.
-
-### Enabling automatic security review
-
-Add `automatic_security_review: true` to your workflow. When both `automatic_review` and `automatic_security_review` are enabled, the security reviewer runs as a parallel subagent during the code review pass:
-
-```yaml
-with:
-  automatic_review: true
-  automatic_security_review: true
-```
-
-The security review findings are included in the same PR comment, appended as a **Security Review Summary** section with its own severity ratings.
-
-### On-demand security review
-
-You can also trigger a security review manually by commenting on any PR:
-
-```
-@droid security
-```
-
-For a full repository security scan that creates a dedicated report:
-
-```
-@droid security --full
-```
-
-The `--full` scan creates a new branch (`droid/security-report-{date}`), generates a report at `.factory/security/reports/security-report-{date}.md`, and opens a PR with the findings.
-
-### Security configuration
-
-| Input | Default | Description |
-|-------|---------|-------------|
-| `automatic_security_review` | `false` | Run security review automatically on every PR |
-| `security_model` | (inherits from `review_model`) | Model for security analysis |
-| `security_severity_threshold` | `medium` | Minimum severity to report: `critical`, `high`, `medium`, `low` |
-
-### Scheduled security scans
-
-Run periodic full-repository scans on a schedule by adding a cron trigger to your workflow:
-
-```yaml
-name: Security Scan
-on:
-  schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 6am
-
-jobs:
-  security-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Factory-AI/droid-action@main
-        with:
-          security_scan_schedule: true
-          security_scan_days: 7  # Scan commits from the last 7 days
-```
+Security review is a dedicated workflow for STRIDE, OWASP, OWASP LLM Top 10, and supply-chain analysis. See [Security Review](/enterprise/security-review) for automatic PR security reviews, scheduled scans, and local full-codebase audits with the built-in `security-review` skill.
 
 ## What Droid reviews
 
@@ -206,14 +150,12 @@ Guidelines:
 | `review_model` | (from depth) | Override model for code review |
 | `reasoning_effort` | (from depth) | Override reasoning effort |
 | `include_suggestions` | `true` | Include code suggestion blocks in comments |
-| `automatic_security_review` | `false` | Run security review on every PR |
-| `security_model` | (from `review_model`) | Override model for security review |
-| `security_severity_threshold` | `medium` | Minimum severity to report |
-| `security_scan_schedule` | `false` | Enable scheduled full-repo scans |
-| `security_scan_days` | `7` | Days of commits to scan |
+
+Security review inputs are documented in [Security Review](/enterprise/security-review#configuration).
 
 ## See also
 
+- [Security Review](/enterprise/security-review) - Security-focused PR reviews and full-codebase audits
 - [GitHub Integration Security](/enterprise/github-integration-security) - Security architecture for the GitHub App integration
 - [GitHub Actions examples](/guides/droid-exec/github-actions) - More automation workflows
 - [Droid Exec](/cli/droid-exec/overview) - Running Droid in CI/CD environments


### PR DESCRIPTION
## Summary
- Add Security Review as a first-class Enterprise Security docs page
- Document STRIDE, OWASP, OWASP LLM Top 10, supply-chain methodology, PR automation, scheduled scans, and local full-codebase audits
- Replace the long embedded security-review section in automated code review docs with a link to the new page

## Validation
- python3 -m json.tool docs/docs.json
- custom internal link check
- mintlify validate