### PR TITLE
docs: add BYOK FSC pricing section

### DIFF
--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -102,9 +102,7 @@ Missions draw from the same rolling rate limits as regular sessions. Running Mis
 
 ## BYOK
 
-All plans include 100M free FSC for BYOK usage. This applies to individual plans, Teams, and Enterprise.
-
-After the free 100M FSC is used, BYOK usage is metered in FSC and charged accordingly.
+All Individual, Teams, and Enterprise plans include an allowance of free BYOK usage. After this allowance, BYOK usage will be charged accordingly to your specific plan. 
 
 ## FAQ
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -102,7 +102,7 @@ Missions draw from the same rolling rate limits as regular sessions. Running Mis
 
 ## BYOK
 
-All Individual, Teams, and Enterprise plans include an allowance of free BYOK usage. After this allowance, BYOK usage will be charged accordingly to your specific plan. 
+All Individual, Teams, and Enterprise plans include an allowance of free BYOK usage. After this allowance, BYOK usage will be charged according to your specific plan. 
 
 ## FAQ
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -100,6 +100,11 @@ Missions draw from the same rolling rate limits as regular sessions. Running Mis
 
 **Tip:** run Missions on Droid Core when possible. Core models often deliver comparable results and stretch your plan further.
 
+## BYOK
+
+All plans include 100M free FSC for BYOK usage. This applies to individual plans, Teams, and Enterprise.
+
+After the free 100M FSC is used, BYOK usage is metered in FSC and charged accordingly.
 
 ## FAQ
 


### PR DESCRIPTION
## Summary
- Add a BYOK pricing section under Missions
- Clarify that all plans include 100M free FSC for BYOK before metered FSC charges apply

## Validation
- mintlify validate