### PR TITLE
docs: add Grok 4.6 to model catalog

### DIFF
--- a/docs/jp/models.mdx
+++ b/docs/jp/models.mdx
@@ -41,6 +41,13 @@ keywords: ['models', 'model id', 'available models', 'model families', 'model mu
 | Gemini 3.5 Flash | 0.6× | 高速なGemini Flashモデル |
 | Gemini 3 Flash | 0.2× | 高頻度タスク向けの高速・安価 |
 
+## <span className="provider-heading"><img src="/images/model-icons/xai.svg" alt="" className="provider-icon" />xAI</span>
+
+| モデル | 倍率 | 最適用途 |
+| ----- | ---- | -------- |
+| Grok 4.6 | 0.8× | コーディングとエージェントタスク向けの最新xAIモデル |
+| Grok 4.5 | 0.8× | コーディングとエンジニアリング向けのxAIモデル |
+
 ## <span className="provider-heading"><img src="/favicon.svg" alt="" className="provider-icon factory-icon" />Droid Core（オープンモデル）</span>
 
 | モデル | 倍率 | 最適用途 |

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -52,6 +52,7 @@ keywords: ['models', 'model id', 'available models', 'model families', 'model mu
 
 | Model | Model ID | Multiplier | Reasoning |
 | --- | --- | --- | --- |
+| Grok 4.6 | `grok-4.6` | 0.8× | `Low`, `Medium`, `High (default)` |
 | Grok 4.5 | `grok-4.5` | 0.8× | `Low`, `Medium`, `High (default)` |
 
 ## <span className="provider-heading"><img src="/favicon.svg" alt="" className="provider-icon factory-icon" />Droid Core (Open Models)</span>


### PR DESCRIPTION
Adds Grok 4.6 (`grok-4.6`, 0.8× multiplier, Low/Medium/High reasoning with High default) to the xAI model table in the catalog and its Japanese mirror. The Japanese page previously had no xAI section, so both Grok 4.6 and Grok 4.5 are now listed there.

- `docs/models.mdx`: new Grok 4.6 row above Grok 4.5
- `docs/jp/models.mdx`: new xAI section with Grok 4.6 and Grok 4.5

Linear: [RSI-1339](https://linear.app/factoryai/issue/RSI-1339/update-public-docs-after-factory-aifactory-mono18201-featmonorepo-add)

Automation session: https://app.factory.ai/sessions/52d90059-41b4-499c-b1de-71dca21a1b5d