### PR TITLE
docs: add Gemini 3.7 Flash to model catalog

### DIFF
--- a/docs/jp/models.mdx
+++ b/docs/jp/models.mdx
@@ -37,6 +37,7 @@ keywords: ['models', 'model id', 'available models', 'model families', 'model mu
 
 | モデル | 倍率 | 最適用途 |
 | ----- | ---- | -------- |
+| Gemini 3.7 Flash | 0.6× | 最新の高速Gemini Flashモデル |
 | Gemini 3.1 Pro | 0.8× | 新世代Geminiによる研究、分析 |
 | Gemini 3.5 Flash | 0.6× | 高速なGemini Flashモデル |
 | Gemini 3 Flash | 0.2× | 高頻度タスク向けの高速・安価 |

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -43,6 +43,7 @@ keywords: ['models', 'model id', 'available models', 'model families', 'model mu
 
 | Model | Model ID | Multiplier | Reasoning |
 | --- | --- | --- | --- |
+| Gemini 3.7 Flash | `gemini-3.7-flash` | 0.6× | `Low`, `Medium`, `High (default)` |
 | Gemini 3.6 Flash | `gemini-3.6-flash` | 0.6× | `Minimal`, `Low`, `Medium`, `High (default)` |
 | Gemini 3.1 Pro | `gemini-3.1-pro-preview` | 0.8× | `Low`, `Medium`, `High (default)` |
 | Gemini 3.5 Flash | `gemini-3.5-flash` | 0.6× | `Minimal`, `Low`, `Medium`, `High (default)` |


### PR DESCRIPTION
Adds Gemini 3.7 Flash (`gemini-3.7-flash`, 0.6× multiplier, Low/Medium/High reasoning with High default) to the Google model table in the catalog and its Japanese mirror.

- `docs/models.mdx`: new Gemini 3.7 Flash row
- `docs/jp/models.mdx`: new Gemini 3.7 Flash row

Linear: [RSI-1360](https://linear.app/factoryai/issue/RSI-1360/update-public-docs-after-factory-aifactory-mono18319-featmonorepo-add)

Automation session: https://app.factory.ai/sessions/52d90059-41b4-499c-b1de-71dca21a1b5d