### PR TITLE
docs: publish Droid SDK references

### DIFF
--- a/docs/cli/droid-exec/overview.mdx
+++ b/docs/cli/droid-exec/overview.mdx
@@ -302,12 +302,12 @@ To disable Factory-provided builtin skills, set `disableBuiltinSkills` when init
 
 In stream JSON-RPC mode, use the request field instead of the `--disable-builtin-skills` CLI flag. The TypeScript SDK exposes the same option through `createSession({ disableBuiltinSkills: true })` and `resumeSession(sessionId, { disableBuiltinSkills: true })`.
 
-For protocol reference and implementation patterns, see the low-level client and process transport in the [TypeScript SDK](https://github.com/Factory-AI/droid-sdk-typescript).
+For protocol reference and implementation patterns, see the low-level client and process transport in the [TypeScript SDK](/sdk/typescript).
 
 Prefer an SDK when possible:
 
-- **TypeScript**: [`@factory/droid-sdk`](https://github.com/Factory-AI/droid-sdk-typescript) for Node.js apps, streaming, multi-turn sessions, structured output, permissions, tool controls, and SDK-backed MCP tools
-- **Python**: [`droid-sdk`](https://github.com/Factory-AI/droid-sdk-python) for asyncio apps, streaming, direct client control, notifications, permissions, and typed event handling
+- **TypeScript**: [`@factory/droid-sdk`](/sdk/typescript) for Node.js apps, streaming, multi-turn sessions, structured output, permissions, tool controls, and SDK-backed MCP tools
+- **Python**: [`droid-sdk`](/sdk/python) for asyncio apps, streaming, direct client control, notifications, permissions, and typed event handling
 
 For automated pipelines, you can also direct the agent to write specific artifacts:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,6 +64,10 @@
                 ]
               },
               {
+                "group": "SDK",
+                "pages": ["sdk/python", "sdk/typescript"]
+              },
+              {
                 "group": "Capabilities",
                 "pages": [
                   {

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -1,0 +1,1820 @@
+---
+title: "Droid Python SDK"
+sidebarTitle: "Python"
+description: "Use the Factory Droid SDK for Python to build custom agents, workflows, and product integrations."
+keywords: ["Droid SDK", "Python", "agents", "automation", "MCP"]
+---
+
+Install the package as `droid-sdk` and import it as `droid_sdk`.
+
+## Overview
+
+The SDK runs a local `droid` subprocess and exposes two ways to run a turn:
+
+| Goal | API |
+| --- | --- |
+| Run one turn and return its result | `await run(...)` |
+| Run turns in an existing session | `session.stream(...)` |
+
+Use `Session` when prompts need shared history or session operations such as
+interruption, compaction, or rewind. There is no `session.run()`; every
+session turn goes through `stream()`.
+
+## Install and authenticate
+
+```bash
+pip install droid-sdk
+```
+
+Requirements:
+
+- Python 3.10 or later
+- `droid` on `PATH`
+- an authenticated Droid CLI session or a Factory API key
+
+The SDK uses the Droid CLI's local authentication by default. It reads
+`FACTORY_API_KEY` when present; pass `api_key=` only when the key comes from
+application configuration. The SDK never places keys in command arguments,
+logs, or exception messages.
+
+## Quick start
+
+### Run one turn
+
+```python
+import asyncio
+
+from droid_sdk import run
+
+
+async def main() -> None:
+    result = await run("Summarize this repository.")
+    if result.success:
+        print(result.text)
+    else:
+        print(result.subtype)
+
+
+asyncio.run(main())
+```
+
+`run()` starts a session, runs one turn, and closes everything it created.
+The saved session remains resumable. See [Result types](#result-types) for
+every terminal outcome.
+
+### Continue a conversation
+
+```python
+import asyncio
+from pathlib import Path
+
+from droid_sdk import Session
+
+
+async def run_turn(session: Session, prompt: str) -> str:
+    async with session.stream(prompt) as stream:
+        async for _ in stream:
+            pass
+
+    result = stream.result
+    if not result.success:
+        raise RuntimeError(result.subtype)
+    return result.text
+
+
+async def main() -> None:
+    async with Session(cwd=Path.cwd()) as session:
+        print(await run_turn(session, "What does this project do?"))
+        print(await run_turn(session, "What should I test first?"))
+
+
+asyncio.run(main())
+```
+
+The second turn includes context from the first. Exiting the session closes
+the subprocess and session-owned resources. See
+[Default stream types](#default-stream-types) for every yielded value.
+
+### Stream partial events
+
+```python
+from droid_sdk import Session, TextDelta
+
+async with Session() as session:
+    async with session.stream(
+        "Explain the failing test.",
+        include_partial_messages=True,
+    ) as stream:
+        async for event in stream:
+            if isinstance(event, TextDelta):
+                print(event.text, end="", flush=True)
+
+    print()
+    if not stream.result.success:
+        print(f"Turn ended: {stream.result.subtype}")
+```
+
+The default stream yields complete messages. Set
+`include_partial_messages=True` to add deltas and operational events. Both
+modes yield the terminal result and cache it in `stream.result`. See
+[Partial stream types](#partial-stream-types) for the complete event union.
+
+## Core contract
+
+### Sessions and turns
+
+A `Session` owns conversation history, settings, a working directory, and one
+Droid connection. It accepts one active turn at a time.
+
+A turn begins with `session.stream(prompt)` and ends when the stream yields a
+`RunResult`. Create separate sessions for parallel work.
+
+### Results and exceptions
+
+A turn's outcome is a value, not an exception: `RunSuccess`,
+`RunInterrupted`, or `RunFailure`. Interrupted turns, execution failures, and
+structured-output failures do not raise. Failures in the machinery around a
+turn (setup, connection, process, protocol, timeout, and cancellation) raise
+exceptions.
+
+### Ownership
+
+| Object | Owner |
+| --- | --- |
+| Resources created by `run()` | `run()` |
+| `Session` used with `async with` | The context manager |
+| Manually opened `Session` | The caller |
+| In-process MCP servers | The session |
+
+### Typing
+
+The package includes `py.typed`, and the public API type-checks under strict
+Pyright and mypy. Public unions narrow with `isinstance()`. High-level value
+models are immutable dataclasses.
+
+| Call | Static return type |
+| --- | --- |
+| `run(..., output=None)` | `RunResult[None]` |
+| `run(..., output=Model)` | `RunResult[Model]` |
+| `run(..., output=JsonSchema(...))` | `RunResult[JsonObject]` |
+| `session.stream(...)` | `RunStream[T, StreamMessage[T]]` |
+| Partial `session.stream(...)` | `RunStream[T, StreamEvent[T]]` |
+| `stream.result` | `RunResult[T]` |
+
+## Models
+
+Model IDs are strings because availability depends on account and
+organization policy. Omit `model` to use the configured default, which
+lives in `~/.factory/settings.json` under `sessionDefaultSettings`.
+An unknown model ID is rejected by the backend: the turn returns
+`RunFailure(subtype="error_during_execution")` with the rejection message
+in `error.message`.
+
+### Select a model
+
+```python
+from droid_sdk import ReasoningEffort, run
+
+result = await run(
+    "Review this repository.",
+    model="model-id",
+    reasoning_effort=ReasoningEffort.HIGH,
+)
+```
+
+Omit `reasoning_effort` to use the model default.
+
+Change the model for later turns:
+
+```python
+await session.update_settings(
+    model="model-id",
+    reasoning_effort=ReasoningEffort.HIGH,
+)
+```
+
+See [Update settings](#update-settings) for the full `update_settings()`
+contract.
+
+### Use the Factory Router
+
+The model ID `auto` selects the
+[Factory Router](/web/factory-router),
+which routes each task to the model with the best balance of quality,
+latency, and cost. Some product surfaces label it Auto Model; the model
+ID is `auto` everywhere.
+
+```python
+from droid_sdk import run
+
+result = await run("Review this repository.", model="auto")
+```
+
+Pin a session to the router the same way:
+
+```python
+async with Session(model="auto") as session:
+    ...
+```
+
+Move a live session onto the router:
+
+```python
+await session.update_settings(model="auto")
+```
+
+Omit `reasoning_effort`; the router chooses the effort along with the
+model and ignores a supplied value. `session.settings.model` reports
+`auto`; the underlying model can differ per response.
+
+The model ID `auto` is unrelated to `Mode.AUTO`, the default interaction
+mode, and to `Autonomy`, the permission level.
+
+#### See which model handled a response
+
+Assistant messages in the wire `create_message` notification carry the
+underlying model in `modelId`; `routerId` is `"auto"` when the router
+made the choice. High-level messages omit these fields. Subscribe with
+[`on_notification()`](#subscribe-to-raw-notifications):
+
+```python
+from collections.abc import Mapping
+
+
+def report_routing(notification: Mapping[str, object]) -> None:
+    message = notification.get("message")
+    if isinstance(message, Mapping) and message.get("role") == "assistant":
+        print(message.get("modelId"), message.get("routerId"))
+
+
+unsubscribe = session.on_notification(report_routing, type="create_message")
+```
+
+Wire payloads use camelCase keys and evolve server-side; treat absent
+keys as normal.
+
+### Configure mode-specific models
+
+```python
+from droid_sdk import Mode, ReasoningEffort, Session, SessionConfig
+
+config = SessionConfig(
+    mode=Mode.SPEC,
+    spec_model="model-id",
+    spec_reasoning_effort=ReasoningEffort.HIGH,
+)
+
+async with Session(model="model-id", config=config) as session:
+    async with session.stream("Draft an implementation plan.") as stream:
+        async for _ in stream:
+            pass
+```
+
+The primary model handles Auto turns. `spec_model` handles Spec turns.
+Switch modes on a live session with `enter_spec()` and `leave_spec()`; see
+[Modes](#modes).
+
+### Model configuration contract
+
+| Field | Type | Used by |
+| --- | --- | --- |
+| `model` | `str \| None` | `run()`, `Session`, `update_settings()` |
+| `reasoning_effort` | `ReasoningEffort \| None` | Same |
+| `spec_model` | `str \| None` | `SessionConfig`, `update_settings()` |
+| `spec_reasoning_effort` | `ReasoningEffort \| None` | Same |
+
+`None` uses the configured default. Setting a Spec field to `None` through
+`update_settings()` clears it.
+
+## Sessions
+
+Use a session when turns share history.
+
+### Open a session
+
+`Session` is lazy. It creates the subprocess and session on entry:
+
+```python
+async with Session(
+    cwd=Path.cwd(),
+    model="auto",
+) as session:
+    async with session.stream("Review the project.") as stream:
+        async for message in stream:
+            handle(message)
+```
+
+`model="auto"` selects the [Factory Router](#use-the-factory-router).
+
+Configure behavior and attach handlers with `SessionConfig` and
+`InteractionHandlers`:
+
+```python
+from droid_sdk import (
+    Autonomy,
+    InteractionHandlers,
+    PermissionRequest,
+    PermissionResponse,
+    SessionConfig,
+    ToolConfirmationOutcome,
+)
+
+
+def approve(request: PermissionRequest) -> PermissionResponse:
+    return request.respond(ToolConfirmationOutcome.PROCEED_ONCE)
+
+
+config = SessionConfig(
+    autonomy=Autonomy.LOW,
+    disabled_tools={"Execute"},  # any iterable of tool IDs works here
+    disable_builtin_skills=True,
+)
+
+async with Session(
+    config=config,
+    interactions=InteractionHandlers(on_permission=approve),
+) as session:
+    ...
+```
+
+Handlers are plain callables that inspect the request and choose an offered
+outcome; see [Permissions and user input](#permissions-and-user-input) for
+the full contract.
+
+`SessionConfig` also accepts mode-specific models, MCP servers, tags, source
+attribution, `machine_id`, automatic permission rejection, and native-tool
+overrides. It does not expose a system-prompt API.
+
+### Resume a saved session
+
+```python
+async with Session.resume(
+    session_id,
+    interactions=InteractionHandlers(on_question=answer),
+    disabled_tools={"Execute"},
+) as session:
+    async with session.stream("Continue the previous task.") as stream:
+        async for _ in stream:
+            pass
+```
+
+Get a session ID from `session.id`, `result.session_id`, or
+[`list_sessions()`](#list-saved-sessions).
+
+Resume restores conversation history, working directory, title, and settings;
+runtime concerns such as handlers and MCP servers must be attached again (see
+the table below). It does not accept a new working directory or model.
+
+### What persists
+
+| Restored | Attach again |
+| --- | --- |
+| Conversation history | Interaction handlers |
+| Working directory | Session-scoped MCP servers |
+| Title | Observability sinks |
+| Session settings | |
+
+### Open and close manually
+
+```python
+session = Session()
+await session.open()
+
+try:
+    async with session.stream("Review the project.") as stream:
+        async for _ in stream:
+            pass
+finally:
+    await session.close()
+```
+
+`open()` and `close()` are idempotent, but a closed session cannot be
+reopened. Calling an active method before `open()` raises
+`SessionNotOpenError`.
+
+Concurrent `open()` calls share one startup attempt. If one waiter is
+cancelled, startup continues for the others. Cancelling the final waiter
+cancels startup and completes resource cleanup before the session becomes
+retryable. `close()` racing startup waits for startup cleanup and leaves the
+session closed.
+
+### Read session state
+
+```python
+print(session.id)
+print(session.cwd)
+print(session.settings.model)
+print(session.settings.mode)
+```
+
+These properties are read-only. `settings` is an immutable snapshot, replaced
+when Droid reports a settings change.
+
+### Update settings
+
+```python
+await session.update_settings(
+    model="model-id",
+    reasoning_effort=ReasoningEffort.HIGH,
+    autonomy=Autonomy.MEDIUM,
+    disabled_tools={"Execute"},
+)
+```
+
+Only supplied fields change. Set nullable Spec-model fields to `None` to
+clear them.
+
+`update_settings()` accepts:
+
+| Field | Type |
+| --- | --- |
+| `model` | `str \| None` |
+| `reasoning_effort` | `ReasoningEffort \| None` |
+| `mode` | `Mode \| None` |
+| `autonomy` | `Autonomy \| None` |
+| `spec_model` | `str \| None` |
+| `spec_reasoning_effort` | `ReasoningEffort \| None` |
+| `tags` | `Sequence[SessionTag] \| None` |
+| `compaction_token_limit` | `int \| None` |
+| `compaction_threshold_check_enabled` | `bool \| None` |
+| `additional_tools` | `Iterable[str] \| None` |
+| `enabled_tools` | `Iterable[str] \| None` |
+| `disabled_tools` | `Iterable[str] \| None` |
+| `restrict_tools` | `Iterable[str] \| None` |
+
+It returns `UpdateSettingsResult`. The result currently has no fields.
+
+### Rename a session
+
+```python
+await session.rename("Authentication review")
+```
+
+`rename(title: str)` returns `None`.
+
+### Subscribe to raw notifications
+
+```python
+unsubscribe = session.on_notification(handle_notification, type="custom_type")
+try:
+    ...
+finally:
+    unsubscribe()
+```
+
+High-level streams ignore unknown notifications. `on_notification()` exposes
+them without creating a second client.
+
+### List saved sessions
+
+```python
+from droid_sdk import list_sessions
+
+for saved in await list_sessions(limit=10):
+    print(saved.id, saved.title, saved.modified_at)
+```
+
+Pass `all_workspaces=True` to list sessions across working directories.
+
+`list_sessions()` reads local files without starting Droid. Results are newest
+first. Timestamps are timezone-aware.
+
+### Session construction contract
+
+`Session(...)` accepts:
+
+| Argument | Type |
+| --- | --- |
+| `cwd` | `str \| Path \| None` |
+| `model` | `str \| None` |
+| `reasoning_effort` | `ReasoningEffort \| None` |
+| `config` | `SessionConfig \| None` |
+| `interactions` | `InteractionHandlers \| None` |
+| `runtime` | `Runtime \| None` |
+| `api_key` | `str \| None` |
+
+`SessionConfig` fields:
+
+| Field | Type |
+| --- | --- |
+| `mode` | `Mode \| None` |
+| `autonomy` | `Autonomy \| None` |
+| `spec_model` | `str \| None` |
+| `spec_reasoning_effort` | `ReasoningEffort \| None` |
+| `mcp_servers` | `Sequence[McpServerConfig]` |
+| `machine_id` | `str \| None` |
+| `tags` | `Sequence[SessionTag]` |
+| `session_source` | `SessionSource \| None` |
+| `auto_reject_permission_requests` | `bool \| None` |
+| `disable_builtin_skills` | `bool \| None` |
+| `additional_tools` | `Iterable[str] \| None` |
+| `enabled_tools` | `Iterable[str] \| None` |
+| `disabled_tools` | `Iterable[str] \| None` |
+| `restrict_tools` | `Iterable[str] \| None` |
+
+`Session.resume(session_id, ...)` accepts only values that can be reattached:
+
+| Argument | Type |
+| --- | --- |
+| `session_id` | `str` |
+| `interactions` | `InteractionHandlers \| None` |
+| `mcp_servers` | `Sequence[McpServerConfig]` |
+| `runtime` | `Runtime \| None` |
+| `api_key` | `str \| None` |
+| `disabled_tools` | `Iterable[str] \| None` |
+| `auto_reject_permission_requests` | `bool \| None` |
+| `disable_builtin_skills` | `bool \| None` |
+| `session_source` | `SessionSource \| None` |
+
+### Session state schemas
+
+| Type | Fields |
+| --- | --- |
+| `SessionSettings` | `model`, `reasoning_effort`, `mode`, `autonomy`, `spec_model`, `spec_reasoning_effort`, `tags`, `sandbox`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools` |
+| `SessionSettingsUpdate` | `model`, `reasoning_effort`, `mode`, `autonomy`, `spec_model`, `spec_reasoning_effort`, `tags`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools`, `compaction_threshold_check_enabled` |
+| `SandboxSettings` | `enabled: bool`, `mode: str \| None = None` |
+| `SessionTag` | `name`, `metadata` |
+| `SavedSession` | `id`, `title`, `owner`, `message_count`, `modified_at`, `created_at`, `cwd`, `is_favorite` |
+
+Every `SessionSettingsUpdate` field defaults to `None`. Its field types
+match the `update_settings()` table above.
+
+`list_sessions()` returns `list[SavedSession]`. Its filters are `cwd`,
+`all_workspaces`, and `limit`.
+
+`on_notification(callback, type=None)` passes
+`Mapping[str, object]` to the callback and returns an unsubscribe function.
+
+`SessionSource` requires `platform: SessionPlatform`; every other attribution
+field is optional and defaults to `None`. Required combinations are validated
+when converted to the wire protocol.
+
+## Streaming and results
+
+Use top-level `run()` when only the result matters. Session turns always use
+`stream()`.
+
+`session.stream()` accepts:
+
+| Argument | Type |
+| --- | --- |
+| `prompt` | `str` |
+| `images` | `Sequence[Image]` |
+| `files` | `Sequence[Document]` |
+| `output` | `type[BaseModel] \| JsonSchema \| None` |
+| `timeout` | `float \| None` |
+| `include_partial_messages` | `bool` |
+
+### Complete messages by default
+
+```python
+from droid_sdk import AssistantMessage
+
+async with session.stream("Run the tests.") as stream:
+    async for message in stream:
+        if isinstance(message, AssistantMessage):
+            print(message.text)
+```
+
+### Default stream types
+
+```python
+StreamMessage[T] = (
+    UserMessage
+    | AssistantMessage
+    | ToolCall
+    | ToolResult
+    | HookExecution
+    | ErrorEvent
+    | RunResult[T]
+)
+```
+
+`session.stream(prompt)` yields:
+
+| Type | Fields |
+| --- | --- |
+| `UserMessage` | Conversation-message fields |
+| `AssistantMessage` | Conversation-message fields |
+| `ToolCall` | `name`, `tool_use_id`, `input` |
+| `ToolResult` | `tool_use_id`, `tool_name`, `content`, `is_error` |
+| `HookExecution` | `hook_id`, `event_name`, `matcher`, `tool_call_id`, `command`, `timeout`, `status`, `exit_code`, `stdout`, `stderr`, `suppress_output` |
+| `ErrorEvent` | `message`, `error_type`, `timestamp` |
+| `RunResult[T]` | Terminal result described below |
+
+Values appear in delivery order. `RunResult[T]` is always last.
+
+### Include partial events
+
+```python
+from droid_sdk import RunResult, TextDelta
+
+async with session.stream(
+    "Explain the failing test.",
+    include_partial_messages=True,
+) as stream:
+    async for event in stream:
+        if isinstance(event, TextDelta):
+            print(event.text, end="", flush=True)
+        elif isinstance(event, RunResult) and not event.success:
+            print(f"\nTurn ended: {event.subtype}")
+```
+
+### Partial stream types
+
+```python
+StreamEvent[T] = (
+    StreamMessage[T]
+    | TextDelta
+    | TextComplete
+    | ThinkingDelta
+    | ThinkingComplete
+    | ToolCallDelta
+    | ToolProgress
+    | TokenUsageUpdate
+    | WorkingStateChanged
+    | PermissionResolved
+    | SettingsUpdated
+    | SessionTitleUpdated
+    | SessionWorkingDirectoryChanged
+    | McpStatusChanged
+    | McpAuthRequired
+    | McpAuthCompleted
+)
+```
+
+With `include_partial_messages=True`, the stream yields every
+`StreamMessage[T]` plus:
+
+| Type | Fields |
+| --- | --- |
+| `TextDelta` | `message_id`, `block_index`, `text` |
+| `TextComplete` | `message_id`, `block_index` |
+| `ThinkingDelta` | `message_id`, `block_index`, `text` |
+| `ThinkingComplete` | `message_id`, `block_index`, `duration` |
+| `ToolCallDelta` | `tool_use` |
+| `ToolProgress` | `tool_use_id`, `tool_name`, `content`, `update` |
+| `TokenUsageUpdate` | Token-usage fields |
+| `WorkingStateChanged` | `state` |
+| `PermissionResolved` | `request_id`, `tool_use_ids`, `selected_option` |
+| `SettingsUpdated` | `settings` |
+| `SessionTitleUpdated` | `title` |
+| `SessionWorkingDirectoryChanged` | `cwd` |
+| `McpStatusChanged` | `servers`, `summary` |
+| `McpAuthRequired` | `server_name`, `auth_url`, `message`, `state` |
+| `McpAuthCompleted` | `server_name`, `outcome`, `message` |
+
+`ToolProgress.update` is a `ToolProgressUpdate`:
+
+| Type | Fields |
+| --- | --- |
+| `ToolProgressUpdate` | `type`, `tool_name`, `status`, `details`, `text`, `error`, `timestamp`, `parameters`, `value_snippet`, `terminal_id`, `full_output`, `subagent_session_id` |
+
+`ToolProgressUpdate.type` is `"tool_call"`, `"tool_result"`, `"error"`,
+`"status"`, or `"message"`.
+
+Unknown high-level events are ignored. Use `session.on_notification()` when
+the application needs raw notifications.
+
+### Message model
+
+```python
+from droid_sdk import AssistantMessage, ConversationMessage, UserMessage
+
+completed: list[ConversationMessage] = []
+
+async with session.stream("Explain the failing test.") as stream:
+    async for event in stream:
+        if isinstance(event, (UserMessage, AssistantMessage)):
+            completed.append(event)
+            save(event)
+```
+
+`ConversationMessage` defines the fields shared by user and assistant
+messages:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `id` | `str` | Stable message ID |
+| `content` | `tuple[ContentBlock, ...]` | Ordered canonical content |
+| `text` | `str` | Visible text blocks joined in order |
+| `parent_id` | `str \| None` | Parent message, when present |
+| `created_at` | `datetime` | Timezone-aware creation time |
+| `updated_at` | `datetime` | Timezone-aware update time |
+
+`ContentBlock` is a typed union for text, thinking, tool use, tool result,
+redacted thinking, images, and documents. Narrow blocks with `isinstance()`.
+
+```python
+ContentBlock = (
+    TextBlock
+    | ThinkingBlock
+    | RedactedThinkingBlock
+    | ToolUseBlock
+    | ToolResultBlock
+    | ImageBlock
+    | DocumentBlock
+)
+```
+
+| Type | Fields |
+| --- | --- |
+| `TextBlock` | `id`, `text` |
+| `ThinkingBlock` | `id`, `thinking`, `signature`, `signature_provider`, `duration` |
+| `RedactedThinkingBlock` | `id`, `data` |
+| `ToolUseBlock` | `id`, `name`, `input`, `thought_signature` |
+| `ToolResultBlock` | `id`, `tool_use_id`, `content`, `is_error` |
+| `ImageBlock` | `id`, `source`, `generated` |
+| `DocumentBlock` | `id`, `source` |
+
+`Message` is `StreamMessage[T]` without `RunResult[T]`. Partial events are not
+messages.
+
+`TextDelta.message_id` and `block_index` identify the assistant content block
+that eventually appears in `AssistantMessage.content`.
+`ToolCall.tool_use_id` matches the corresponding `ToolUseBlock.id`.
+
+A complete message can repeat text already delivered through `TextDelta`.
+Use deltas for live rendering and complete messages for persistence. Do not
+concatenate both.
+
+`stream.result.messages` is the ordered tuple of complete `Message` values
+emitted before the result. It excludes the result and partial events.
+
+### Read the result
+
+The terminal `RunResult` is yielded by the iterator and cached on the stream:
+
+```python
+from droid_sdk import RunResult
+
+async with session.stream("Run the tests.") as stream:
+    async for message in stream:
+        if isinstance(message, RunResult):
+            print(message.subtype)
+
+result = stream.result
+if result.success:
+    print(result.text)
+```
+
+Reading `stream.result` before completion raises `StreamIncompleteError`.
+
+### Result types
+
+`RunResult[T]` is a union of three terminal states:
+
+```python
+RunResult[T] = RunSuccess[T] | RunInterrupted[T] | RunFailure[T]
+```
+
+| Type | Subtype | `success` | `interrupted` |
+| --- | --- | --- | --- |
+| `RunSuccess[T]` | `success` | `True` | `False` |
+| `RunInterrupted[T]` | `interrupted` | `False` | `True` |
+| `RunFailure[T]` | `error_during_execution` | `False` | `False` |
+| `RunFailure[T]` | `error_structured_output` | `False` | `False` |
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `subtype` | `str` | Terminal state |
+| `text` | `str` | Final assistant text; reconstructed from deltas if no complete message arrived |
+| `messages` | `tuple[Message, ...]` | Complete messages from the turn |
+| `usage` | `Usage \| None` | Per-turn token and credit usage |
+| `duration` | `timedelta` | Wall-clock duration |
+| `turn_count` | `int` | SDK turn count, currently `1` |
+| `session_id` | `str` | Session that ran the turn |
+| `output` | `T \| None` | Locally adapted structured output |
+| `structured_output` | `FrozenJsonObject \| None` | Immutable raw structured output |
+| `output_validation_error` | `ValidationError \| None` | Pydantic failure |
+| `structured_output_error` | `StructuredOutputError \| None` | Droid failure |
+| `error` | `ErrorEvent \| None` | Terminal execution error |
+
+All result variants retain partial output. `RunFailure` also exposes `error`
+and the server's `structured_output_error` when available. A successful turn
+may have no structured output.
+
+`RunResult` does not define truthiness. Check `success` or `subtype`.
+
+### Token and context usage
+
+```python
+if result.usage:
+    print(result.usage.input_tokens)
+    print(result.usage.output_tokens)
+    print(result.usage.cache_read_tokens)
+    print(result.usage.cache_creation_tokens)
+    print(result.usage.thinking_tokens)
+    print(result.usage.factory_credits)
+```
+
+`TokenUsageUpdate` contains cumulative committed session usage. Context
+occupancy is separate:
+
+```python
+context = await session.context()
+print(context.used, context.remaining, context.limit, context.accuracy)
+```
+
+`ContextUsage.updated_at` records when Droid measured the value.
+
+| Type | Fields |
+| --- | --- |
+| `Usage` | `input_tokens`, `output_tokens`, `cache_creation_tokens`, `cache_read_tokens`, `thinking_tokens`, `factory_credits` |
+| `ContextUsage` | `used`, `remaining`, `limit`, `accuracy`, `updated_at` |
+
+### Failures and exceptions
+
+```python
+async with session.stream("Run the tests.") as stream:
+    async for _ in stream:
+        pass
+
+result = stream.result
+if result.subtype == "interrupted":
+    print("The turn was interrupted.")
+elif result.subtype in ("error_during_execution", "error_structured_output"):
+    print(result.error.message if result.error else result.subtype)
+```
+
+Setup, connection, process, protocol, and timeout failures raise
+`DroidError` subclasses. Python programming errors use normal built-in
+exceptions. `asyncio.CancelledError` is never wrapped.
+
+### Concurrency
+
+A session may have one active stream. Starting another raises
+`SessionBusyError`.
+
+Different sessions may run concurrently.
+
+### Timeout
+
+```python
+async with session.stream("Perform a long review.", timeout=60) as stream:
+    async for event in stream:
+        handle(event)
+```
+
+On expiry, the SDK interrupts the turn and raises `RunTimeoutError`.
+
+### Interrupt a turn
+
+Another task may stop active work:
+
+```python
+await session.interrupt()
+```
+
+The active stream yields an interrupted result if its consumer remains
+attached. The session stays open.
+
+### Cancellation and early exit
+
+Cancelling the task running a turn sends a best-effort interrupt, releases the
+subscription, then re-raises `asyncio.CancelledError`.
+
+Use the stream context manager when iteration may stop early:
+
+```python
+async with session.stream("Inspect every test.") as stream:
+    async for event in stream:
+        if should_stop(event):
+            break
+```
+
+Context exit interrupts unfinished work. A bare async iterator cannot
+guarantee immediate cleanup on `break`.
+`await stream.aclose()` explicitly interrupts and detaches an unfinished
+stream; it is idempotent.
+
+## Inputs and outputs
+
+### Images and files
+
+Attach images and files to a turn with the `images` and `files` options:
+
+```python
+from droid_sdk import Document, Image, run
+
+result = await run(
+    "Compare these files.",
+    images=[
+        Image.from_path("screenshot.png"),
+        Image.from_bytes(image_bytes, media_type="image/png"),
+    ],
+    files=[
+        Document.from_path("report.pdf"),
+        Document.from_text(source, name="auth.py"),
+    ],
+)
+```
+
+The constructors read local data and encode it for the turn.
+Supported image types are PNG, JPEG, GIF, and WebP; image URLs are
+unsupported. Invalid local input raises `InvalidAttachmentError` before the
+turn starts. Attachments are limited to `MAX_ATTACHMENT_BYTES` (5 MiB), and
+PDFs to `MAX_PDF_ATTACHMENT_BYTES` (3 MiB).
+
+### Input schemas
+
+| Type | Fields |
+| --- | --- |
+| `Image` | `source: Base64ImageSource` |
+| `Base64ImageSource` | `data`, `media_type` |
+| `Document` | `source: TextDocumentSource \| PdfDocumentSource` |
+| `TextDocumentSource` | `data`, `name`, `mime` |
+| `PdfDocumentSource` | `data`, `parsed_data`, `name`, `path` |
+
+| Constructor | Returns |
+| --- | --- |
+| `Image.from_path(path)` | `Image` |
+| `Image.from_bytes(data, media_type=...)` | `Image` |
+| `Document.from_path(path)` | `Document` |
+| `Document.from_text(text, name=..., mime=...)` | `Document` |
+| `Document.from_bytes(data, name=...)` | `Document` |
+
+`images` accepts `Sequence[Image]`. `files` accepts `Sequence[Document]`.
+Wire payloads use canonical `mediaType` fields. The optional `mime` hint on
+text documents is forwarded with the document.
+
+### Return a Pydantic model
+
+```python
+from typing import Literal
+
+from pydantic import BaseModel
+
+from droid_sdk import RunSuccess, run
+
+
+class Finding(BaseModel):
+    severity: Literal["low", "medium", "high"]
+    message: str
+
+
+class Review(BaseModel):
+    summary: str
+    findings: list[Finding]
+
+
+result = await run(
+    "Review the authentication code.",
+    output=Review,
+)
+
+if isinstance(result, RunSuccess) and result.output is not None:
+    print(result.output.summary)  # success guarantees output when requested
+elif result.output_validation_error is not None:
+    print(result.output_validation_error)
+```
+
+`output` accepts a `BaseModel` subclass, not an arbitrary class. Unsupported
+types raise `TypeError` before the turn starts. With `output=Review`, the
+return type is `RunResult[Review]`.
+
+When structured output arrives, the SDK validates it against the model.
+If output was requested, `RunSuccess` guarantees `result.output` is set.
+Missing or invalid output turns the result into `RunFailure` with subtype
+`error_structured_output`; the failure keeps the text, messages, usage, raw
+`structured_output`, and `output_validation_error` for inspection.
+
+### Use raw JSON Schema
+
+```python
+from droid_sdk import JsonObject, JsonSchema, RunResult, run
+
+schema = JsonSchema(
+    {
+        "type": "object",
+        "properties": {"summary": {"type": "string"}},
+        "required": ["summary"],
+    }
+)
+
+result: RunResult[JsonObject] = await run(
+    "Summarize the repository.",
+    output=schema,
+)
+
+if result.output is not None:
+    print(result.output["summary"])
+```
+
+`JsonSchema` accepts an object-shaped schema. Droid reports unsupported or
+invalid schemas through the normal result subtype.
+
+### Output contract
+
+| `output` argument | Return type |
+| --- | --- |
+| Omitted or `None` | `RunResult[None]` |
+| `type[BaseModel]` | `RunResult[Model]` |
+| `JsonSchema` | `RunResult[JsonObject]` |
+
+`JsonSchema.schema` is `FrozenJsonObject`. Schema mappings must contain only
+JSON-compatible values; the SDK validates this and freezes them recursively.
+Raw schema output remains `JsonObject`.
+
+```python
+JsonValue = bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"] | None
+JsonObject = dict[str, JsonValue]
+FrozenJsonValue = (
+    bool
+    | int
+    | float
+    | str
+    | tuple["FrozenJsonValue", ...]
+    | Mapping[str, "FrozenJsonValue"]
+    | None
+)
+FrozenJsonObject = Mapping[str, FrozenJsonValue]
+```
+
+Both local and Droid-side output failures produce `RunFailure` with subtype
+`error_structured_output`. To tell them apart, check
+`structured_output_error.code`: local failures use `local_validation_failed`
+(with the Pydantic error in `output_validation_error`) or
+`local_output_missing`; Droid-side failures use Droid's own codes.
+
+## Permissions and user input
+
+### Autonomy
+
+Autonomy controls which actions require approval in Auto mode:
+
+| Level | Behavior |
+| --- | --- |
+| `Autonomy.OFF` | Ask before every action |
+| `Autonomy.LOW` | Allow edits and read-only commands |
+| `Autonomy.MEDIUM` | Allow reversible commands |
+| `Autonomy.HIGH` | Allow commands without approval |
+
+Configure it through `SessionConfig`:
+
+```python
+config = SessionConfig(autonomy=Autonomy.LOW)
+```
+
+Autonomy does not select Auto or Spec mode. `Mode` controls that.
+
+### Handle permission requests
+
+```python
+from droid_sdk import (
+    InteractionHandlers,
+    PermissionRequest,
+    PermissionResponse,
+    Session,
+    ToolConfirmationOutcome,
+)
+from droid_sdk.permissions import CreateFile
+
+
+def approve(request: PermissionRequest) -> PermissionResponse:
+    if request.actions and all(
+        isinstance(action, CreateFile) for action in request.actions
+    ):
+        return request.respond(ToolConfirmationOutcome.PROCEED_ONCE)
+    return request.respond(ToolConfirmationOutcome.CANCEL)
+
+
+session = Session(
+    interactions=InteractionHandlers(on_permission=approve),
+)
+```
+
+Droid decides which outcomes are on offer. `respond()` accepts only an
+outcome listed in `request.options`, plus optional `comment` or
+`edited_spec_content`.
+
+An absent handler, an invalid response, or a handler exception cancels the
+request. Handler failures appear as `ErrorEvent` values; they do not raise
+through the active stream.
+
+### Answer questions from Droid
+
+```python
+from droid_sdk import QuestionRequest, QuestionResponse
+
+
+def answer(request: QuestionRequest) -> QuestionResponse:
+    answers = [
+        question.answer(question.options[0] if question.options else "none")
+        for question in request.questions
+    ]
+    return request.submit(answers)
+```
+
+Cancel the questionnaire:
+
+```python
+return request.cancel()
+```
+
+Answers are always strings on the wire. Without a handler, or when a
+handler fails or returns an invalid shape, the questionnaire is cancelled and
+the stream receives an `ErrorEvent`.
+
+`question.answer(value)` answers one value.
+`question.answer_multiple(values)` joins multi-select values with `", "` to
+produce the wire-compatible string.
+
+Handlers run inside the active turn. Use async handlers for I/O, and do not
+start another turn on the same session from a handler.
+
+### Interaction contracts
+
+```python
+PermissionHandler = Callable[
+    [PermissionRequest],
+    PermissionResponse | Awaitable[PermissionResponse],
+]
+QuestionHandler = Callable[
+    [QuestionRequest],
+    QuestionResponse | Awaitable[QuestionResponse],
+]
+```
+
+| Type | Fields |
+| --- | --- |
+| `InteractionHandlers` | `on_permission`, `on_question` |
+| `PermissionRequest` | `actions`, `options`, `associated_session_ids`, `plan` |
+| `PermissionOption` | `label`, `value` |
+| `Plan` | `text`, `title` |
+| `PermissionResponse` | `selected_option`, `comment`, `edited_spec_content` |
+| `QuestionRequest` | `tool_call_id`, `questions` |
+| `Question` | `index`, `topic`, `question`, `options`, `multi_select` |
+| `QuestionAnswer` | `index`, `question`, `answer` |
+| `QuestionResponse` | `cancelled`, `answers` |
+
+`PermissionAction` is a discriminated union:
+
+```python
+PermissionAction = (
+    EditAction
+    | ExecuteAction
+    | CreateFile
+    | AskUserAction
+    | ExitSpecModeAction
+    | ApplyPatchAction
+    | McpToolAction
+    | SandboxViolationAction
+    | DroidShieldViolationAction
+)
+```
+
+Every action includes its `tool_use`, confirmation type, and typed details:
+
+| Type | Detail fields |
+| --- | --- |
+| `EditAction` | `file_path`, `file_name`, `old_content`, `new_content` |
+| `ExecuteAction` | `full_command`, `command`, `extracted_commands`, `impact_level`, `risk_level_reason` |
+| `CreateFile` | `file_path`, `file_name`, `content` |
+| `AskUserAction` | `questionnaire`, `questions`, `parse_error` |
+| `ExitSpecModeAction` | `plan`, `title` |
+| `ApplyPatchAction` | `file_path`, `file_name`, `patch_content`, `old_content`, `new_content`, `files` |
+| `ApplyPatchFile` | `file_path`, `file_name`, `operation`, `move_to`, `old_content`, `new_content` |
+| `McpToolAction` | `tool_name`, `server_name`, `actual_tool_name`, `impact_level` |
+| `SandboxViolationAction` | `violating_tool_name`, `target`, `operation`, `violation_type`, `reason`, `violation_reason`, `is_org_deny` |
+| `DroidShieldViolationAction` | `command`, `reason` |
+
+`AskUserParseError(message: str, line: int | None = None)` records malformed
+questionnaire details. `ApplyPatchFile` requires `file_path`, `file_name`, and
+`operation` (`"create"`, `"update"`, or `"delete"`); `move_to`,
+`old_content`, and `new_content` default to `None`.
+
+`ToolConfirmationOutcome` defines:
+
+| Outcome | Meaning |
+| --- | --- |
+| `PROCEED_ONCE` | Approve this request |
+| `PROCEED_ALWAYS` | Persist the offered rule |
+| `PROCEED_ALWAYS_EXACT_PATH` | Persist the exact file path |
+| `PROCEED_AUTO_RUN` | Continue with automatic approvals |
+| `PROCEED_AUTO_RUN_LOW` | Continue at low autonomy |
+| `PROCEED_AUTO_RUN_MEDIUM` | Continue at medium autonomy |
+| `PROCEED_AUTO_RUN_HIGH` | Continue at high autonomy |
+| `PROCEED_NEW_SESSION` | Continue in a new session |
+| `PROCEED_NEW_SESSION_LOW` | New session at low autonomy |
+| `PROCEED_NEW_SESSION_MEDIUM` | New session at medium autonomy |
+| `PROCEED_NEW_SESSION_HIGH` | New session at high autonomy |
+| `PROCEED_EDIT` | Submit edited plan content |
+| `PROCEED_ALWAYS_TOOLS` | Persist approval for MCP tools |
+| `PROCEED_ALWAYS_SERVER` | Persist approval for an MCP server |
+| `CANCEL` | Reject the request |
+
+Only outcomes present in `PermissionRequest.options` are valid.
+
+### Control native tools
+
+```python
+config = SessionConfig(
+    additional_tools={"CustomTool"},
+    enabled_tools={"Read"},
+    disabled_tools={"Execute", "Edit"},
+    restrict_tools={"Read", "Grep"},
+)
+```
+
+Each of the four sets has a distinct role:
+
+- `additional_tools` adds IDs to the catalog.
+- `enabled_tools` enables otherwise available tools.
+- `disabled_tools` removes tools.
+- `restrict_tools` is a restrictive allowlist and never elevates permission.
+
+```python
+for tool in await session.list_tools(model="model-id", mode=Mode.AUTO):
+    print(tool.id, tool.allowed)
+```
+
+`update_settings()` accepts the same override fields for later turns.
+The four override parameters accept any iterable of tool IDs, such as a set,
+list, or tuple. Passing a bare string raises `TypeError`.
+
+`list_tools()` returns `list[ToolInfo]`.
+
+| Type | Fields |
+| --- | --- |
+| `ToolInfo` | `id`, `display_name`, `description`, `category`, `default_allowed`, `allowed` |
+| `ListToolsOptions` | `model`, `mode`, `autonomy`, `spec_model`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools`, `skip_permissions_unsafe` |
+
+## Tools and extensions
+
+| Extension | Use it for |
+| --- | --- |
+| Skills | Reusable instructions and supporting files |
+| In-process MCP tools | Python functions exposed to Droid |
+| External MCP servers | Tools from another process or service |
+| Hooks | Commands run at Droid lifecycle points |
+
+### Skills
+
+```python
+skills = await session.list_skills()
+for skill in skills.skills:
+    print(skill.name, skill.enabled)
+```
+
+`skills.project_available` reports whether a project skill scope is
+available; it is `None` when Droid does not report it.
+
+Enable or disable a skill:
+
+```python
+await session.enable_skill("review", scope="project")
+await session.disable_skill("legacy", scope="user")
+```
+
+Skills may come from project, personal, built-in, or automation settings.
+
+#### Skill schemas
+
+| Type | Fields |
+| --- | --- |
+| `SkillsResult` | `skills`, `project_available` |
+| `SkillInfo` | `name`, `description`, `location`, `file_path`, `enabled`, `user_invocable`, `version`, `content`, `resources`, `disabled_by` |
+| `SkillResource` | `name`, `path`, `type` |
+| `SkillMutationResult` | `success` |
+
+`scope` is `"user"` or `"project"`. `SkillResource.type` is `"reference"` or
+`"asset"`. `SkillInfo.location` is `"project"`, `"personal"`, `"builtin"`, or
+`"automation"`.
+
+### In-process MCP tools
+
+In-process servers require the `mcp` extra
+(`pip install "droid-sdk[mcp]"`). Use `@tool` to expose an annotated Python
+function:
+
+```python
+from droid_sdk.mcp import create_sdk_mcp_server, tool
+
+
+@tool("lookup_owner", "Return the owner of a repository file.")
+async def lookup_owner(path: str) -> str:
+    return f"Owner for {path}: platform-team"
+
+
+server = create_sdk_mcp_server(
+    name="review-tools",
+    tools=[lookup_owner],
+    version="1.0.0",
+)
+config = SessionConfig(mcp_servers=[server])
+```
+
+The decorator derives JSON Schema from type annotations. Invalid input is
+returned to Droid as a tool error and is not passed to the function.
+
+Tool functions may be synchronous or asynchronous. They may return text or a
+typed `ToolResponse`.
+
+The SDK starts an authenticated loopback server and closes it with the
+session. Attach in-process servers again when resuming.
+
+#### In-process MCP schemas
+
+| Type | Fields |
+| --- | --- |
+| `DroidTool` | `name`, `description`, `input_schema`, `handler`, `output_schema` |
+| `SdkMcpServer` | `name`, `version`, `tools` |
+| `ToolResponse` | `content`, `is_error`, `structured_content` |
+
+`tool(name, description)` is a decorator;
+`tool(name, description, function)` is the equivalent direct call. A return
+annotation that describes an object is validated at call time, returned as
+structured content, and advertised through the MCP `outputSchema` field.
+
+`create_sdk_mcp_server(name, tools, version="1.0.0")` returns `SdkMcpServer`.
+`SdkMcpServer.config` is the active `HttpMcpServerConfig` or `None`;
+`await server.start()` returns that config, and `await server.close()` stops
+the server. Sessions normally own these calls.
+
+### External MCP servers
+
+External server configs do not need the `mcp` extra:
+
+```python
+from droid_sdk import HttpMcpServerConfig, StdioMcpServerConfig
+
+config = SessionConfig(
+    mcp_servers=[
+        HttpMcpServerConfig(name="docs", url="https://example.com/mcp"),
+        StdioMcpServerConfig(
+            name="search",
+            command="python",
+            args=["-m", "search_server"],
+        ),
+    ],
+)
+```
+
+HTTP, SSE, and stdio transports are supported. HTTP and SSE configurations
+support headers and OAuth settings.
+
+Inspect connected servers and tools:
+
+```python
+servers = await session.list_mcp_servers()
+tools = await session.list_mcp_tools()
+
+print(servers.summary)
+for server in servers.servers:
+    print(server.name, server.status)
+```
+
+Session methods can add, remove, enable, disable, and authenticate external
+servers. Configuration mutations affect the user's Droid settings. Servers
+passed through `SessionConfig` are session-scoped.
+
+| Session MCP method | Signature |
+| --- | --- |
+| `list_mcp_servers` | `() -> McpServersResult` |
+| `list_mcp_tools` | `() -> list[McpToolInfo]` |
+| `add_mcp_server` | `(config) -> McpMutationResult` |
+| `remove_mcp_server` | `(name: str) -> McpMutationResult` |
+| `enable_mcp_server` / `disable_mcp_server` | `(name: str) -> McpMutationResult` |
+| `enable_mcp_tool` / `disable_mcp_tool` | `(server_name: str, tool_name: str) -> McpMutationResult` |
+| `authenticate_mcp_server` | `(name: str) -> McpMutationResult` |
+| `cancel_mcp_auth` / `clear_mcp_auth` | `(name: str) -> McpMutationResult` |
+| `submit_mcp_auth_code` | `(name: str, *, code: str, state: str) -> McpMutationResult` |
+| `submit_mcp_auth_error` | `(name: str, *, error: str, state: str, error_description: str \| None = None) -> McpMutationResult` |
+
+#### External MCP schemas
+
+```python
+McpServerConfig = (
+    StdioMcpServerConfig | HttpMcpServerConfig | SseMcpServerConfig | SdkMcpServer
+)
+```
+
+| Type | Fields |
+| --- | --- |
+| `StdioMcpServerConfig` | `name`, `command`, `args`, `env` |
+| `HttpMcpServerConfig` | `name`, `url`, `headers`, `oauth` |
+| `SseMcpServerConfig` | `name`, `url`, `headers`, `oauth` |
+| `HttpHeader` | `name`, `value` |
+| `McpOAuthOptions` | `scopes`, `resource`, `authorization_server_issuer`, `client_metadata_url`, `client_id`, `client_secret`, `callback_port`, `token_endpoint_auth_method` |
+| `McpServersResult` | `servers`, `summary` |
+| `McpServerStatusInfo` | `name`, `status`, `source`, `is_managed`, `error`, `tool_count`, `server_type`, `has_auth_tokens`, `requires_auth`, `pending_auth_url`, `pending_auth_message`, `pending_auth_state` |
+| `McpStatusSummary` | `total`, `connected`, `connecting`, `failed`, `disabled`, `config_error` |
+| `McpConfigError` | `path`, `message` |
+| `McpToolInfo` | `server_name`, `name`, `description`, `is_enabled`, `is_read_only`, `input_schema` |
+| `McpToolInputSchema` | `type`, `properties`, `required` |
+| `McpMutationResult` | `success` |
+
+`oauth` accepts `McpOAuthOptions` or `False`.
+
+Remove, enable, and disable mutate user-scoped MCP configuration only. These
+methods do not accept a project-scope argument.
+
+### Hooks
+
+There is no Python API for defining hooks; configure them in
+`.factory/hooks.json`. Hook execution appears as `HookExecution` values in
+the run stream. `HookExecution.status` is `"started"`, `"completed"`, or
+`"error"`.
+
+## Session lifecycle
+
+Fork, compact, and rewind create successor sessions. The successor is an
+opened `Session` that takes over the existing Droid connection; `fork()`
+returns it directly, while `compact()` and `rewind()` return it on their
+outcome objects.
+
+### Fork
+
+Fork copies the conversation into a new session and continues there.
+
+```python
+fork = await session.fork(
+    title="Alternative approach",
+    tags=[SessionTag(name="experiment")],
+)
+
+async with fork:
+    async with fork.stream("Try the other strategy.") as stream:
+        async for _ in stream:
+            pass
+```
+
+### Compact
+
+Compaction summarizes older conversation history to free context-window
+space.
+
+```python
+outcome = await session.compact(instructions="Keep decisions and unresolved failures.")
+
+async with outcome.session as compacted:
+    print(outcome.removed_count)
+```
+
+### Rewind
+
+Rewind returns the conversation to an earlier message and can restore or
+delete files changed since.
+
+```python
+info = await session.rewind_info(message_id)
+
+outcome = await session.rewind(
+    message_id,
+    restore=info.available_files,
+    delete=info.created_files,
+    title="Before the failed change",
+)
+
+async with outcome.session as rewound:
+    print(outcome.restored_count, outcome.deleted_count)
+    print(outcome.failed_restore_count, outcome.failed_delete_count)
+```
+
+`info.evicted_files` explains files that cannot be restored.
+
+### Lifecycle contracts
+
+| Method | Arguments | Returns |
+| --- | --- | --- |
+| `fork()` | `title`, `tags` | Opened `Session` |
+| `compact()` | `instructions` | `CompactOutcome` |
+| `rewind_info()` | `message_id` | `RewindInfo` |
+| `rewind()` | `message_id`, `restore`, `delete`, `title` | `RewindOutcome` |
+
+| Type | Fields |
+| --- | --- |
+| `CompactOutcome` | `session`, `removed_count` |
+| `RewindInfo` | `available_files`, `created_files`, `evicted_files` |
+| `RewindFileSnapshot` | `file_path`, `content_hash`, `size` |
+| `RewindFileCreation` | `file_path` |
+| `RewindEvictedFile` | `file_path`, `reason` |
+| `RewindOutcome` | `session`, `restored_count`, `deleted_count`, `failed_restore_count`, `failed_delete_count` |
+
+### Successor ownership
+
+After a successful replacement:
+
+- the returned successor owns the connection and runtime resources
+- the source session becomes retired
+- `id`, `cwd`, and `settings` remain readable on the source
+- active methods on the source raise `SessionReplacedError`
+- closing the source is a no-op
+
+Replacing a session with an active turn raises `SessionBusyError`.
+
+Only one replacement may run at a time. `open()` and another replacement
+raise `SessionBusyError` while replacement is active. `close()` racing a
+replacement waits; on success it closes the successor, and on rollback it
+closes the source.
+
+Cancelling a replacement before handoff restores the source to open state.
+If cancellation arrives after a successor is created, the SDK reloads the
+source with its attached policies and retires the detached successor. If
+source restoration fails, the SDK closes the connection rather than leaving
+an ambiguous owner.
+
+## Modes
+
+### Spec mode
+
+Spec mode lets Droid inspect a codebase and propose a plan without changing
+files.
+
+#### Enter Spec mode
+
+```python
+await session.enter_spec(
+    model="model-id",
+    reasoning_effort=ReasoningEffort.HIGH,
+)
+```
+
+Start directly in Spec mode with `SessionConfig(mode=Mode.SPEC)`.
+
+#### Leave without approving
+
+```python
+await session.leave_spec()
+```
+
+This changes the mode only. It does not approve the plan or start
+implementation.
+
+#### Approve a plan
+
+Plan approval arrives through the permission handler:
+
+```python
+def approve(request: PermissionRequest) -> PermissionResponse:
+    if request.plan:
+        print(request.plan.text)
+        return request.respond(ToolConfirmationOutcome.PROCEED_ONCE)
+    return request.respond(ToolConfirmationOutcome.CANCEL)
+```
+
+Return any offered `PROCEED_NEW_SESSION*` outcome to hand implementation to a
+new session. Return `PROCEED_EDIT` with `edited_spec_content` to revise the
+plan. `CANCEL` ends the turn with an interrupted result.
+
+### Mode contract
+
+| API | Arguments | Returns |
+| --- | --- | --- |
+| `SessionConfig(mode=...)` | `Mode.AUTO` or `Mode.SPEC` | `SessionConfig` |
+| `enter_spec()` | `model`, `reasoning_effort` | `UpdateSettingsResult` |
+| `leave_spec()` | None | `UpdateSettingsResult` |
+
+Entering or leaving Spec mode only changes settings. Plan approval is an
+`ExitSpecModeAction` permission request, and only an offered
+`ToolConfirmationOutcome` is valid.
+
+## Operations
+
+### Observability
+
+```python
+from droid_sdk import Runtime, run
+from droid_sdk.observability import LogEvent, Observability
+
+
+class PrintLogger:
+    def log(self, event: LogEvent) -> None:
+        print(event.level, event.name, event.message)
+
+
+runtime = Runtime(observability=Observability(logger=PrintLogger()))
+
+result = await run("Check repository status.", runtime=runtime)
+```
+
+Logger, metric, and trace-context sinks are synchronous and best-effort. Sink
+failures never fail a Droid operation.
+
+Events exclude prompts, messages, thinking, tool inputs and results, file
+contents, raw process output, stack traces, and credentials.
+
+#### Observability schemas
+
+| Type | Fields or methods |
+| --- | --- |
+| `Observability` | `logger`, `metrics`, `tracing` |
+| `Logger` | `log(event: LogEvent) -> None` |
+| `LogEvent` | `level`, `name`, `message`, `attributes`, `error` |
+| `SerializedError` | `name`, `message`, `code` |
+| `MetricSink` | `record(event: MetricEvent) -> None` |
+| `MetricEvent` | `name`, `kind`, `value`, `unit`, `attributes` |
+| `TraceContextProvider` | `inject(carrier: TraceContext) -> None` |
+| `TraceContext` | `traceparent`, `tracestate` |
+
+`attributes` is `Mapping[str, str | int | float | bool | None]`. Log levels are
+`"debug"`, `"info"`, `"warn"`, and `"error"`. Metric kinds are `"counter"`
+and `"histogram"`. `TraceContext` is deliberately mutable so tracing providers
+can inject values into it.
+
+### Custom runtime
+
+`Runtime` holds process configuration:
+
+```python
+runtime = Runtime(
+    executable=Path("/opt/factory/bin/droid"),
+    args=["--flag"],
+    env={"EXAMPLE": "value"},
+)
+```
+
+Environment entries extend the current process environment when the SDK
+starts Droid.
+
+#### Runtime schema
+
+| Field | Type |
+| --- | --- |
+| `executable` | `str \| Path \| None` |
+| `args` | `Sequence[str]` |
+| `env` | `Mapping[str, str]` |
+| `observability` | `Observability \| None` |
+
+## API index
+
+### Root constants and supporting types
+
+| Export | Contract |
+| --- | --- |
+| `__version__` | Installed package version as `str` |
+| `MAX_ATTACHMENT_BYTES` | General attachment limit, `5 * 1024 * 1024` |
+| `MAX_PDF_ATTACHMENT_BYTES` | PDF limit, `3 * 1024 * 1024` |
+| `ImageMediaType` | Supported image MIME literal union |
+| `JsonValue`, `JsonObject` | Mutable JSON input/output aliases |
+| `FrozenJsonValue`, `FrozenJsonObject` | Recursively immutable JSON aliases |
+| `ApplyPatchFile` | Per-file patch details documented above |
+| `AskUserParseError` | `message`, `line` |
+| `SandboxSettings` | `enabled`, `mode` |
+| `SessionSettingsUpdate` | Partial settings notification documented above |
+
+### Top-level functions
+
+| API | Returns | Purpose |
+| --- | --- | --- |
+| `run(prompt, **options)` | `RunResult[T]` | Run one turn |
+| `list_sessions(**filters)` | `list[SavedSession]` | List saved sessions |
+
+| `run()` argument | Type |
+| --- | --- |
+| `prompt` | `str` |
+| `cwd` | `str \| Path \| None` |
+| `model` | `str \| None` |
+| `reasoning_effort` | `ReasoningEffort \| None` |
+| `images` | `Sequence[Image]` |
+| `files` | `Sequence[Document]` |
+| `output` | `type[BaseModel] \| JsonSchema \| None` |
+| `timeout` | `float \| None` |
+| `config` | `SessionConfig \| None` |
+| `interactions` | `InteractionHandlers \| None` |
+| `runtime` | `Runtime \| None` |
+| `api_key` | `str \| None` |
+
+### `Session`
+
+| Member | Returns |
+| --- | --- |
+| `Session(...)` | Lazy `Session` |
+| `Session.resume(id, ...)` | Lazy `Session` |
+| `open()` | `None` |
+| `close()` | `None` |
+| `id` | `str` |
+| `cwd` | `Path \| None` |
+| `settings` | `SessionSettings` |
+| `stream()` | `RunStream[T, E]` |
+| `interrupt()` | `None` |
+| `update_settings()` | `UpdateSettingsResult` |
+| `rename()` | `None` |
+| `on_notification()` | `Callable[[], None]` |
+| `list_tools()` | `list[ToolInfo]` |
+| `list_skills()` | `SkillsResult` |
+| `enable_skill()` / `disable_skill()` | `SkillMutationResult` |
+| `list_mcp_servers()` | `McpServersResult` |
+| `list_mcp_tools()` | `list[McpToolInfo]` |
+| MCP mutation methods | `McpMutationResult` |
+| `context()` | `ContextUsage` |
+| `fork()` | Opened `Session` |
+| `compact()` | `CompactOutcome` |
+| `rewind_info()` | `RewindInfo` |
+| `rewind()` | `RewindOutcome` |
+| `enter_spec()` / `leave_spec()` | `UpdateSettingsResult` |
+
+### `RunStream`
+
+| Member | Returns |
+| --- | --- |
+| Async iteration | `StreamMessage[T]` or `StreamEvent[T]` values |
+| `result` | Cached `RunResult[T]` |
+| `aclose()` | `None` |
+
+### Main enums
+
+| Enum | Values |
+| --- | --- |
+| `Mode` | `AUTO`, `SPEC` |
+| `Autonomy` | `OFF`, `LOW`, `MEDIUM`, `HIGH` |
+| `ReasoningEffort` | See supported values below |
+| `ToolCategory` | `READ`, `EDIT`, `EXECUTE`, `OTHER` |
+| `ToolConfirmationType` | `EDIT`, `EXECUTE`, `CREATE`, `ASK_USER`, `EXIT_SPEC_MODE`, `APPLY_PATCH`, `MCP_TOOL`, `SANDBOX_VIOLATION`, `DROID_SHIELD_VIOLATION` |
+| `ToolConfirmationOutcome` | Permission outcomes offered by Droid |
+| `WorkingState` | `IDLE`, `THINKING`, `STREAMING_ASSISTANT_MESSAGE`, `WAITING_FOR_TOOL_CONFIRMATION`, `EXECUTING_TOOL`, `COMPACTING_CONVERSATION` |
+| `ContextAccuracy` | `EXACT`, `ESTIMATED` |
+| `McpServerType` | `STDIO`, `HTTP`, `SSE` |
+| `McpServerStatus` | `CONNECTING`, `CONNECTED`, `DISCONNECTED`, `FAILED`, `DISABLED` |
+| `McpAuthOutcome` | `SUCCESS`, `CANCELLED`, `FAILED` |
+| `OAuthTokenEndpointAuthMethod` | `NONE`, `CLIENT_SECRET_BASIC`, `CLIENT_SECRET_POST` |
+| `SessionPlatform` | `SLACK`, `WEB`, `API`, `SESSIONS_API`, `JIRA`, `LINEAR`, `MICROSOFT_TEAMS`, `READINESS_REMEDIATION`, `READINESS_EVALUATION`, `AUTOMATION`, `WIKI_GENERATION`, `WIKI_CI_SETUP`, `TUI`, `DESKTOP`, `ACP`, `UNKNOWN` |
+| `SandboxOperation` | `READ`, `WRITE`, `NETWORK`, `TOOL` |
+| `SandboxViolationType` | `FILESYSTEM_READ`, `FILESYSTEM_WRITE`, `NETWORK`, `TOOL` |
+| `SandboxViolationReason` | `DENY_LIST`, `NOT_ALLOWED` |
+| `ErrorType` | `CONNECTION_ERROR`, `PROTOCOL_ERROR`, `SESSION_ERROR`, `TIMEOUT_ERROR`, `DROID_CLIENT_ERROR`, `PROCESS_EXIT_ERROR`, `ERROR` |
+
+`ReasoningEffort` defines `NONE`, `DYNAMIC`, `OFF`, `MINIMAL`, `LOW`,
+`MEDIUM`, `HIGH`, `EXTRA_HIGH`, and `MAX`. Model and tool IDs are plain
+strings, not enums.
+
+On the wire, these enums use the following values:
+
+```text
+ToolCategory: read, edit, execute, other
+ToolConfirmationType: edit, exec, create, ask_user, exit_spec_mode,
+  apply_patch, mcp_tool, sandbox_violation, droid_shield_violation
+OAuthTokenEndpointAuthMethod: none, client_secret_basic, client_secret_post
+SandboxOperation: read, write, network, tool
+SandboxViolationType: filesystem-read, filesystem-write, network, tool
+SandboxViolationReason: deny-list, not-allowed
+SessionPlatform: slack, web, api, sessions_api, jira, linear,
+  microsoft-teams, readiness-remediation, readiness-evaluation, automation,
+  wiki-generation, wiki-ci-setup, tui, desktop, acp, unknown
+```
+
+### Exceptions
+
+All SDK-defined exceptions derive from `DroidError`. Python built-ins and
+`asyncio.CancelledError` do not.
+
+| Exception | Meaning |
+| --- | --- |
+| `RunTimeoutError` | The turn exceeded its deadline |
+| `StreamIncompleteError` | A stream result was read before completion |
+| `InvalidAttachmentError` | A local attachment was invalid |
+| `SessionNotOpenError` | An operation required an opened session |
+| `SessionBusyError` | The session already had an active turn or replacement in progress |
+| `SessionClosedError` | The session was closed |
+| `SessionReplacedError` | A successor retired the source session |
+| `SessionReplacementError` | Successor load or source restore failed |
+| `SessionNotFoundError` | A saved session ID was not found |
+| `InvalidWorkingDirectoryError` | A working directory is unavailable |
+| `DroidConnectionError` | The local connection failed |
+| `DroidProcessError` | The Droid process exited unexpectedly |
+| `DroidProtocolError` | Protocol negotiation or validation failed |
+
+Exception constructor metadata is public:
+
+| Exception | Additional constructor fields |
+| --- | --- |
+| `RunTimeoutError(message, ...)` | `request_id`, `method`, `timeout_duration` |
+| `SessionReplacedError(session_id, replacement_session_id)` | both session IDs |
+| `SessionReplacementError(session_id, replacement_session_id, ...)` | both IDs, `rollback_error`, `rollback_failed` |
+| `SessionNotFoundError(session_id)` | `session_id` |
+| `InvalidWorkingDirectoryError(cwd, message=None)` | `cwd` |
+| `DroidConnectionError(message, ...)` | `cwd`, `exec_path` |
+| `DroidProcessError(message, ...)` | `exit_code`, `signal` |
+| `DroidProtocolError(message, ...)` | `code`, `data` |
+
+## Runnable examples
+
+Run commands from the repository root:
+
+| Example | Command | Expected result |
+| --- | --- | --- |
+| Attachments | `uv run python examples/attachments.py` | Live image, text, and PDF turn |
+| Factory Router | `uv run python examples/factory_router.py` | Live routed turns with per-response model IDs |
+| Interaction helpers | `uv run python examples/interaction_helpers.py` | Offline typed responses |
+| Interactions | `uv run python examples/interactions.py` | Live permission/question turn |
+| Interactive session | `uv run python examples/interactive_session.py` | Two live turns sharing history |
+| Saved sessions | `uv run python examples/list_saved_sessions.py` | Local saved-session count |
+| Observability | `uv run python examples/observability.py` | Offline isolated sink counts |
+| One-shot run | `uv run python examples/one_shot.py` | Live one-turn result |
+| Resume | `uv run python examples/resume_session.py --session-id ID` | Live resumed turn |
+| SDK MCP | `uv run python examples/sdk_mcp.py` | Live in-process MCP result |
+| Session operations | `uv run python examples/session_operations.py` | Live settings, discovery, fork, and compact |
+| Stream events | `uv run python examples/stream_events.py` | Live tour of every stream event type |
+| Structured output | `uv run python examples/structured_output_model.py` | Live validated model output |
+
+Live examples require an authenticated local Droid CLI or `FACTORY_API_KEY`;
+every model call uses a finite timeout.
+
+## Known limitations
+
+- The SDK runs local Droid subprocess sessions only.
+- The API is asyncio-only.
+- Hooks are configured through Droid files, not Python callbacks.
+- Image URLs are not supported by the local runtime.
+- One session can run one turn at a time.

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -5,26 +5,40 @@ description: "Use the Factory Droid SDK for Python to build custom agents, workf
 keywords: ["Droid SDK", "Python", "agents", "automation", "MCP"]
 ---
 
-Install the package as `droid-sdk` and import it as `droid_sdk`.
+The Droid SDK lets you run the same agent harness that powers Factory's CLI, desktop application, and web platform from your own code. It manages conversation context, tool execution, permissions, streaming, model selection, and multi-step execution.
+
+Your application decides when Droid runs, which tools and models it can use, and what happens to the result.
 
 ## Overview
 
-The SDK runs a local `droid` subprocess and exposes two ways to run a turn:
+The Python SDK runs a local `droid` subprocess and provides one-shot runs, persistent sessions, streaming, and session discovery.
+
+### Choose an API
 
 | Goal | API |
 | --- | --- |
-| Run one turn and return its result | `await run(...)` |
-| Run turns in an existing session | `session.stream(...)` |
+| Run one prompt and return its result | `await run(...)` |
+| Keep context across prompts | `Session(...)` |
+| Continue a saved session | `Session.resume(...)` |
+| Find saved sessions | `await list_sessions(...)` |
 
 Use `Session` when prompts need shared history or session operations such as
 interruption, compaction, or rewind. There is no `session.run()`; every
 session turn goes through `stream()`.
 
+### What you can build
+
+Invoke Droid when a pull request opens, a support ticket is escalated, an incident is created, or scheduled repository maintenance is due. The agent does not need a chat interface.
+
 ## Install and authenticate
+
+Install the `droid-sdk` package and import it as `droid_sdk`:
 
 ```bash
 pip install droid-sdk
 ```
+
+The package provides an async API for running Droid locally.
 
 Requirements:
 
@@ -39,7 +53,7 @@ logs, or exception messages.
 
 ## Quick start
 
-### Run one turn
+### Run one prompt
 
 ```python
 import asyncio
@@ -95,41 +109,19 @@ The second turn includes context from the first. Exiting the session closes
 the subprocess and session-owned resources. See
 [Default stream types](#default-stream-types) for every yielded value.
 
-### Stream partial events
+## Core concepts
 
-```python
-from droid_sdk import Session, TextDelta
-
-async with Session() as session:
-    async with session.stream(
-        "Explain the failing test.",
-        include_partial_messages=True,
-    ) as stream:
-        async for event in stream:
-            if isinstance(event, TextDelta):
-                print(event.text, end="", flush=True)
-
-    print()
-    if not stream.result.success:
-        print(f"Turn ended: {stream.result.subtype}")
-```
-
-The default stream yields complete messages. Set
-`include_partial_messages=True` to add deltas and operational events. Both
-modes yield the terminal result and cache it in `stream.result`. See
-[Partial stream types](#partial-stream-types) for the complete event union.
-
-## Core contract
-
-### Sessions and turns
+### Session
 
 A `Session` owns conversation history, settings, a working directory, and one
 Droid connection. It accepts one active turn at a time.
 
+### Turn
+
 A turn begins with `session.stream(prompt)` and ends when the stream yields a
 `RunResult`. Create separate sessions for parallel work.
 
-### Results and exceptions
+### Result
 
 A turn's outcome is a value, not an exception: `RunSuccess`,
 `RunInterrupted`, or `RunFailure`. Interrupted turns, execution failures, and
@@ -137,7 +129,7 @@ structured-output failures do not raise. Failures in the machinery around a
 turn (setup, connection, process, protocol, timeout, and cancellation) raise
 exceptions.
 
-### Ownership
+### Ownership and cleanup
 
 | Object | Owner |
 | --- | --- |
@@ -161,136 +153,11 @@ models are immutable dataclasses.
 | Partial `session.stream(...)` | `RunStream[T, StreamEvent[T]]` |
 | `stream.result` | `RunResult[T]` |
 
-## Models
-
-Model IDs are strings because availability depends on account and
-organization policy. Omit `model` to use the configured default, which
-lives in `~/.factory/settings.json` under `sessionDefaultSettings`.
-An unknown model ID is rejected by the backend: the turn returns
-`RunFailure(subtype="error_during_execution")` with the rejection message
-in `error.message`.
-
-### Select a model
-
-```python
-from droid_sdk import ReasoningEffort, run
-
-result = await run(
-    "Review this repository.",
-    model="model-id",
-    reasoning_effort=ReasoningEffort.HIGH,
-)
-```
-
-Omit `reasoning_effort` to use the model default.
-
-Change the model for later turns:
-
-```python
-await session.update_settings(
-    model="model-id",
-    reasoning_effort=ReasoningEffort.HIGH,
-)
-```
-
-See [Update settings](#update-settings) for the full `update_settings()`
-contract.
-
-### Use the Factory Router
-
-The model ID `auto` selects the
-[Factory Router](/web/factory-router),
-which routes each task to the model with the best balance of quality,
-latency, and cost. Some product surfaces label it Auto Model; the model
-ID is `auto` everywhere.
-
-```python
-from droid_sdk import run
-
-result = await run("Review this repository.", model="auto")
-```
-
-Pin a session to the router the same way:
-
-```python
-async with Session(model="auto") as session:
-    ...
-```
-
-Move a live session onto the router:
-
-```python
-await session.update_settings(model="auto")
-```
-
-Omit `reasoning_effort`; the router chooses the effort along with the
-model and ignores a supplied value. `session.settings.model` reports
-`auto`; the underlying model can differ per response.
-
-The model ID `auto` is unrelated to `Mode.AUTO`, the default interaction
-mode, and to `Autonomy`, the permission level.
-
-#### See which model handled a response
-
-Assistant messages in the wire `create_message` notification carry the
-underlying model in `modelId`; `routerId` is `"auto"` when the router
-made the choice. High-level messages omit these fields. Subscribe with
-[`on_notification()`](#subscribe-to-raw-notifications):
-
-```python
-from collections.abc import Mapping
-
-
-def report_routing(notification: Mapping[str, object]) -> None:
-    message = notification.get("message")
-    if isinstance(message, Mapping) and message.get("role") == "assistant":
-        print(message.get("modelId"), message.get("routerId"))
-
-
-unsubscribe = session.on_notification(report_routing, type="create_message")
-```
-
-Wire payloads use camelCase keys and evolve server-side; treat absent
-keys as normal.
-
-### Configure mode-specific models
-
-```python
-from droid_sdk import Mode, ReasoningEffort, Session, SessionConfig
-
-config = SessionConfig(
-    mode=Mode.SPEC,
-    spec_model="model-id",
-    spec_reasoning_effort=ReasoningEffort.HIGH,
-)
-
-async with Session(model="model-id", config=config) as session:
-    async with session.stream("Draft an implementation plan.") as stream:
-        async for _ in stream:
-            pass
-```
-
-The primary model handles Auto turns. `spec_model` handles Spec turns.
-Switch modes on a live session with `enter_spec()` and `leave_spec()`; see
-[Modes](#modes).
-
-### Model configuration contract
-
-| Field | Type | Used by |
-| --- | --- | --- |
-| `model` | `str \| None` | `run()`, `Session`, `update_settings()` |
-| `reasoning_effort` | `ReasoningEffort \| None` | Same |
-| `spec_model` | `str \| None` | `SessionConfig`, `update_settings()` |
-| `spec_reasoning_effort` | `ReasoningEffort \| None` | Same |
-
-`None` uses the configured default. Setting a Spec field to `None` through
-`update_settings()` clears it.
-
 ## Sessions
 
 Use a session when turns share history.
 
-### Open a session
+### Create and use a session
 
 `Session` is lazy. It creates the subprocess and session on entry:
 
@@ -353,7 +220,7 @@ async with Session.resume(
     interactions=InteractionHandlers(on_question=answer),
     disabled_tools={"Execute"},
 ) as session:
-    async with session.stream("Continue the previous task.") as stream:
+    async with session.stream("Continue from the previous prompt.") as stream:
         async for _ in stream:
             pass
 ```
@@ -364,39 +231,6 @@ Get a session ID from `session.id`, `result.session_id`, or
 Resume restores conversation history, working directory, title, and settings;
 runtime concerns such as handlers and MCP servers must be attached again (see
 the table below). It does not accept a new working directory or model.
-
-### What persists
-
-| Restored | Attach again |
-| --- | --- |
-| Conversation history | Interaction handlers |
-| Working directory | Session-scoped MCP servers |
-| Title | Observability sinks |
-| Session settings | |
-
-### Open and close manually
-
-```python
-session = Session()
-await session.open()
-
-try:
-    async with session.stream("Review the project.") as stream:
-        async for _ in stream:
-            pass
-finally:
-    await session.close()
-```
-
-`open()` and `close()` are idempotent, but a closed session cannot be
-reopened. Calling an active method before `open()` raises
-`SessionNotOpenError`.
-
-Concurrent `open()` calls share one startup attempt. If one waiter is
-cancelled, startup continues for the others. Cancelling the final waiter
-cancels startup and completes resource cleanup before the session becomes
-retryable. `close()` racing startup waits for startup cleanup and leaves the
-session closed.
 
 ### Read session state
 
@@ -410,7 +244,7 @@ print(session.settings.mode)
 These properties are read-only. `settings` is an immutable snapshot, replaced
 when Droid reports a settings change.
 
-### Update settings
+### Update session settings
 
 ```python
 await session.update_settings(
@@ -452,19 +286,6 @@ await session.rename("Authentication review")
 
 `rename(title: str)` returns `None`.
 
-### Subscribe to raw notifications
-
-```python
-unsubscribe = session.on_notification(handle_notification, type="custom_type")
-try:
-    ...
-finally:
-    unsubscribe()
-```
-
-High-level streams ignore unknown notifications. `on_notification()` exposes
-them without creating a second client.
-
 ### List saved sessions
 
 ```python
@@ -479,75 +300,51 @@ Pass `all_workspaces=True` to list sessions across working directories.
 `list_sessions()` reads local files without starting Droid. Results are newest
 first. Timestamps are timezone-aware.
 
-### Session construction contract
+### What persists
 
-`Session(...)` accepts:
-
-| Argument | Type |
+| Restored | Attach again |
 | --- | --- |
-| `cwd` | `str \| Path \| None` |
-| `model` | `str \| None` |
-| `reasoning_effort` | `ReasoningEffort \| None` |
-| `config` | `SessionConfig \| None` |
-| `interactions` | `InteractionHandlers \| None` |
-| `runtime` | `Runtime \| None` |
-| `api_key` | `str \| None` |
+| Conversation history | Interaction handlers |
+| Working directory | Session-scoped MCP servers |
+| Title | Observability sinks |
+| Session settings | |
 
-`SessionConfig` fields:
+### Close sessions safely
 
-| Field | Type |
-| --- | --- |
-| `mode` | `Mode \| None` |
-| `autonomy` | `Autonomy \| None` |
-| `spec_model` | `str \| None` |
-| `spec_reasoning_effort` | `ReasoningEffort \| None` |
-| `mcp_servers` | `Sequence[McpServerConfig]` |
-| `machine_id` | `str \| None` |
-| `tags` | `Sequence[SessionTag]` |
-| `session_source` | `SessionSource \| None` |
-| `auto_reject_permission_requests` | `bool \| None` |
-| `disable_builtin_skills` | `bool \| None` |
-| `additional_tools` | `Iterable[str] \| None` |
-| `enabled_tools` | `Iterable[str] \| None` |
-| `disabled_tools` | `Iterable[str] \| None` |
-| `restrict_tools` | `Iterable[str] \| None` |
+```python
+session = Session()
+await session.open()
 
-`Session.resume(session_id, ...)` accepts only values that can be reattached:
+try:
+    async with session.stream("Review the project.") as stream:
+        async for _ in stream:
+            pass
+finally:
+    await session.close()
+```
 
-| Argument | Type |
-| --- | --- |
-| `session_id` | `str` |
-| `interactions` | `InteractionHandlers \| None` |
-| `mcp_servers` | `Sequence[McpServerConfig]` |
-| `runtime` | `Runtime \| None` |
-| `api_key` | `str \| None` |
-| `disabled_tools` | `Iterable[str] \| None` |
-| `auto_reject_permission_requests` | `bool \| None` |
-| `disable_builtin_skills` | `bool \| None` |
-| `session_source` | `SessionSource \| None` |
+`open()` and `close()` are idempotent, but a closed session cannot be
+reopened. Calling an active method before `open()` raises
+`SessionNotOpenError`.
 
-### Session state schemas
+Concurrent `open()` calls share one startup attempt. If one waiter is
+cancelled, startup continues for the others. Cancelling the final waiter
+cancels startup and completes resource cleanup before the session becomes
+retryable. `close()` racing startup waits for startup cleanup and leaves the
+session closed.
 
-| Type | Fields |
-| --- | --- |
-| `SessionSettings` | `model`, `reasoning_effort`, `mode`, `autonomy`, `spec_model`, `spec_reasoning_effort`, `tags`, `sandbox`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools` |
-| `SessionSettingsUpdate` | `model`, `reasoning_effort`, `mode`, `autonomy`, `spec_model`, `spec_reasoning_effort`, `tags`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools`, `compaction_threshold_check_enabled` |
-| `SandboxSettings` | `enabled: bool`, `mode: str \| None = None` |
-| `SessionTag` | `name`, `metadata` |
-| `SavedSession` | `id`, `title`, `owner`, `message_count`, `modified_at`, `created_at`, `cwd`, `is_favorite` |
+### Subscribe to raw notifications
 
-Every `SessionSettingsUpdate` field defaults to `None`. Its field types
-match the `update_settings()` table above.
+```python
+unsubscribe = session.on_notification(handle_notification, type="custom_type")
+try:
+    ...
+finally:
+    unsubscribe()
+```
 
-`list_sessions()` returns `list[SavedSession]`. Its filters are `cwd`,
-`all_workspaces`, and `limit`.
-
-`on_notification(callback, type=None)` passes
-`Mapping[str, object]` to the callback and returns an unsubscribe function.
-
-`SessionSource` requires `platform: SessionPlatform`; every other attribution
-field is optional and defaults to `None`. Required combinations are validated
-when converted to the wire protocol.
+High-level streams ignore unknown notifications. `on_notification()` exposes
+them without creating a second client.
 
 ## Streaming and results
 
@@ -565,7 +362,7 @@ Use top-level `run()` when only the result matters. Session turns always use
 | `timeout` | `float \| None` |
 | `include_partial_messages` | `bool` |
 
-### Complete messages by default
+### Complete messages
 
 ```python
 from droid_sdk import AssistantMessage
@@ -604,7 +401,29 @@ StreamMessage[T] = (
 
 Values appear in delivery order. `RunResult[T]` is always last.
 
-### Include partial events
+### Partial events
+
+```python
+from droid_sdk import Session, TextDelta
+
+async with Session() as session:
+    async with session.stream(
+        "Explain the failing test.",
+        include_partial_messages=True,
+    ) as stream:
+        async for event in stream:
+            if isinstance(event, TextDelta):
+                print(event.text, end="", flush=True)
+
+    print()
+    if not stream.result.success:
+        print(f"Turn ended: {stream.result.subtype}")
+```
+
+The default stream yields complete messages. Set
+`include_partial_messages=True` to add deltas and operational events. Both
+modes yield the terminal result and cache it in `stream.result`. See
+[Partial stream types](#partial-stream-types) for the complete event union.
 
 ```python
 from droid_sdk import RunResult, TextDelta
@@ -741,7 +560,7 @@ concatenate both.
 `stream.result.messages` is the ordered tuple of complete `Message` values
 emitted before the result. It excludes the result and partial events.
 
-### Read the result
+### Handle the result
 
 The terminal `RunResult` is yielded by the iterator and cached on the stream:
 
@@ -823,7 +642,7 @@ print(context.used, context.remaining, context.limit, context.accuracy)
 | `Usage` | `input_tokens`, `output_tokens`, `cache_creation_tokens`, `cache_read_tokens`, `thinking_tokens`, `factory_credits` |
 | `ContextUsage` | `used`, `remaining`, `limit`, `accuracy`, `updated_at` |
 
-### Failures and exceptions
+### Errors
 
 ```python
 async with session.stream("Run the tests.") as stream:
@@ -841,7 +660,7 @@ Setup, connection, process, protocol, and timeout failures raise
 `DroidError` subclasses. Python programming errors use normal built-in
 exceptions. `asyncio.CancelledError` is never wrapped.
 
-### Concurrency
+### Stream concurrency
 
 A session may have one active stream. Starting another raises
 `SessionBusyError`.
@@ -869,7 +688,7 @@ await session.interrupt()
 The active stream yields an interrupted result if its consumer remains
 attached. The session stays open.
 
-### Cancellation and early exit
+### Cancellation and interruption
 
 Cancelling the task running a turn sends a best-effort interrupt, releases the
 subscription, then re-raises `asyncio.CancelledError`.
@@ -888,9 +707,134 @@ guarantee immediate cleanup on `break`.
 `await stream.aclose()` explicitly interrupts and detaches an unfinished
 stream; it is idempotent.
 
+## Models
+
+Model IDs are strings because availability depends on account and
+organization policy. Omit `model` to use the configured default, which
+lives in `~/.factory/settings.json` under `sessionDefaultSettings`.
+An unknown model ID is rejected by the backend: the turn returns
+`RunFailure(subtype="error_during_execution")` with the rejection message
+in `error.message`.
+
+### Select a model
+
+```python
+from droid_sdk import ReasoningEffort, run
+
+result = await run(
+    "Review this repository.",
+    model="model-id",
+    reasoning_effort=ReasoningEffort.HIGH,
+)
+```
+
+Omit `reasoning_effort` to use the model default.
+
+Change the model for later turns:
+
+```python
+await session.update_settings(
+    model="model-id",
+    reasoning_effort=ReasoningEffort.HIGH,
+)
+```
+
+See [Update session settings](#update-session-settings) for the full `update_settings()`
+contract.
+
+### Use the Factory Router
+
+The model ID `auto` selects the
+[Factory Router](/web/factory-router),
+which routes each prompt to the model with the best balance of quality,
+latency, and cost. Some product surfaces label it Auto Model; the model
+ID is `auto` everywhere.
+
+```python
+from droid_sdk import run
+
+result = await run("Review this repository.", model="auto")
+```
+
+Pin a session to the router the same way:
+
+```python
+async with Session(model="auto") as session:
+    ...
+```
+
+Move a live session onto the router:
+
+```python
+await session.update_settings(model="auto")
+```
+
+Omit `reasoning_effort`; the router chooses the effort along with the
+model and ignores a supplied value. `session.settings.model` reports
+`auto`; the underlying model can differ per response.
+
+The model ID `auto` is unrelated to `Mode.AUTO`, the default interaction
+mode, and to `Autonomy`, the permission level.
+
+#### See which model handled a response
+
+Assistant messages in the wire `create_message` notification carry the
+underlying model in `modelId`; `routerId` is `"auto"` when the router
+made the choice. High-level messages omit these fields. Subscribe with
+[`on_notification()`](#subscribe-to-raw-notifications):
+
+```python
+from collections.abc import Mapping
+
+
+def report_routing(notification: Mapping[str, object]) -> None:
+    message = notification.get("message")
+    if isinstance(message, Mapping) and message.get("role") == "assistant":
+        print(message.get("modelId"), message.get("routerId"))
+
+
+unsubscribe = session.on_notification(report_routing, type="create_message")
+```
+
+Wire payloads use camelCase keys and evolve server-side; treat absent
+keys as normal.
+
+### Configure mode-specific models
+
+```python
+from droid_sdk import Mode, ReasoningEffort, Session, SessionConfig
+
+config = SessionConfig(
+    mode=Mode.SPEC,
+    spec_model="model-id",
+    spec_reasoning_effort=ReasoningEffort.HIGH,
+)
+
+async with Session(model="model-id", config=config) as session:
+    async with session.stream("Draft an implementation plan.") as stream:
+        async for _ in stream:
+            pass
+```
+
+The primary model handles Auto turns. `spec_model` handles Spec turns.
+Switch modes on a live session with `enter_spec()` and `leave_spec()`; see
+[Spec mode](#spec-mode).
+
+### Model configuration contract
+
+| Field | Type | Used by |
+| --- | --- | --- |
+| `model` | `str \| None` | `run()`, `Session`, `update_settings()` |
+| `reasoning_effort` | `ReasoningEffort \| None` | Same |
+| `spec_model` | `str \| None` | `SessionConfig`, `update_settings()` |
+| `spec_reasoning_effort` | `ReasoningEffort \| None` | Same |
+
+`None` uses the configured default. Setting a Spec field to `None` through
+`update_settings()` clears it.
+
 ## Inputs and outputs
 
-### Images and files
+### Images and documents
 
 Attach images and files to a turn with the `images` and `files` options:
 
@@ -938,7 +882,9 @@ PDFs to `MAX_PDF_ATTACHMENT_BYTES` (3 MiB).
 Wire payloads use canonical `mediaType` fields. The optional `mime` hint on
 text documents is forwarded with the document.
 
-### Return a Pydantic model
+### Structured output
+
+#### Return a Pydantic model
 
 ```python
 from typing import Literal
@@ -979,7 +925,7 @@ Missing or invalid output turns the result into `RunFailure` with subtype
 `error_structured_output`; the failure keeps the text, messages, usage, raw
 `structured_output`, and `output_validation_error` for inspection.
 
-### Use raw JSON Schema
+#### Use raw JSON Schema
 
 ```python
 from droid_sdk import JsonObject, JsonSchema, RunResult, run
@@ -1058,7 +1004,7 @@ config = SessionConfig(autonomy=Autonomy.LOW)
 
 Autonomy does not select Auto or Spec mode. `Mode` controls that.
 
-### Handle permission requests
+### Permission handler
 
 ```python
 from droid_sdk import (
@@ -1092,7 +1038,7 @@ An absent handler, an invalid response, or a handler exception cancels the
 request. Handler failures appear as `ErrorEvent` values; they do not raise
 through the active stream.
 
-### Answer questions from Droid
+### AskUser handler
 
 ```python
 from droid_sdk import QuestionRequest, QuestionResponse
@@ -1206,7 +1152,7 @@ questionnaire details. `ApplyPatchFile` requires `file_path`, `file_name`, and
 
 Only outcomes present in `PermissionRequest.options` are valid.
 
-### Control native tools
+### Tool controls
 
 ```python
 config = SessionConfig(
@@ -1240,7 +1186,7 @@ list, or tuple. Passing a bare string raises `TypeError`.
 | `ToolInfo` | `id`, `display_name`, `description`, `category`, `default_allowed`, `allowed` |
 | `ListToolsOptions` | `model`, `mode`, `autonomy`, `spec_model`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools`, `skip_permissions_unsafe` |
 
-## Tools and extensions
+## Extensions
 
 | Extension | Use it for |
 | --- | --- |
@@ -1515,14 +1461,12 @@ source with its attached policies and retires the detached successor. If
 source restoration fails, the SDK closes the connection rather than leaving
 an ambiguous owner.
 
-## Modes
-
-### Spec mode
+## Spec mode
 
 Spec mode lets Droid inspect a codebase and propose a plan without changing
 files.
 
-#### Enter Spec mode
+### Enter Spec mode
 
 ```python
 await session.enter_spec(
@@ -1533,7 +1477,7 @@ await session.enter_spec(
 
 Start directly in Spec mode with `SessionConfig(mode=Mode.SPEC)`.
 
-#### Leave without approving
+### Leave without approving a plan
 
 ```python
 await session.leave_spec()
@@ -1542,7 +1486,7 @@ await session.leave_spec()
 This changes the mode only. It does not approve the plan or start
 implementation.
 
-#### Approve a plan
+### Approve a plan
 
 Plan approval arrives through the permission handler:
 
@@ -1570,7 +1514,7 @@ Entering or leaving Spec mode only changes settings. Plan approval is an
 `ExitSpecModeAction` permission request, and only an offered
 `ToolConfirmationOutcome` is valid.
 
-## Operations
+## Observability and advanced APIs
 
 ### Observability
 
@@ -1637,7 +1581,30 @@ starts Droid.
 | `env` | `Mapping[str, str]` |
 | `observability` | `Observability \| None` |
 
-## API index
+## Examples
+
+Run commands from the repository root:
+
+| Example | Command | Expected result |
+| --- | --- | --- |
+| [Attachments](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/attachments.py) | `uv run python examples/attachments.py` | Live image, text, and PDF turn |
+| [Factory Router](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/factory_router.py) | `uv run python examples/factory_router.py` | Live routed turns with per-response model IDs |
+| [Interaction helpers](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/interaction_helpers.py) | `uv run python examples/interaction_helpers.py` | Offline typed responses |
+| [Interactions](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/interactions.py) | `uv run python examples/interactions.py` | Live permission/question turn |
+| [Interactive session](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/interactive_session.py) | `uv run python examples/interactive_session.py` | Two live turns sharing history |
+| [Saved sessions](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/list_saved_sessions.py) | `uv run python examples/list_saved_sessions.py` | Local saved-session count |
+| [Observability](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/observability.py) | `uv run python examples/observability.py` | Offline isolated sink counts |
+| [One-shot run](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/one_shot.py) | `uv run python examples/one_shot.py` | Live one-turn result |
+| [Resume](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/resume_session.py) | `uv run python examples/resume_session.py --session-id ID` | Live resumed turn |
+| [SDK MCP](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/sdk_mcp.py) | `uv run python examples/sdk_mcp.py` | Live in-process MCP result |
+| [Session operations](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/session_operations.py) | `uv run python examples/session_operations.py` | Live settings, discovery, fork, and compact |
+| [Stream events](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/stream_events.py) | `uv run python examples/stream_events.py` | Live tour of every stream event type |
+| [Structured output](https://github.com/Factory-AI/droid-sdk-python/blob/main/examples/structured_output_model.py) | `uv run python examples/structured_output_model.py` | Live validated model output |
+
+Live examples require an authenticated local Droid CLI or `FACTORY_API_KEY`;
+every model call uses a finite timeout.
+
+## API reference
 
 ### Root constants and supporting types
 
@@ -1788,28 +1755,77 @@ Exception constructor metadata is public:
 | `DroidProcessError(message, ...)` | `exit_code`, `signal` |
 | `DroidProtocolError(message, ...)` | `code`, `data` |
 
-## Runnable examples
+### Detailed session contracts
 
-Run commands from the repository root:
+#### Session construction contract
 
-| Example | Command | Expected result |
-| --- | --- | --- |
-| Attachments | `uv run python examples/attachments.py` | Live image, text, and PDF turn |
-| Factory Router | `uv run python examples/factory_router.py` | Live routed turns with per-response model IDs |
-| Interaction helpers | `uv run python examples/interaction_helpers.py` | Offline typed responses |
-| Interactions | `uv run python examples/interactions.py` | Live permission/question turn |
-| Interactive session | `uv run python examples/interactive_session.py` | Two live turns sharing history |
-| Saved sessions | `uv run python examples/list_saved_sessions.py` | Local saved-session count |
-| Observability | `uv run python examples/observability.py` | Offline isolated sink counts |
-| One-shot run | `uv run python examples/one_shot.py` | Live one-turn result |
-| Resume | `uv run python examples/resume_session.py --session-id ID` | Live resumed turn |
-| SDK MCP | `uv run python examples/sdk_mcp.py` | Live in-process MCP result |
-| Session operations | `uv run python examples/session_operations.py` | Live settings, discovery, fork, and compact |
-| Stream events | `uv run python examples/stream_events.py` | Live tour of every stream event type |
-| Structured output | `uv run python examples/structured_output_model.py` | Live validated model output |
+`Session(...)` accepts:
 
-Live examples require an authenticated local Droid CLI or `FACTORY_API_KEY`;
-every model call uses a finite timeout.
+| Argument | Type |
+| --- | --- |
+| `cwd` | `str \| Path \| None` |
+| `model` | `str \| None` |
+| `reasoning_effort` | `ReasoningEffort \| None` |
+| `config` | `SessionConfig \| None` |
+| `interactions` | `InteractionHandlers \| None` |
+| `runtime` | `Runtime \| None` |
+| `api_key` | `str \| None` |
+
+`SessionConfig` fields:
+
+| Field | Type |
+| --- | --- |
+| `mode` | `Mode \| None` |
+| `autonomy` | `Autonomy \| None` |
+| `spec_model` | `str \| None` |
+| `spec_reasoning_effort` | `ReasoningEffort \| None` |
+| `mcp_servers` | `Sequence[McpServerConfig]` |
+| `machine_id` | `str \| None` |
+| `tags` | `Sequence[SessionTag]` |
+| `session_source` | `SessionSource \| None` |
+| `auto_reject_permission_requests` | `bool \| None` |
+| `disable_builtin_skills` | `bool \| None` |
+| `additional_tools` | `Iterable[str] \| None` |
+| `enabled_tools` | `Iterable[str] \| None` |
+| `disabled_tools` | `Iterable[str] \| None` |
+| `restrict_tools` | `Iterable[str] \| None` |
+
+`Session.resume(session_id, ...)` accepts only values that can be reattached:
+
+| Argument | Type |
+| --- | --- |
+| `session_id` | `str` |
+| `interactions` | `InteractionHandlers \| None` |
+| `mcp_servers` | `Sequence[McpServerConfig]` |
+| `runtime` | `Runtime \| None` |
+| `api_key` | `str \| None` |
+| `disabled_tools` | `Iterable[str] \| None` |
+| `auto_reject_permission_requests` | `bool \| None` |
+| `disable_builtin_skills` | `bool \| None` |
+| `session_source` | `SessionSource \| None` |
+
+#### Session state schemas
+
+| Type | Fields |
+| --- | --- |
+| `SessionSettings` | `model`, `reasoning_effort`, `mode`, `autonomy`, `spec_model`, `spec_reasoning_effort`, `tags`, `sandbox`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools` |
+| `SessionSettingsUpdate` | `model`, `reasoning_effort`, `mode`, `autonomy`, `spec_model`, `spec_reasoning_effort`, `tags`, `additional_tools`, `enabled_tools`, `disabled_tools`, `restrict_tools`, `compaction_threshold_check_enabled` |
+| `SandboxSettings` | `enabled: bool`, `mode: str \| None = None` |
+| `SessionTag` | `name`, `metadata` |
+| `SavedSession` | `id`, `title`, `owner`, `message_count`, `modified_at`, `created_at`, `cwd`, `is_favorite` |
+
+Every `SessionSettingsUpdate` field defaults to `None`. Its field types
+match the `update_settings()` table above.
+
+`list_sessions()` returns `list[SavedSession]`. Its filters are `cwd`,
+`all_workspaces`, and `limit`.
+
+`on_notification(callback, type=None)` passes
+`Mapping[str, object]` to the callback and returns an unsubscribe function.
+
+`SessionSource` requires `platform: SessionPlatform`; every other attribution
+field is optional and defaults to `None`. Required combinations are validated
+when converted to the wire protocol.
 
 ## Known limitations
 

--- a/docs/sdk/typescript.mdx
+++ b/docs/sdk/typescript.mdx
@@ -5,18 +5,13 @@ description: "Use the Factory Droid SDK for TypeScript to build custom agents, w
 keywords: ["Droid SDK", "TypeScript", "Node.js", "agents", "automation", "MCP"]
 ---
 
-Use the Factory TypeScript SDK to run Droid from Node.js.
+The Droid SDK lets you run the same agent harness that powers Factory's CLI, desktop application, and web platform from your own code. It manages conversation context, tool execution, permissions, streaming, model selection, and multi-step execution.
 
-The public npm package is `@factory/droid-sdk`.
-
-This guide covers the high-level public API. The package's exported TypeScript
-declarations define the complete compile-time API.
+Your application decides when Droid runs, which tools and models it can use, and what happens to the result.
 
 ## Overview
 
-Import the SDK from `@factory/droid-sdk/node`. It starts a Droid CLI subprocess
-and provides session management, streaming, local session discovery, and
-in-process MCP tool APIs.
+The TypeScript SDK can start Droid as a Node.js subprocess or connect to an existing daemon. It provides one-shot runs, persistent sessions, streaming, local session discovery, and in-process MCP tools.
 
 ### Choose an API
 
@@ -30,13 +25,27 @@ in-process MCP tool APIs.
 Start with `run()` for one prompt. Use a session when later prompts need the
 same conversation history.
 
+### What you can build
+
+Invoke Droid when a pull request opens, a support ticket is escalated, an incident is created, or scheduled repository maintenance is due. The agent does not need a chat interface.
+
 ## Install and authenticate
 
-Install the package:
+Install the public npm package:
 
 ```bash
 npm install @factory/droid-sdk
 ```
+
+If your code imports Zod for structured output or SDK MCP tools, use Zod 3:
+
+```bash
+npm install zod@^3.24.0
+```
+
+Import Node.js APIs from `@factory/droid-sdk/node`. Browser and daemon clients
+are available from the root entrypoint. This guide covers the high-level public
+API; the exported TypeScript declarations define the complete compile-time API.
 
 The SDK requires Node.js 18 or later.
 
@@ -132,190 +141,6 @@ Cleanup depends on how the session was created.
 
 Use `finally` blocks so cleanup also runs after an error.
 
-## Models
-
-Model IDs are strings because availability depends on the account,
-organization policy, and daemon configuration. Omit `modelId` to use the Droid
-default.
-
-### Discover available models
-
-**Runtime: Node.js**
-
-```ts
-import { listModels } from '@factory/droid-sdk/node';
-
-const models = await listModels();
-const catalog = await listModels({ includeDisabled: true });
-```
-
-The Node helper starts a one-shot Droid process, requests the catalog without
-creating a session, and closes the process before returning.
-
-**Runtime: Daemon** (`droid` is a client returned by `connectToDaemon()`)
-
-```ts
-const models = await droid.models.list();
-const catalog = await droid.models.list({ includeDisabled: true });
-
-for (const model of models) {
-  console.log(model.id, model.supportedReasoningEfforts);
-}
-```
-
-`includeDisabled` defaults to `false`, so both APIs return only selectable
-models when options are omitted. When disabled models are requested, every
-disabled entry includes a `disabledReason` for display. Regular organization
-members cannot enable these models. An organization manager may be able to
-change the model policy or complete a required opt-in.
-
-Each available model includes:
-
-| Field                       | Meaning                                        |
-| --------------------------- | ---------------------------------------------- |
-| `id`                        | Value accepted by `modelId`                    |
-| `displayName`               | Full display name                              |
-| `shortDisplayName`          | Compact display name                           |
-| `modelProvider`             | Model provider                                 |
-| `supportedReasoningEfforts` | Reasoning levels accepted by the model         |
-| `defaultReasoningEffort`    | Reasoning level used when none is supplied     |
-| `isCustom`                  | Whether the model is user-configured           |
-| `disabled`                  | Whether policy prevents selecting the model    |
-| `disabledReason`            | Required explanation when `disabled` is `true` |
-| `noImageSupport`            | Whether image input is unavailable             |
-| `supportsImageGeneration`   | Whether the model can generate images          |
-| `kind`                      | Model or router classification, when present   |
-
-Other optional fields provide tier, token multiplier, and display badges.
-
-### Node and daemon discovery
-
-| Runtime | Discovery API         | Lifecycle                                |
-| ------- | --------------------- | ---------------------------------------- |
-| Node    | `listModels(options)` | Uses and closes a one-shot Droid process |
-| Daemon  | `droid.models.list()` | Reuses the connected daemon client       |
-
-Both APIs return the same `ModelInfo[]` type and include built-in models plus
-configured custom models.
-
-### Select a model
-
-Pass a configured model ID when creating a session or running one prompt.
-
-```ts
-import {
-  createSession,
-  DroidMessageType,
-  ReasoningEffort,
-} from '@factory/droid-sdk/node';
-
-const session = await createSession({
-  modelId: 'model-id',
-  reasoningEffort: ReasoningEffort.High,
-});
-
-try {
-  for await (const message of session.stream('Review this repository.')) {
-    if (message.type === DroidMessageType.Assistant) {
-      console.log(message.text);
-    }
-  }
-} finally {
-  await session.close();
-}
-```
-
-For an existing session, call `updateSettings()`:
-
-```ts
-await session.updateSettings({
-  modelId: 'model-id',
-  reasoningEffort: ReasoningEffort.High,
-});
-```
-
-Set `reasoningEffort` only to a level supported by the selected model. Omit it
-to use the model's configured default.
-
-### Use Auto Router
-
-Set `modelId` to `"auto"` to let Factory choose a model for each turn.
-
-```ts
-import { run } from '@factory/droid-sdk/node';
-
-const result = await run('Find the cause of the failing tests.', {
-  modelId: 'auto',
-});
-
-if (!result.success) {
-  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
-}
-
-console.log(result.text);
-```
-
-The selected model can change between turns. Choose a fixed model ID when runs must use the same model.
-
-### Choose a spec-mode model
-
-The primary model handles normal turns. The spec-mode model handles turns in
-spec mode.
-
-```ts
-import {
-  createSession,
-  DroidInteractionMode,
-  ReasoningEffort,
-} from '@factory/droid-sdk/node';
-
-const session = await createSession({
-  modelId: 'auto',
-  interactionMode: DroidInteractionMode.Spec,
-  specModeModelId: 'model-id',
-  specModeReasoningEffort: ReasoningEffort.High,
-});
-
-try {
-  for await (const _message of session.stream(
-    'Draft an implementation plan.'
-  )) {
-    // Consume messages.
-  }
-} finally {
-  await session.close();
-}
-```
-
-You can also choose the model when entering spec mode:
-
-```ts
-await session.enterSpecMode({
-  specModeModelId: 'model-id',
-  specModeReasoningEffort: ReasoningEffort.High,
-});
-```
-
-### Use a custom model
-
-Configure custom models in `~/.factory/settings.json`. See [Custom Models (BYOK)](/cli/byok/overview) for provider, credential, and model settings.
-
-After configuration, pass the custom model ID anywhere the SDK accepts `modelId`. The ID uses `custom:` followed by the configured `model` value.
-
-```ts
-import { run } from '@factory/droid-sdk/node';
-
-const result = await run('Summarize this repository.', {
-  modelId: 'custom:gpt-4o-mini',
-});
-
-if (!result.success) {
-  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
-}
-
-console.log(result.text);
-```
-
 ## Sessions
 
 Use a session when prompts need shared conversation history. A session owns its working directory, settings, and one active turn at a time.
@@ -347,8 +172,6 @@ try {
 
 The second turn uses context from the first. `cwd` defaults to `process.cwd()`. Model and reasoning defaults come from Droid settings.
 
-Runnable example:
-[`examples/node/multi-turn-session.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/multi-turn-session.ts)
 
 ### Resume a saved session
 
@@ -390,9 +213,8 @@ console.log(session.settings.interactionMode);
 
 `settings` is read-only. The SDK updates `settings` and `cwd` when Droid reports a change.
 
-Runnable example: [`examples/node/init-metadata.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/init-metadata.ts)
 
-### Update active-session settings
+### Update session settings
 
 Use `updateSettings()` for changes that should apply to later turns in the current session.
 
@@ -416,11 +238,11 @@ Updatable settings include:
 
 Interaction mode controls whether Droid operates normally in Auto mode or produces a read-only plan in Spec mode. Autonomy level controls which actions require approval while Droid is in Auto mode. Tool availability overrides can enable, disable, or restrict the tools available to the session.
 
-When only changing interaction modes, use `enterSpecMode()` and `exitSpecMode()` instead of setting `interactionMode` directly.
+Use `enterSpecMode()` to enter Spec mode. Return to Auto mode with
+`updateSettings({ interactionMode: DroidInteractionMode.Auto })`.
 
 The updated values are available through `session.settings`.
 
-Runnable example: [`examples/node/session-settings.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/session-settings.ts)
 
 ### Rename a session
 
@@ -430,8 +252,6 @@ Use `rename()` after the first turn to replace the generated title.
 await session.rename({ title: 'Authentication review' });
 ```
 
-Runnable example:
-[`examples/node/rename-session.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/rename-session.ts)
 
 ### List saved sessions
 
@@ -461,7 +281,6 @@ const sessions = await listSessions({
 
 Results are sorted by `modifiedTime`, newest first. Each item includes its ID, title, owner, message count, creation time, modification time, and working directory when available.
 
-Runnable example: [`examples/node/list-sessions.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/list-sessions.ts)
 
 ### What persists
 
@@ -530,7 +349,24 @@ Default message types:
 | `error`       | Runtime error event                  |
 | `result`      | Terminal `DroidResult`               |
 
-Runnable example: [`examples/node/session-stream.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/session-stream.ts)
+
+### Partial events
+
+Enable partial events only when the application needs live text, thinking, tool progress, token usage, or state updates.
+
+```ts
+for await (const event of session.stream('Explain the test failure.', {
+  includePartialMessages: true,
+})) {
+  if (event.type === DroidMessageType.AssistantTextDelta) {
+    process.stdout.write(event.text);
+  }
+}
+```
+
+Partial streams can also include thinking deltas, tool-call deltas, tool
+progress, token updates, permission results, settings changes, working-state
+changes, and MCP status.
 
 ### Handle the result
 
@@ -577,25 +413,6 @@ console.log(result.tokenUsage);
 
 `run()` returns the terminal result directly. When consuming `session.stream()`, handle the message whose type is `DroidMessageType.Result`.
 
-Runnable example: [`examples/node/result-metadata.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/result-metadata.ts)
-
-### Partial events
-
-Enable partial events only when the application needs live text, thinking, tool progress, token usage, or state updates.
-
-```ts
-for await (const event of session.stream('Explain the test failure.', {
-  includePartialMessages: true,
-})) {
-  if (event.type === DroidMessageType.AssistantTextDelta) {
-    process.stdout.write(event.text);
-  }
-}
-```
-
-Partial streams can also include thinking deltas, tool-call deltas, tool
-progress, token updates, permission results, settings changes, working-state
-changes, and MCP status.
 
 ### Token and context usage
 
@@ -730,16 +547,135 @@ receive the interrupted turn's terminal `DroidResult`.
 A session-level abort signal passed to `createSession()` closes the entire
 session when aborted.
 
-Runnable examples:
+## Models
 
-- [`examples/node/abort-session-stream.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/abort-session-stream.ts)
-- [`examples/node/interrupt-session.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/interrupt-session.ts)
+Model IDs are strings because availability depends on the account,
+organization policy, and daemon configuration. Omit `modelId` to use the Droid
+default.
+
+### Select a model
+
+Pass a configured model ID when creating a session or running one prompt.
+
+```ts
+import {
+  createSession,
+  DroidMessageType,
+  ReasoningEffort,
+} from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  modelId: 'model-id',
+  reasoningEffort: ReasoningEffort.High,
+});
+
+try {
+  for await (const message of session.stream('Review this repository.')) {
+    if (message.type === DroidMessageType.Assistant) {
+      console.log(message.text);
+    }
+  }
+} finally {
+  await session.close();
+}
+```
+
+For an existing session, call `updateSettings()`:
+
+```ts
+await session.updateSettings({
+  modelId: 'model-id',
+  reasoningEffort: ReasoningEffort.High,
+});
+```
+
+Set `reasoningEffort` only to a level supported by the selected model. Omit it
+to use the model's configured default.
+
+### Use the Factory Router
+
+Set `modelId` to `"auto"` to let Factory choose a model for each turn.
+
+```ts
+import { run } from '@factory/droid-sdk/node';
+
+const result = await run('Find the cause of the failing tests.', {
+  modelId: 'auto',
+});
+
+if (!result.success) {
+  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
+}
+
+console.log(result.text);
+```
+
+The selected model can change between turns. Choose a fixed model ID when runs must use the same model.
+
+### Configure mode-specific models
+
+The primary model handles normal turns. The spec-mode model handles turns in
+spec mode.
+
+```ts
+import {
+  createSession,
+  DroidInteractionMode,
+  ReasoningEffort,
+} from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  modelId: 'auto',
+  interactionMode: DroidInteractionMode.Spec,
+  specModeModelId: 'model-id',
+  specModeReasoningEffort: ReasoningEffort.High,
+});
+
+try {
+  for await (const _message of session.stream(
+    'Draft an implementation plan.'
+  )) {
+    // Consume messages.
+  }
+} finally {
+  await session.close();
+}
+```
+
+You can also choose the model when entering spec mode:
+
+```ts
+await session.enterSpecMode({
+  specModeModelId: 'model-id',
+  specModeReasoningEffort: ReasoningEffort.High,
+});
+```
+
+### Use a custom model
+
+Configure custom models in `~/.factory/settings.json`. See [Custom Models (BYOK)](/cli/byok/overview) for provider, credential, and model settings.
+
+After configuration, pass the custom model ID anywhere the SDK accepts `modelId`. The ID uses `custom:` followed by the configured `model` value.
+
+```ts
+import { run } from '@factory/droid-sdk/node';
+
+const result = await run('Summarize this repository.', {
+  modelId: 'custom:gpt-4o-mini',
+});
+
+if (!result.success) {
+  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
+}
+
+console.log(result.text);
+```
 
 ## Inputs and outputs
 
 Pass images, documents, or an output schema in the options for the turn that should use them. Both `run()` and `session.stream()` accept these options.
 
-### Images
+### Images and documents
 
 ```ts
 const result = await run('Describe this image.', {
@@ -755,9 +691,8 @@ const result = await run('Describe this image.', {
 
 `data` contains the base64-encoded image bytes. Supported media types are `image/jpeg`, `image/png`, `image/gif`, and `image/webp`.
 
-Runnable example: [`examples/node/image-attachment.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/image-attachment.ts)
 
-### Documents
+#### Documents
 
 ```ts
 const result = await run('Summarize this document.', {
@@ -822,7 +757,6 @@ Invalid or missing schema output normally produces a failed result with subtype 
 
 `structuredOutput` is typed as `unknown`, because a JSON Schema does not provide a TypeScript runtime validator. Check that it is present and validate or narrow its shape before reading fields or passing it to another system. A successful result can still omit structured output, so do not use `result.success` as the only check.
 
-Runnable example: [`examples/node/structured-output.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/structured-output.ts)
 
 ## Permissions and user input
 
@@ -887,8 +821,6 @@ const session = await createSession({
 
 The available outcomes vary by request. Returning an unavailable value, throwing from the handler, or omitting the handler cancels the request.
 
-Runnable example:
-[`examples/node/permission-handler.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/permission-handler.ts)
 
 ### AskUser handler
 
@@ -916,8 +848,6 @@ return { cancelled: true, answers: [] };
 
 Without a handler, AskUser requests are declined.
 
-Runnable example:
-[`examples/node/ask-user-elicitation.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/ask-user-elicitation.ts)
 
 ### Tool controls
 
@@ -946,9 +876,8 @@ for (const tool of tools) {
 The public SDK provides subtractive `disabledToolIds`. It does not expose a
 restrictive allowlist.
 
-Runnable example: [`examples/node/tool-controls.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/tool-controls.ts)
 
-## Tools and extensions
+## Extensions
 
 Use the extension that matches the job:
 
@@ -985,9 +914,10 @@ await session.setSkillDisabled({
 
 Skills can come from project, personal, built-in, or automation settings.
 
-### SDK MCP tools
+### In-process MCP tools
 
 Use `tool()` to define an in-process TypeScript function with a Zod input schema.
+The SDK and Droid CLI must use compatible Factory protocol versions.
 
 ```ts
 import { z } from 'zod';
@@ -1028,7 +958,6 @@ The SDK starts an authenticated loopback MCP server and closes it with the sessi
 Tool calls still follow the session's autonomy and permission rules.
 Attach SDK MCP servers again when resuming a saved session because they are runtime objects, not persisted session data.
 
-Runnable example: [`examples/node/sdk-mcp-tool.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/sdk-mcp-tool.ts)
 
 ### External MCP servers
 
@@ -1106,21 +1035,32 @@ for await (const message of session.stream('Run the tests.')) {
 
 The SDK exposes hook schemas and stream events, but it does not provide a programmatic hook-registration API.
 
-Runnable example: [`examples/node/hook-execution.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/hook-execution.ts)
 
 ## Session lifecycle
 
-### Replacement handles
+Fork, compact, and rewind return ready successor sessions and retire the source wrapper.
 
-`fork()` returns a ready successor handle. `compact()` and `rewind()` return
-outcome objects containing a ready successor in `session`. Each operation
-retires its source wrapper.
+### Fork
+
+`fork()` creates a new session from the current conversation.
 
 ```ts
 const forked = await session.fork();
+```
 
+### Compact
+
+`compact()` summarizes older conversation history and returns the successor in `session`.
+
+```ts
 const { session: compacted, removedCount } = await forked.compact();
+```
 
+### Rewind
+
+`rewind()` returns the conversation to an earlier message and can restore or delete files.
+
+```ts
 const {
   session: rewound,
   restoredCount,
@@ -1132,6 +1072,8 @@ const {
   forkTitle: 'Before the failed change',
 });
 ```
+
+### Successor ownership
 
 After a successful replacement, active operations on the source wrapper throw
 `SessionReplacedError`. Its `id`, `settings`, and `cwd` remain readable, and
@@ -1164,23 +1106,32 @@ await session.enterSpecMode({
 
 ### Leave without approving a plan
 
-Call `exitSpecMode()` to return the session to Auto mode without approving a plan or starting implementation:
+Call `updateSettings()` to return the session to Auto mode without approving a
+plan or starting implementation:
 
 ```ts
-await session.enterSpecMode();
+import { DroidInteractionMode } from '@factory/droid-sdk/node';
 
 // Return to Auto mode without approving or implementing the plan.
-await session.exitSpecMode();
+await session.updateSettings({
+  interactionMode: DroidInteractionMode.Auto,
+});
 ```
 
-`exitSpecMode()` changes the interaction mode only. It does not select a `ToolConfirmationOutcome` or approve an `ExitSpecMode` permission request.
+Changing the interaction mode does not select a `ToolConfirmationOutcome` or
+approve an `ExitSpecMode` permission request.
 
-The method is available on Node `DroidSession` handles returned by `createSession()`, `resumeSession()`, and replacement operations such as `fork()`, `compact()`, and `rewind()`. Daemon clients continue to change the mode with `droid.sessions.updateSettings()`.
+`updateSettings()` is available on Node `DroidSession` handles returned by
+`createSession()`, `resumeSession()`, and replacement operations such as
+`fork()`, `compact()`, and `rewind()`. Daemon clients use
+`droid.sessions.updateSettings()`.
 
 ### Approve a plan
 
 When the plan is ready, Droid sends an `ExitSpecMode` permission request. Its
-details contain the plan. Unlike calling `exitSpecMode()`, approving it with `ProceedOnce` accepts the completed plan, returns to Auto mode, and continues implementation in the same session:
+details contain the plan. Unlike changing the interaction mode with
+`updateSettings()`, approving it with `ProceedOnce` accepts the completed plan,
+returns to Auto mode, and continues implementation in the same session:
 
 ```ts
 import {
@@ -1229,10 +1180,8 @@ Return `Cancel` to reject the plan. The turn ends with an `interrupted` result, 
 
 Some `ExitSpecMode` requests offer `ProceedNewSession` variants. Return one of those offered values to hand implementation to a new session. Return only values present in the request's `options`.
 
-Runnable example:
-[`examples/node/enter-spec-mode.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/enter-spec-mode.ts)
 
-## Operations
+## Observability and advanced APIs
 
 ### Observability
 
@@ -1260,8 +1209,6 @@ The SDK excludes prompts, messages, tool inputs, raw output, and stack traces fr
 Process startup emits telemetry before the first turn, and `close()` emits a request log.
 To verify turn-specific logs, snapshot the count after creating the session and check it before closing.
 
-Runnable example:
-[`examples/node/observability.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/observability.ts)
 
 ### Low-level APIs
 
@@ -1286,6 +1233,29 @@ const unsubscribe = session.onNotification(
 unsubscribe();
 ```
 
+## Examples
+
+| Example | Demonstrates |
+| --- | --- |
+| [Multi-turn session](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/multi-turn-session.ts) | Keep context across prompts |
+| [Initialization metadata](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/init-metadata.ts) | Read session metadata after initialization |
+| [Session settings](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/session-settings.ts) | Read and update active-session settings |
+| [Rename a session](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/rename-session.ts) | Change a saved session's title |
+| [List sessions](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/list-sessions.ts) | Discover saved sessions |
+| [Session stream](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/session-stream.ts) | Consume complete stream messages |
+| [Result metadata](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/result-metadata.ts) | Inspect terminal result metadata |
+| [Abort a stream](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/abort-session-stream.ts) | Cancel a turn with an abort signal |
+| [Interrupt a session](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/interrupt-session.ts) | Request interruption during a turn |
+| [Image attachment](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/image-attachment.ts) | Send a local image with a prompt |
+| [Structured output](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/structured-output.ts) | Validate model output against a schema |
+| [Permission handler](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/permission-handler.ts) | Respond to tool permission requests |
+| [AskUser handler](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/ask-user-elicitation.ts) | Answer questions from Droid |
+| [Tool controls](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/tool-controls.ts) | Restrict and configure native tools |
+| [Enter Spec mode](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/enter-spec-mode.ts) | Plan before implementation |
+| [SDK MCP tool](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/sdk-mcp-tool.ts) | Define an in-process MCP tool |
+| [Hook execution](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/hook-execution.ts) | Observe configured hook events |
+| [Observability](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/observability.ts) | Capture SDK logs and telemetry |
+
 ## API reference
 
 ### Entrypoint
@@ -1300,7 +1270,6 @@ Import functions, classes, enums, and types from `@factory/droid-sdk/node`.
 | `createSession(options?)`            | `Promise<DroidSession>`      |
 | `resumeSession(sessionId, options?)` | `Promise<DroidSession>`      |
 | `listSessions(options?)`             | `Promise<SessionMetadata[]>` |
-| `listModels(options?)`               | `Promise<ModelInfo[]>`       |
 | `createSdkMcpServer(options)`        | `SdkMcpServer`               |
 | `tool(...)`                          | `DroidTool`                  |
 
@@ -1315,7 +1284,6 @@ Import functions, classes, enums, and types from `@factory/droid-sdk/node`.
 | `interrupt()`             | Stop the active turn                         |
 | `updateSettings()`        | Update session settings                      |
 | `enterSpecMode()`         | Change to spec mode                          |
-| `exitSpecMode()`          | Return to Auto mode without approving a plan |
 | `listTools()`             | List normalized tools                        |
 | `listSkills()`            | List skills                                  |
 | `setSkillDisabled()`      | Enable or disable a skill                    |
@@ -1334,7 +1302,7 @@ Import functions, classes, enums, and types from `@factory/droid-sdk/node`.
 | `onNotification()`        | Subscribe to raw notifications               |
 | `close()`                 | Close the session and owned resources        |
 
-### Stream and model types
+### Stream types
 
 | Type                 | Purpose                                           |
 | -------------------- | ------------------------------------------------- |
@@ -1343,7 +1311,6 @@ Import functions, classes, enums, and types from `@factory/droid-sdk/node`.
 | `DroidResult`        | Terminal result returned by `run()`               |
 | `DroidMessageType`   | Runtime constants for narrowing stream messages   |
 | `TokenUsage`         | Token counts and optional Factory Service Credits |
-| `ModelInfo`          | Model catalog entry returned by discovery APIs    |
 
 `session.stream()` yields `DroidStreamMessage` by default and `DroidStreamEvent` when `includePartialMessages` is `true`.
 
@@ -1389,3 +1356,5 @@ Model IDs and tool IDs are strings rather than closed enums.
 ## Known limitations
 
 - New-session spec handoff IDs require raw notification inspection.
+- SDK MCP tools require compatible protocol versions in the npm package and
+  Droid CLI.

--- a/docs/sdk/typescript.mdx
+++ b/docs/sdk/typescript.mdx
@@ -1,0 +1,1391 @@
+---
+title: "Droid TypeScript SDK"
+sidebarTitle: "TypeScript"
+description: "Use the Factory Droid SDK for TypeScript to build custom agents, workflows, and product integrations."
+keywords: ["Droid SDK", "TypeScript", "Node.js", "agents", "automation", "MCP"]
+---
+
+Use the Factory TypeScript SDK to run Droid from Node.js.
+
+The public npm package is `@factory/droid-sdk`.
+
+This guide covers the high-level public API. The package's exported TypeScript
+declarations define the complete compile-time API.
+
+## Overview
+
+Import the SDK from `@factory/droid-sdk/node`. It starts a Droid CLI subprocess
+and provides session management, streaming, local session discovery, and
+in-process MCP tool APIs.
+
+### Choose an API
+
+| Goal                                    | API               |
+| --------------------------------------- | ----------------- |
+| Run one prompt and get the final result | `run()`           |
+| Keep context across prompts             | `createSession()` |
+| Continue a saved session                | `resumeSession()` |
+| Find saved sessions                     | `listSessions()`  |
+
+Start with `run()` for one prompt. Use a session when later prompts need the
+same conversation history.
+
+## Install and authenticate
+
+Install the package:
+
+```bash
+npm install @factory/droid-sdk
+```
+
+The SDK requires Node.js 18 or later.
+
+By default, the SDK starts the `droid` CLI from `PATH`. Pass `execPath` to use a
+different `droid` executable.
+
+Set an API key:
+
+```bash
+export FACTORY_API_KEY="your-key"
+```
+
+The SDK reads `FACTORY_API_KEY` from the process environment by default. You
+can also pass `apiKey` to `run()`, `createSession()`, or `resumeSession()`.
+
+## Quick start
+
+### Run one prompt
+
+```ts
+import { run } from '@factory/droid-sdk/node';
+
+const result = await run('Summarize this repository.');
+
+if (!result.success) {
+  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
+}
+
+console.log(result.text);
+```
+
+`run()` creates a session, consumes its complete message stream, returns the
+terminal `DroidResult`, and closes the session.
+
+### Continue a conversation
+
+```ts
+import { createSession, DroidMessageType } from '@factory/droid-sdk/node';
+
+const session = await createSession();
+
+try {
+  for await (const message of session.stream('What does this project do?')) {
+    if (message.type === DroidMessageType.Assistant) {
+      console.log(message.text);
+    }
+  }
+
+  for await (const message of session.stream('What should I test first?')) {
+    if (message.type === DroidMessageType.Assistant) {
+      console.log(message.text);
+    }
+  }
+} finally {
+  await session.close();
+}
+```
+
+In the above example, the second prompt uses context from the first turn.
+Remember to close sessions that your code creates.
+
+## Core concepts
+
+### Session
+
+A session holds conversation history, settings, and a working directory. Create
+one with `createSession()` or load a saved session with `resumeSession()`.
+
+### Turn
+
+A turn starts when you send one prompt with `session.stream()`. A session can
+run one turn at a time.
+
+### Stream message
+
+`session.stream()` returns an async iterable of complete messages. Narrow each
+message by its `type`. Messages can report user input, assistant output, tool
+activity, hooks, errors, and a terminal `DroidResult`.
+
+### Result
+
+A normally completed turn ends with a `DroidResult`. `run()` consumes the stream and returns that same result type. See [Streaming and results](#streaming-and-results) for result handling, errors, token usage, and cancellation.
+
+### Ownership and cleanup
+
+Cleanup depends on how the session was created.
+
+| API               | Cleanup                          |
+| ----------------- | -------------------------------- |
+| `run()`           | Closes its session automatically |
+| `createSession()` | Call `await session.close()`     |
+| `resumeSession()` | Call `await session.close()`     |
+
+Use `finally` blocks so cleanup also runs after an error.
+
+## Models
+
+Model IDs are strings because availability depends on the account,
+organization policy, and daemon configuration. Omit `modelId` to use the Droid
+default.
+
+### Discover available models
+
+**Runtime: Node.js**
+
+```ts
+import { listModels } from '@factory/droid-sdk/node';
+
+const models = await listModels();
+const catalog = await listModels({ includeDisabled: true });
+```
+
+The Node helper starts a one-shot Droid process, requests the catalog without
+creating a session, and closes the process before returning.
+
+**Runtime: Daemon** (`droid` is a client returned by `connectToDaemon()`)
+
+```ts
+const models = await droid.models.list();
+const catalog = await droid.models.list({ includeDisabled: true });
+
+for (const model of models) {
+  console.log(model.id, model.supportedReasoningEfforts);
+}
+```
+
+`includeDisabled` defaults to `false`, so both APIs return only selectable
+models when options are omitted. When disabled models are requested, every
+disabled entry includes a `disabledReason` for display. Regular organization
+members cannot enable these models. An organization manager may be able to
+change the model policy or complete a required opt-in.
+
+Each available model includes:
+
+| Field                       | Meaning                                        |
+| --------------------------- | ---------------------------------------------- |
+| `id`                        | Value accepted by `modelId`                    |
+| `displayName`               | Full display name                              |
+| `shortDisplayName`          | Compact display name                           |
+| `modelProvider`             | Model provider                                 |
+| `supportedReasoningEfforts` | Reasoning levels accepted by the model         |
+| `defaultReasoningEffort`    | Reasoning level used when none is supplied     |
+| `isCustom`                  | Whether the model is user-configured           |
+| `disabled`                  | Whether policy prevents selecting the model    |
+| `disabledReason`            | Required explanation when `disabled` is `true` |
+| `noImageSupport`            | Whether image input is unavailable             |
+| `supportsImageGeneration`   | Whether the model can generate images          |
+| `kind`                      | Model or router classification, when present   |
+
+Other optional fields provide tier, token multiplier, and display badges.
+
+### Node and daemon discovery
+
+| Runtime | Discovery API         | Lifecycle                                |
+| ------- | --------------------- | ---------------------------------------- |
+| Node    | `listModels(options)` | Uses and closes a one-shot Droid process |
+| Daemon  | `droid.models.list()` | Reuses the connected daemon client       |
+
+Both APIs return the same `ModelInfo[]` type and include built-in models plus
+configured custom models.
+
+### Select a model
+
+Pass a configured model ID when creating a session or running one prompt.
+
+```ts
+import {
+  createSession,
+  DroidMessageType,
+  ReasoningEffort,
+} from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  modelId: 'model-id',
+  reasoningEffort: ReasoningEffort.High,
+});
+
+try {
+  for await (const message of session.stream('Review this repository.')) {
+    if (message.type === DroidMessageType.Assistant) {
+      console.log(message.text);
+    }
+  }
+} finally {
+  await session.close();
+}
+```
+
+For an existing session, call `updateSettings()`:
+
+```ts
+await session.updateSettings({
+  modelId: 'model-id',
+  reasoningEffort: ReasoningEffort.High,
+});
+```
+
+Set `reasoningEffort` only to a level supported by the selected model. Omit it
+to use the model's configured default.
+
+### Use Auto Router
+
+Set `modelId` to `"auto"` to let Factory choose a model for each turn.
+
+```ts
+import { run } from '@factory/droid-sdk/node';
+
+const result = await run('Find the cause of the failing tests.', {
+  modelId: 'auto',
+});
+
+if (!result.success) {
+  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
+}
+
+console.log(result.text);
+```
+
+The selected model can change between turns. Choose a fixed model ID when runs must use the same model.
+
+### Choose a spec-mode model
+
+The primary model handles normal turns. The spec-mode model handles turns in
+spec mode.
+
+```ts
+import {
+  createSession,
+  DroidInteractionMode,
+  ReasoningEffort,
+} from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  modelId: 'auto',
+  interactionMode: DroidInteractionMode.Spec,
+  specModeModelId: 'model-id',
+  specModeReasoningEffort: ReasoningEffort.High,
+});
+
+try {
+  for await (const _message of session.stream(
+    'Draft an implementation plan.'
+  )) {
+    // Consume messages.
+  }
+} finally {
+  await session.close();
+}
+```
+
+You can also choose the model when entering spec mode:
+
+```ts
+await session.enterSpecMode({
+  specModeModelId: 'model-id',
+  specModeReasoningEffort: ReasoningEffort.High,
+});
+```
+
+### Use a custom model
+
+Configure custom models in `~/.factory/settings.json`. See [Custom Models (BYOK)](/cli/byok/overview) for provider, credential, and model settings.
+
+After configuration, pass the custom model ID anywhere the SDK accepts `modelId`. The ID uses `custom:` followed by the configured `model` value.
+
+```ts
+import { run } from '@factory/droid-sdk/node';
+
+const result = await run('Summarize this repository.', {
+  modelId: 'custom:gpt-4o-mini',
+});
+
+if (!result.success) {
+  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
+}
+
+console.log(result.text);
+```
+
+## Sessions
+
+Use a session when prompts need shared conversation history. A session owns its working directory, settings, and one active turn at a time.
+
+### Create and use a session
+
+```ts
+import { createSession, DroidMessageType } from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  cwd: process.cwd(),
+});
+
+async function send(prompt: string) {
+  for await (const message of session.stream(prompt)) {
+    if (message.type === DroidMessageType.Assistant) {
+      console.log(message.text);
+    }
+  }
+}
+
+try {
+  await send('What does this project do?');
+  await send('What should I test first?');
+} finally {
+  await session.close();
+}
+```
+
+The second turn uses context from the first. `cwd` defaults to `process.cwd()`. Model and reasoning defaults come from Droid settings.
+
+Runnable example:
+[`examples/node/multi-turn-session.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/multi-turn-session.ts)
+
+### Resume a saved session
+
+```ts
+import { DroidMessageType, resumeSession } from '@factory/droid-sdk/node';
+
+async function continueSession(sessionId: string) {
+  const session = await resumeSession(sessionId);
+
+  try {
+    for await (const message of session.stream(
+      'Continue from the last conversation.'
+    )) {
+      if (message.type === DroidMessageType.Assistant) {
+        console.log(message.text);
+      }
+    }
+  } finally {
+    await session.close();
+  }
+}
+```
+
+`resumeSession()` restores the saved conversation, working directory, and session settings. It does not accept `cwd`, `modelId`, or reasoning options.
+
+Resume options can provide new permission and AskUser handlers, disabled tools, MCP servers, an abort signal, and observability sinks.
+
+### Read session state
+
+Each handle exposes its ID, current working directory, and current settings.
+
+```ts
+console.log(session.id);
+console.log(session.cwd);
+console.log(session.settings.modelId);
+console.log(session.settings.reasoningEffort);
+console.log(session.settings.interactionMode);
+```
+
+`settings` is read-only. The SDK updates `settings` and `cwd` when Droid reports a change.
+
+Runnable example: [`examples/node/init-metadata.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/init-metadata.ts)
+
+### Update active-session settings
+
+Use `updateSettings()` for changes that should apply to later turns in the current session.
+
+```ts
+import { AutonomyLevel, ReasoningEffort } from '@factory/droid-sdk/node';
+
+await session.updateSettings({
+  modelId: 'model-id',
+  reasoningEffort: ReasoningEffort.High,
+  autonomyLevel: AutonomyLevel.Low,
+  disabledToolIds: ['Execute'],
+});
+```
+
+Updatable settings include:
+
+- model and reasoning effort
+- interaction mode and autonomy level
+- spec-mode model settings
+- tool availability overrides
+
+Interaction mode controls whether Droid operates normally in Auto mode or produces a read-only plan in Spec mode. Autonomy level controls which actions require approval while Droid is in Auto mode. Tool availability overrides can enable, disable, or restrict the tools available to the session.
+
+When only changing interaction modes, use `enterSpecMode()` and `exitSpecMode()` instead of setting `interactionMode` directly.
+
+The updated values are available through `session.settings`.
+
+Runnable example: [`examples/node/session-settings.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/session-settings.ts)
+
+### Rename a session
+
+Use `rename()` after the first turn to replace the generated title.
+
+```ts
+await session.rename({ title: 'Authentication review' });
+```
+
+Runnable example:
+[`examples/node/rename-session.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/rename-session.ts)
+
+### List saved sessions
+
+`listSessions()` reads local Droid session storage. It does not start Droid or
+call the Factory API.
+
+List sessions for the current working directory:
+
+```ts
+import { listSessions } from '@factory/droid-sdk/node';
+
+const sessions = await listSessions({ limit: 10 });
+
+for (const session of sessions) {
+  console.log(session.id, session.title, session.modifiedTime);
+}
+```
+
+List sessions across all working directories:
+
+```ts
+const sessions = await listSessions({
+  fetchOutsideCWD: true,
+  limit: 10,
+});
+```
+
+Results are sorted by `modifiedTime`, newest first. Each item includes its ID, title, owner, message count, creation time, modification time, and working directory when available.
+
+Runnable example: [`examples/node/list-sessions.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/list-sessions.ts)
+
+### What persists
+
+Droid saves the session data needed to continue later.
+
+| Restored from the saved session | Attach again when resuming |
+| ------------------------------- | -------------------------- |
+| Conversation history            | Permission handler         |
+| Working directory               | AskUser handler            |
+| Title                           | SDK MCP servers            |
+| Session settings                | Observability sinks        |
+|                                 | Abort signal               |
+
+Session settings include model, reasoning, Auto or Spec interaction mode, autonomy, spec-mode model settings, and tool availability overrides.
+
+Handlers, observability sinks, abort signals, and SDK MCP servers are runtime objects. Droid cannot serialize them with the session, so attach them again when calling `resumeSession()`. They do not need to be the same object instances or implementations used when the session was created.
+
+### Close sessions safely
+
+Call `close()` in `finally` when your code creates or resumes a session.
+Closing releases the subprocess, subscriptions, and SDK-owned MCP servers.
+
+```ts
+const session = await createSession();
+
+try {
+  // Use the session.
+} finally {
+  await session.close();
+}
+```
+
+## Streaming and results
+
+Each call to `session.stream()` starts one turn and returns an async iterable.
+
+By default, it yields complete messages and ends with a terminal `DroidResult`.
+
+### Complete messages
+
+```ts
+for await (const message of session.stream('Find the failing test.')) {
+  switch (message.type) {
+    case DroidMessageType.Assistant:
+      console.log(message.text);
+      break;
+    case DroidMessageType.ToolCall:
+      console.log(`Tool: ${message.name}`);
+      break;
+    case DroidMessageType.Result:
+      console.log(message.subtype);
+      break;
+  }
+}
+```
+
+Default message types:
+
+| Type          | Purpose                              |
+| ------------- | ------------------------------------ |
+| `assistant`   | Complete assistant message           |
+| `user`        | User message recorded by the session |
+| `tool_call`   | Complete tool request                |
+| `tool_result` | Complete tool result                 |
+| `hook`        | Hook execution                       |
+| `error`       | Runtime error event                  |
+| `result`      | Terminal `DroidResult`               |
+
+Runnable example: [`examples/node/session-stream.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/session-stream.ts)
+
+### Handle the result
+
+`DroidResult` is a discriminated union. Check `subtype` or `success` before using the response.
+
+```ts
+const result = await run('Run the test suite.');
+
+switch (result.subtype) {
+  case 'success':
+    console.log(result.text);
+    break;
+  case 'interrupted':
+    console.log('The run was interrupted.');
+    break;
+  case 'error_during_execution':
+  case 'error_structured_output':
+    console.error(
+      result.structuredOutputError?.message ??
+        result.error?.message ??
+        'Unknown error'
+    );
+    break;
+}
+```
+
+| Subtype                   | Meaning                                           |
+| ------------------------- | ------------------------------------------------- |
+| `success`                 | The turn completed successfully                   |
+| `interrupted`             | The turn was cancelled or permission declined     |
+| `error_during_execution`  | Droid could not complete the requested work       |
+| `error_structured_output` | Structured-output generation or validation failed |
+
+Every result includes:
+
+```ts
+console.log(result.sessionId);
+console.log(result.durationMs);
+console.log(result.turnCount);
+console.log(result.messages);
+console.log(result.text);
+console.log(result.tokenUsage);
+```
+
+`run()` returns the terminal result directly. When consuming `session.stream()`, handle the message whose type is `DroidMessageType.Result`.
+
+Runnable example: [`examples/node/result-metadata.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/result-metadata.ts)
+
+### Partial events
+
+Enable partial events only when the application needs live text, thinking, tool progress, token usage, or state updates.
+
+```ts
+for await (const event of session.stream('Explain the test failure.', {
+  includePartialMessages: true,
+})) {
+  if (event.type === DroidMessageType.AssistantTextDelta) {
+    process.stdout.write(event.text);
+  }
+}
+```
+
+Partial streams can also include thinking deltas, tool-call deltas, tool
+progress, token updates, permission results, settings changes, working-state
+changes, and MCP status.
+
+### Token and context usage
+
+`DroidResult.tokenUsage` reports raw token counts for the current SDK turn and,
+when available, the Factory Service Credits (FSC) charged for that turn. One
+turn is one `run()` or `session.stream()` call. This is not the session's
+lifetime total.
+
+```ts
+if (result.tokenUsage) {
+  console.log(`input: ${result.tokenUsage.inputTokens}`);
+  console.log(`output: ${result.tokenUsage.outputTokens}`);
+  console.log(`cache read: ${result.tokenUsage.cacheReadTokens}`);
+  console.log(`cache created: ${result.tokenUsage.cacheCreationTokens}`);
+  if (result.tokenUsage.factoryCredits !== undefined) {
+    console.log(`Factory Service Credits: ${result.tokenUsage.factoryCredits}`);
+  }
+}
+```
+
+| Field                 | What it measures during the turn                                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `inputTokens`         | Provider-reported input across model calls, which can include instructions, tools, conversation history, and the latest message |
+| `outputTokens`        | Output generated across model calls, not only the final visible response                                                        |
+| `cacheReadTokens`     | Input tokens reused from the prompt cache                                                                                       |
+| `cacheCreationTokens` | Input tokens written to the prompt cache                                                                                        |
+| `thinkingTokens`      | Reasoning tokens reported separately when available                                                                             |
+| `factoryCredits`      | Factory Service Credits charged, when available                                                                                 |
+
+One turn can make several model calls while Droid uses tools. Their usage is combined in the result, along with usage from delegated work. Earlier conversation can be counted again when it is included as input to a later turn. Cached input is also reported through the separate cache fields. `tokenUsage` is `null` when usage is unavailable.
+
+Partial streams can emit `DroidMessageType.TokenUsageUpdate`. Unlike the per-turn result, these events contain cumulative committed usage for the session.
+
+`getContextStats()` measures current context occupancy, not cumulative token usage:
+
+```ts
+const stats = await session.getContextStats();
+
+console.log(stats.used, stats.remaining, stats.limit, stats.accuracy);
+```
+
+| Field       | Meaning                                                                                               |
+| ----------- | ----------------------------------------------------------------------------------------------------- |
+| `used`      | Estimated tokens currently occupied by prompts, tools, instructions, and conversation history         |
+| `limit`     | Active model's maximum input window; unresolved model IDs fall back to the effective compaction limit |
+| `remaining` | `Math.max(0, limit - used)`                                                                           |
+| `accuracy`  | Currently `estimated`, because Droid approximates tokens from character counts                        |
+
+`remaining` estimates room in the model's input window. It does not
+necessarily mean tokens remaining before compaction. Droid can compact at a
+lower configured threshold, commonly 250,000 tokens, even when the active
+model's input window is larger.
+
+### Errors
+
+An error event and a thrown exception mean different things:
+
+- An `error` message reports a runtime problem during the turn. A terminal `DroidResult` normally follows and describes the final outcome.
+- A failed `DroidResult` means the stream completed, but the requested work or structured output failed.
+- A thrown exception means the SDK operation itself could not finish, such as an abort, connection failure, protocol error, or concurrent stream attempt.
+
+Handle stream exceptions around the iteration:
+
+```ts
+try {
+  for await (const message of session.stream('Run the tests.')) {
+    if (message.type === DroidMessageType.Error) {
+      console.error(message.message);
+    }
+  }
+} catch (error) {
+  console.error('The stream could not finish:', error);
+}
+```
+
+`run()` follows the same distinction: agent failures are returned as failed results, while setup, transport, protocol, and abort failures are thrown.
+
+### Stream concurrency
+
+One session handle can have one active stream. Starting another active stream
+throws `ConcurrentStreamError`.
+
+### Cancellation and interruption
+
+Use an abort signal to cancel one turn:
+
+```ts
+const controller = new AbortController();
+
+setTimeout(
+  () => controller.abort(new Error('Timed out after 5 seconds')),
+  5_000
+);
+
+for await (const message of session.stream('Perform a long review.', {
+  abortSignal: controller.signal,
+})) {
+  // Handle messages.
+}
+```
+
+The stream interrupts the active turn and throws the abort reason.
+
+Use `session.interrupt()` when another part of the application needs to stop
+the active turn:
+
+```ts
+await session.interrupt();
+```
+
+The stream normally continues to a terminal result with subtype `interrupted`.
+The session remains available for later prompts.
+
+Breaking out of the stream also interrupts the active turn:
+
+```ts
+for await (const message of session.stream('Investigate every failing test.')) {
+  if (message.type === DroidMessageType.Assistant) {
+    console.log(message.text);
+
+    // Interrupt this turn instead of merely hiding its remaining output.
+    break;
+  }
+}
+```
+
+Breaking out of the loop before the turn finishes sends an interrupt request
+to Droid. This cancels the remaining model and tool work for that turn. The
+session remains open and can accept another prompt, but this loop does not
+receive the interrupted turn's terminal `DroidResult`.
+
+A session-level abort signal passed to `createSession()` closes the entire
+session when aborted.
+
+Runnable examples:
+
+- [`examples/node/abort-session-stream.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/abort-session-stream.ts)
+- [`examples/node/interrupt-session.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/interrupt-session.ts)
+
+## Inputs and outputs
+
+Pass images, documents, or an output schema in the options for the turn that should use them. Both `run()` and `session.stream()` accept these options.
+
+### Images
+
+```ts
+const result = await run('Describe this image.', {
+  images: [
+    {
+      type: 'base64',
+      data: base64Png,
+      mediaType: 'image/png',
+    },
+  ],
+});
+```
+
+`data` contains the base64-encoded image bytes. Supported media types are `image/jpeg`, `image/png`, `image/gif`, and `image/webp`.
+
+Runnable example: [`examples/node/image-attachment.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/image-attachment.ts)
+
+### Documents
+
+```ts
+const result = await run('Summarize this document.', {
+  files: [
+    {
+      type: 'text',
+      mediaType: 'text/plain',
+      data: report,
+      name: 'report.txt',
+    },
+  ],
+});
+```
+
+Document inputs support:
+
+| Source       | `type`   | `mediaType`       | `data`                        |
+| ------------ | -------- | ----------------- | ----------------------------- |
+| Plain text   | `text`   | `text/plain`      | The document text             |
+| PDF document | `base64` | `application/pdf` | Base64-encoded PDF file bytes |
+
+`name` is optional for both forms. Attach content through `data`; a filesystem path by itself is not a document upload.
+
+### Structured output
+
+Use `outputFormat` when another system needs a JSON object that follows a schema.
+
+```ts
+import { OutputFormatType, run } from '@factory/droid-sdk/node';
+
+const result = await run('Return the repository name and test command.', {
+  outputFormat: {
+    type: OutputFormatType.JsonSchema,
+    schema: {
+      type: 'object',
+      properties: {
+        repository: { type: 'string' },
+        testCommand: { type: 'string' },
+      },
+      required: ['repository', 'testCommand'],
+      additionalProperties: false,
+    },
+  },
+});
+
+if (!result.success) {
+  throw new Error(
+    result.structuredOutputError?.message ??
+      result.error?.message ??
+      `Structured output failed (${result.subtype}).`
+  );
+}
+
+if (!result.structuredOutput) {
+  throw new Error('No structured output was returned.');
+}
+
+console.log(JSON.stringify(result.structuredOutput, null, 2));
+```
+
+Invalid or missing schema output normally produces a failed result with subtype `error_structured_output`; `structuredOutputError` contains the available validation details.
+
+`structuredOutput` is typed as `unknown`, because a JSON Schema does not provide a TypeScript runtime validator. Check that it is present and validate or narrow its shape before reading fields or passing it to another system. A successful result can still omit structured output, so do not use `result.success` as the only check.
+
+Runnable example: [`examples/node/structured-output.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/structured-output.ts)
+
+## Permissions and user input
+
+### Autonomy
+
+Autonomy controls which actions require approval in Auto mode.
+
+```ts
+import { AutonomyLevel } from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  autonomyLevel: AutonomyLevel.Off,
+});
+```
+
+| Level    | Behavior                                |
+| -------- | --------------------------------------- |
+| `Off`    | Ask before every action                 |
+| `Low`    | Allow file edits and read-only commands |
+| `Medium` | Allow reversible commands               |
+| `High`   | Allow commands without approval prompts |
+
+When omitted, Droid uses the configured default. Autonomy does not select Auto or Spec mode; `interactionMode` does that.
+
+### Permission handler
+
+Use `permissionHandler` to approve or reject requests that reach the client.
+The handler may be synchronous or asynchronous.
+
+```ts
+import {
+  ToolConfirmationOutcome,
+  ToolConfirmationType,
+} from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  autonomyLevel: AutonomyLevel.Off,
+  permissionHandler({ toolUses, options }) {
+    const createsOnly =
+      toolUses.length > 0 &&
+      toolUses.every((use) => use.details.type === ToolConfirmationType.Create);
+
+    const desired = createsOnly
+      ? ToolConfirmationOutcome.ProceedOnce
+      : ToolConfirmationOutcome.Cancel;
+
+    const offered = options.find((option) => option.value === desired);
+    if (!offered) throw new Error(`Outcome not offered: ${desired}`);
+
+    return desired;
+  },
+});
+```
+
+`toolUses` describes the pending actions. `options` contains the outcomes available for this request. Return one of those values. Common outcomes are:
+
+| Outcome         | Effect                                  |
+| --------------- | --------------------------------------- |
+| `ProceedOnce`   | Approve this request                    |
+| `ProceedAlways` | Approve and persist the applicable rule |
+| `Cancel`        | Reject the request                      |
+
+The available outcomes vary by request. Returning an unavailable value, throwing from the handler, or omitting the handler cancels the request.
+
+Runnable example:
+[`examples/node/permission-handler.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/permission-handler.ts)
+
+### AskUser handler
+
+`askUserHandler` answers questions Droid asks during a turn. Connect it to a form, prompt, or other application UI.
+
+```ts
+const result = await run('Ask me which environment to deploy.', {
+  askUserHandler({ questions }) {
+    return {
+      answers: questions.map((question) => ({
+        index: question.index,
+        question: question.question,
+        answer: question.options[0] ?? 'none',
+      })),
+    };
+  },
+});
+```
+
+Each answer must copy the question's `index` and `question`. To decline the questionnaire:
+
+```ts
+return { cancelled: true, answers: [] };
+```
+
+Without a handler, AskUser requests are declined.
+
+Runnable example:
+[`examples/node/ask-user-elicitation.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/ask-user-elicitation.ts)
+
+### Tool controls
+
+Disable tools when creating, resuming, or updating a session:
+
+```ts
+const session = await createSession({
+  disabledToolIds: ['Execute'],
+});
+
+await session.updateSettings({
+  disabledToolIds: ['Execute', 'Edit'],
+});
+```
+
+Tool IDs are strings. Use `listTools()` to inspect the tools available to the current session.
+
+```ts
+const tools = await session.listTools();
+
+for (const tool of tools) {
+  console.log(tool.id, tool.allowed);
+}
+```
+
+The public SDK provides subtractive `disabledToolIds`. It does not expose a
+restrictive allowlist.
+
+Runnable example: [`examples/node/tool-controls.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/tool-controls.ts)
+
+## Tools and extensions
+
+Use the extension that matches the job:
+
+| Extension            | Use it for                                       |
+| -------------------- | ------------------------------------------------ |
+| Skills               | Reusable instructions and supporting files       |
+| SDK MCP tools        | In-process TypeScript functions exposed to Droid |
+| External MCP servers | Tools provided by another process or service     |
+| Hooks                | Commands that run at defined lifecycle events    |
+
+### Skills
+
+List the skills available to the session:
+
+```ts
+const { skills } = await session.listSkills();
+
+for (const skill of skills) {
+  console.log(skill.name, skill.enabled);
+}
+```
+
+Enable or disable a skill at the user or project level:
+
+```ts
+import { SettingsLevel } from '@factory/droid-sdk/node';
+
+await session.setSkillDisabled({
+  skillName: 'skill-name',
+  disabled: true,
+  settingsLevel: SettingsLevel.Project,
+});
+```
+
+Skills can come from project, personal, built-in, or automation settings.
+
+### SDK MCP tools
+
+Use `tool()` to define an in-process TypeScript function with a Zod input schema.
+
+```ts
+import { z } from 'zod';
+import {
+  createSdkMcpServer,
+  createSession,
+  tool,
+} from '@factory/droid-sdk/node';
+
+const server = createSdkMcpServer({
+  name: 'review-tools',
+  tools: [
+    tool(
+      'lookup_owner',
+      'Returns the owner of a file',
+      { path: z.string() },
+      ({ path }) => `Owner for ${path}: platform-team`
+    ),
+  ],
+});
+
+const session = await createSession({
+  mcpServers: [server],
+});
+
+try {
+  for await (const _message of session.stream(
+    'Find the owner of src/index.ts.'
+  )) {
+    // Consume messages.
+  }
+} finally {
+  await session.close();
+}
+```
+
+The SDK starts an authenticated loopback MCP server and closes it with the session.
+Tool calls still follow the session's autonomy and permission rules.
+Attach SDK MCP servers again when resuming a saved session because they are runtime objects, not persisted session data.
+
+Runnable example: [`examples/node/sdk-mcp-tool.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/sdk-mcp-tool.ts)
+
+### External MCP servers
+
+Pass external MCP configuration when creating or resuming a session:
+
+```ts
+const session = await createSession({
+  mcpServers: [
+    {
+      name: 'docs',
+      type: 'http',
+      url: 'https://example.com/mcp',
+      headers: [],
+    },
+  ],
+});
+```
+
+Supported session configuration:
+
+| Transport     | `type` field | Required configuration |
+| ------------- | ------------ | ---------------------- |
+| Local process | Omit         | `command` and `args`   |
+| HTTP          | `http`       | `url` and `headers`    |
+| SSE           | `sse`        | `url` and `headers`    |
+
+Inspect server status and discovered tools:
+
+```ts
+try {
+  const { servers, summary } = await session.listMcpServers();
+  const tools = await session.listMcpTools();
+
+  console.log(servers, summary, tools);
+} finally {
+  await session.close();
+}
+```
+
+`addMcpServer()`, `removeMcpServer()`, and `toggleMcpServer()` change the user's Droid configuration.
+Use `authenticateMcpServer({ serverName })` when a server requires authentication.
+
+### Hooks
+
+Hooks run shell commands at defined lifecycle events.
+Configure them in `.factory/hooks.json`:
+
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "Execute",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "echo before Execute"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Hooks can run before or after tools, when prompts are submitted, when notifications arrive, during compaction, and when sessions or subagents stop.
+
+Hook events are available in the stream:
+
+```ts
+for await (const message of session.stream('Run the tests.')) {
+  if (message.type === DroidMessageType.Hook) {
+    console.log(message.status, message.command);
+  }
+}
+```
+
+The SDK exposes hook schemas and stream events, but it does not provide a programmatic hook-registration API.
+
+Runnable example: [`examples/node/hook-execution.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/hook-execution.ts)
+
+## Session lifecycle
+
+### Replacement handles
+
+`fork()` returns a ready successor handle. `compact()` and `rewind()` return
+outcome objects containing a ready successor in `session`. Each operation
+retires its source wrapper.
+
+```ts
+const forked = await session.fork();
+
+const { session: compacted, removedCount } = await forked.compact();
+
+const {
+  session: rewound,
+  restoredCount,
+  deletedCount,
+} = await compacted.rewind({
+  messageId,
+  filesToRestore,
+  filesToDelete,
+  forkTitle: 'Before the failed change',
+});
+```
+
+After a successful replacement, active operations on the source wrapper throw
+`SessionReplacedError`. Its `id`, `settings`, and `cwd` remain readable, and
+`close()` is a no-op. The persisted source session can still be loaded later
+with `resumeSession(sourceId)`.
+
+Do not replace a session while it has an active stream.
+
+## Spec mode
+
+Spec mode lets Droid inspect the codebase and propose a plan without changing files. Start a session in Spec mode or switch an existing session with `enterSpecMode()`:
+
+```ts
+const session = await createSession({
+  interactionMode: DroidInteractionMode.Spec,
+});
+
+// Or switch an existing Auto session.
+await session.enterSpecMode();
+```
+
+`enterSpecMode()` can also set the model used for planning:
+
+```ts
+await session.enterSpecMode({
+  specModeModelId: 'model-id',
+  specModeReasoningEffort: ReasoningEffort.High,
+});
+```
+
+### Leave without approving a plan
+
+Call `exitSpecMode()` to return the session to Auto mode without approving a plan or starting implementation:
+
+```ts
+await session.enterSpecMode();
+
+// Return to Auto mode without approving or implementing the plan.
+await session.exitSpecMode();
+```
+
+`exitSpecMode()` changes the interaction mode only. It does not select a `ToolConfirmationOutcome` or approve an `ExitSpecMode` permission request.
+
+The method is available on Node `DroidSession` handles returned by `createSession()`, `resumeSession()`, and replacement operations such as `fork()`, `compact()`, and `rewind()`. Daemon clients continue to change the mode with `droid.sessions.updateSettings()`.
+
+### Approve a plan
+
+When the plan is ready, Droid sends an `ExitSpecMode` permission request. Its
+details contain the plan. Unlike calling `exitSpecMode()`, approving it with `ProceedOnce` accepts the completed plan, returns to Auto mode, and continues implementation in the same session:
+
+```ts
+import {
+  AutonomyLevel,
+  createSession,
+  DroidInteractionMode,
+  DroidMessageType,
+  ToolConfirmationOutcome,
+  ToolConfirmationType,
+} from '@factory/droid-sdk/node';
+
+const session = await createSession({
+  interactionMode: DroidInteractionMode.Auto,
+  autonomyLevel: AutonomyLevel.Low,
+  permissionHandler({ toolUses }) {
+    const request = toolUses.find(
+      ({ details }) => details.type === ToolConfirmationType.ExitSpecMode
+    );
+
+    if (request?.details.type === ToolConfirmationType.ExitSpecMode) {
+      console.log(request.details.plan);
+
+      return ToolConfirmationOutcome.ProceedOnce;
+    }
+
+    return ToolConfirmationOutcome.Cancel;
+  },
+});
+
+try {
+  await session.enterSpecMode();
+
+  for await (const message of session.stream('Plan and update README.md.')) {
+    if (message.type === DroidMessageType.Result) {
+      console.log(message.subtype);
+    }
+  }
+} finally {
+  await session.close();
+}
+```
+
+The handler can be asynchronous. An interactive application should display the plan and wait for the user's decision before returning.
+
+Return `Cancel` to reject the plan. The turn ends with an `interrupted` result, and the session remains available for another prompt.
+
+Some `ExitSpecMode` requests offer `ProceedNewSession` variants. Return one of those offered values to hand implementation to a new session. Return only values present in the request's `options`.
+
+Runnable example:
+[`examples/node/enter-spec-mode.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/enter-spec-mode.ts)
+
+## Operations
+
+### Observability
+
+```ts
+import { run } from '@factory/droid-sdk/node';
+
+const result = await run('Check the repository status.', {
+  observability: {
+    logger: {
+      log(event) {
+        console.log(event.level, event.name, event.attributes);
+      },
+    },
+  },
+});
+
+if (!result.success) {
+  throw new Error(result.error?.message ?? `Run failed: ${result.subtype}`);
+}
+```
+
+Pass `logger`, `metrics`, or `tracing` sinks through `observability`.
+Sink methods must not throw.
+The SDK excludes prompts, messages, tool inputs, raw output, and stack traces from observability events.
+Process startup emits telemetry before the first turn, and `close()` emits a request log.
+To verify turn-specific logs, snapshot the count after creating the session and check it before closing.
+
+Runnable example:
+[`examples/node/observability.ts`](https://github.com/Factory-AI/droid-sdk-typescript/blob/main/examples/node/observability.ts)
+
+### Low-level APIs
+
+Use the high-level APIs unless your application owns the transport or protocol lifecycle.
+
+| Need                         | Preferred API      | Low-level alternative |
+| ---------------------------- | ------------------ | --------------------- |
+| Run a session                | `createSession()`  | `DroidClient`         |
+| Consume typed session events | `session.stream()` | Raw notifications     |
+
+The `/node` entrypoint exports `DroidClient` for direct JSON-RPC integrations.
+Low-level methods return response envelopes, so successful payloads are under `response.result`.
+
+Use `onNotification()` only when `session.stream()` does not expose the event you need:
+
+```ts
+const unsubscribe = session.onNotification(
+  (notification) => console.log(notification.type),
+  { type: 'settings_updated' }
+);
+
+unsubscribe();
+```
+
+## API reference
+
+### Entrypoint
+
+Import functions, classes, enums, and types from `@factory/droid-sdk/node`.
+
+### Functions
+
+| API                                  | Returns                      |
+| ------------------------------------ | ---------------------------- |
+| `run(prompt, options?)`              | `Promise<DroidResult>`       |
+| `createSession(options?)`            | `Promise<DroidSession>`      |
+| `resumeSession(sessionId, options?)` | `Promise<DroidSession>`      |
+| `listSessions(options?)`             | `Promise<SessionMetadata[]>` |
+| `listModels(options?)`               | `Promise<ModelInfo[]>`       |
+| `createSdkMcpServer(options)`        | `SdkMcpServer`               |
+| `tool(...)`                          | `DroidTool`                  |
+
+### `DroidSession`
+
+| Member                    | Purpose                                      |
+| ------------------------- | -------------------------------------------- |
+| `id`                      | Session ID                                   |
+| `cwd`                     | Live working directory                       |
+| `settings`                | Live read-only settings                      |
+| `stream()`                | Run one turn                                 |
+| `interrupt()`             | Stop the active turn                         |
+| `updateSettings()`        | Update session settings                      |
+| `enterSpecMode()`         | Change to spec mode                          |
+| `exitSpecMode()`          | Return to Auto mode without approving a plan |
+| `listTools()`             | List normalized tools                        |
+| `listSkills()`            | List skills                                  |
+| `setSkillDisabled()`      | Enable or disable a skill                    |
+| `addMcpServer()`          | Add an MCP server                            |
+| `removeMcpServer()`       | Remove an MCP server                         |
+| `toggleMcpServer()`       | Enable or disable an MCP server              |
+| `listMcpServers()`        | List MCP servers                             |
+| `listMcpTools()`          | List MCP tools                               |
+| `authenticateMcpServer()` | Start MCP authentication                     |
+| `getContextStats()`       | Read context usage                           |
+| `getRewindInfo()`         | Inspect rewindable file changes              |
+| `rewind()`                | Create a rewound successor                   |
+| `compact()`               | Create a compacted successor                 |
+| `fork()`                  | Create a forked successor                    |
+| `rename()`                | Change the session title                     |
+| `onNotification()`        | Subscribe to raw notifications               |
+| `close()`                 | Close the session and owned resources        |
+
+### Stream and model types
+
+| Type                 | Purpose                                           |
+| -------------------- | ------------------------------------------------- |
+| `DroidStreamMessage` | Complete messages returned by the default stream  |
+| `DroidStreamEvent`   | Complete messages plus partial events             |
+| `DroidResult`        | Terminal result returned by `run()`               |
+| `DroidMessageType`   | Runtime constants for narrowing stream messages   |
+| `TokenUsage`         | Token counts and optional Factory Service Credits |
+| `ModelInfo`          | Model catalog entry returned by discovery APIs    |
+
+`session.stream()` yields `DroidStreamMessage` by default and `DroidStreamEvent` when `includePartialMessages` is `true`.
+
+### Result states
+
+| Subtype                   | `success` | `interrupted` | Meaning                   |
+| ------------------------- | --------- | ------------- | ------------------------- |
+| `success`                 | `true`    | `false`       | Turn completed            |
+| `interrupted`             | `false`   | `true`        | Turn was stopped          |
+| `error_during_execution`  | `false`   | `false`       | Runtime failure           |
+| `error_structured_output` | `false`   | `false`       | Structured-output failure |
+
+Every result includes `sessionId`, `durationMs`, `tokenUsage`, `messages`, `text`, and `turnCount`.
+Check `success` before using successful output.
+
+### Main enums
+
+| Enum                   | Values                                                                           |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `AutonomyLevel`        | `Off`, `Low`, `Medium`, `High`                                                   |
+| `DroidInteractionMode` | `Auto`, `Spec`                                                                   |
+| `ReasoningEffort`      | `None`, `Dynamic`, `Off`, `Minimal`, `Low`, `Medium`, `High`, `ExtraHigh`, `Max` |
+| `OutputFormatType`     | `JsonSchema`                                                                     |
+
+Model IDs and tool IDs are strings rather than closed enums.
+
+### Main errors
+
+| Error                     | Meaning                                       |
+| ------------------------- | --------------------------------------------- |
+| `ConcurrentStreamError`   | A session handle already has an active stream |
+| `SessionReplacedError`    | A source wrapper was replaced                 |
+| `SessionReplacementError` | Successor loading or rollback failed          |
+| `DroidClientError`        | Base client error                             |
+| `ConnectionError`         | Droid process connection failed               |
+| `TimeoutError`            | A request timed out                           |
+| `ProtocolError`           | Protocol or API response failed               |
+| `SessionError`            | Base session error                            |
+| `SessionNotFoundError`    | Saved session was not found                   |
+| `InvalidSessionCwdError`  | Saved working directory is invalid            |
+| `ProcessExitError`        | Droid subprocess exited unexpectedly          |
+
+## Known limitations
+
+- New-session spec handoff IDs require raw notification inspection.


### PR DESCRIPTION
## Description

Publish comprehensive Python and TypeScript references for the Droid SDK at:

- `/sdk/python`
- `/sdk/typescript`

Adds an **SDK** navigation group with short **Python** and **TypeScript** sidebar labels while retaining descriptive page titles. The TypeScript reference links to 18 verified runnable examples in the public SDK repository, and the Droid Exec guide now directs readers to the new documentation.

## Potential Risk & Impact

Low. This is a documentation-only change. The primary risk is stale SDK guidance as the packages evolve; the source references remain in their SDK repositories for future synchronization.

## How Has This Been Tested?

- `npx --yes mintlify@latest validate`
- Mintlify broken-link and anchor check scoped to the changed pages
- Verified all 18 public TypeScript example URLs against the current GitHub tree
- Rendered both routes locally and confirmed HTTP 200 responses
- Visually verified **SDK → Python / TypeScript** sidebar labels and the **Droid Python SDK / Droid TypeScript SDK** page headings
