### PR TITLE
docs: add GPT-5.4 Mini Fast to model catalog

### DIFF
--- a/docs/jp/models.mdx
+++ b/docs/jp/models.mdx
@@ -29,6 +29,7 @@ keywords: ['models', 'model id', 'available models', 'model families', 'model mu
 | GPT-5.4 | 1× | Extra High推論を備えた大規模コンテキストGPTモデル |
 | GPT-5.4 Fast | 2× | より高速なGPT-5.4レスポンス |
 | GPT-5.4 Mini | 0.3× | コスト重視のGPT作業 |
+| GPT-5.4 Mini Fast | 0.6× | より高速なGPT-5.4 Miniレスポンス |
 | GPT-5.3-Codex | 0.7× | Extra High推論による高度なコーディング |
 | GPT-5.3-Codex Fast | 1.4× | より高速なGPT-5.3-Codexレスポンス |
 | GPT-5.2 | 0.7× | Extra High推論を使う一般的なGPT作業 |

--- a/docs/models.mdx
+++ b/docs/models.mdx
@@ -35,6 +35,7 @@ keywords: ['models', 'model id', 'available models', 'model families', 'model mu
 | GPT-5.4 | `gpt-5.4` | 1× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
 | GPT-5.4 Fast | `gpt-5.4-fast` | 2× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
 | GPT-5.4 Mini | `gpt-5.4-mini` | 0.3× | `None`, `Low`, `Medium`, `High (default)`, `Extra High` |
+| GPT-5.4 Mini Fast | `gpt-5.4-mini-fast` | 0.6× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
 | GPT-5.3-Codex | `gpt-5.3-codex` | 0.7× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
 | GPT-5.3-Codex Fast | `gpt-5.3-codex-fast` | 1.4× | `None`, `Low`, `Medium (default)`, `High`, `Extra High` |
 | GPT-5.2 | `gpt-5.2` | 0.7× | `Off`, `Low (default)`, `Medium`, `High`, `Extra High` |


### PR DESCRIPTION
Adds GPT-5.4 Mini Fast (`gpt-5.4-mini-fast`, 0.6× multiplier, None/Low/Medium/High/Extra High reasoning with Medium default) to the OpenAI model table in the catalog and its Japanese mirror.

- `docs/models.mdx`: new GPT-5.4 Mini Fast row
- `docs/jp/models.mdx`: new GPT-5.4 Mini Fast row

Linear: [RSI-1332](https://linear.app/factoryai/issue/RSI-1332/update-public-docs-after-factory-aifactory-mono18147-featmonorepo-move)

Automation session: https://app.factory.ai/sessions/52d90059-41b4-499c-b1de-71dca21a1b5d